### PR TITLE
feat: implement support for Trusted Private Cloud

### DIFF
--- a/baselines/asset-esm/esm/src/v1/asset_service_client.ts.baseline
+++ b/baselines/asset-esm/esm/src/v1/asset_service_client.ts.baseline
@@ -51,6 +51,8 @@ export class AssetServiceClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -107,7 +109,12 @@ export class AssetServiceClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof AssetServiceClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'cloudasset.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -115,7 +122,7 @@ export class AssetServiceClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -140,10 +147,10 @@ export class AssetServiceClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -291,19 +298,47 @@ export class AssetServiceClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'cloudasset.googleapis.com';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'cloudasset.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/asset-esm/esm/test/gapic_asset_service_v1.ts.baseline
+++ b/baselines/asset-esm/esm/test/gapic_asset_service_v1.ts.baseline
@@ -80,13 +80,37 @@ function stubLongRunningCallWithCallback<ResponseType>(response?: ResponseType, 
 describe('v1.AssetServiceClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = assetserviceModule.v1.AssetServiceClient.servicePath;
-            assert(servicePath);
+            const client = new assetserviceModule.v1.AssetServiceClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'cloudasset.googleapis.com');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = assetserviceModule.v1.AssetServiceClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new assetserviceModule.v1.AssetServiceClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'cloudasset.googleapis.com');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new assetserviceModule.v1.AssetServiceClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new assetserviceModule.v1.AssetServiceClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'cloudasset.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new assetserviceModule.v1.AssetServiceClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'cloudasset.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new assetserviceModule.v1.AssetServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/asset-esm/esm/test/gapic_asset_service_v1.ts.baseline
+++ b/baselines/asset-esm/esm/test/gapic_asset_service_v1.ts.baseline
@@ -97,6 +97,23 @@ describe('v1.AssetServiceClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = assetserviceModule.v1.AssetServiceClient.servicePath;
+                assert.strictEqual(servicePath, 'cloudasset.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = assetserviceModule.v1.AssetServiceClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'cloudasset.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new assetserviceModule.v1.AssetServiceClient({universeDomain: 'example.com'});
             const servicePath = client.servicePath;
@@ -108,7 +125,6 @@ describe('v1.AssetServiceClient', () => {
             const servicePath = client.servicePath;
             assert.strictEqual(servicePath, 'cloudasset.example.com');
         });
-
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new assetserviceModule.v1.AssetServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/asset/src/v1/asset_service_client.ts.baseline
+++ b/baselines/asset/src/v1/asset_service_client.ts.baseline
@@ -44,6 +44,8 @@ export class AssetServiceClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -99,7 +101,12 @@ export class AssetServiceClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof AssetServiceClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'cloudasset.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -107,7 +114,7 @@ export class AssetServiceClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -132,10 +139,10 @@ export class AssetServiceClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -275,19 +282,47 @@ export class AssetServiceClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'cloudasset.googleapis.com';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'cloudasset.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/asset/test/gapic_asset_service_v1.ts.baseline
+++ b/baselines/asset/test/gapic_asset_service_v1.ts.baseline
@@ -71,13 +71,37 @@ function stubLongRunningCallWithCallback<ResponseType>(response?: ResponseType, 
 describe('v1.AssetServiceClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = assetserviceModule.v1.AssetServiceClient.servicePath;
-            assert(servicePath);
+            const client = new assetserviceModule.v1.AssetServiceClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'cloudasset.googleapis.com');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = assetserviceModule.v1.AssetServiceClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new assetserviceModule.v1.AssetServiceClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'cloudasset.googleapis.com');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new assetserviceModule.v1.AssetServiceClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new assetserviceModule.v1.AssetServiceClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'cloudasset.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new assetserviceModule.v1.AssetServiceClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'cloudasset.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new assetserviceModule.v1.AssetServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/asset/test/gapic_asset_service_v1.ts.baseline
+++ b/baselines/asset/test/gapic_asset_service_v1.ts.baseline
@@ -88,6 +88,23 @@ describe('v1.AssetServiceClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = assetserviceModule.v1.AssetServiceClient.servicePath;
+                assert.strictEqual(servicePath, 'cloudasset.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = assetserviceModule.v1.AssetServiceClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'cloudasset.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new assetserviceModule.v1.AssetServiceClient({universeDomain: 'example.com'});
             const servicePath = client.servicePath;
@@ -99,7 +116,6 @@ describe('v1.AssetServiceClient', () => {
             const servicePath = client.servicePath;
             assert.strictEqual(servicePath, 'cloudasset.example.com');
         });
-
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new assetserviceModule.v1.AssetServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/bigquery-storage-esm/esm/src/v1beta1/big_query_storage_client.ts.baseline
+++ b/baselines/bigquery-storage-esm/esm/src/v1beta1/big_query_storage_client.ts.baseline
@@ -53,6 +53,8 @@ export class BigQueryStorageClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -108,7 +110,12 @@ export class BigQueryStorageClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof BigQueryStorageClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'bigquerystorage.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -116,7 +123,7 @@ export class BigQueryStorageClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -141,10 +148,10 @@ export class BigQueryStorageClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -277,19 +284,47 @@ export class BigQueryStorageClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'bigquerystorage.googleapis.com';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'bigquerystorage.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/bigquery-storage-esm/esm/test/gapic_big_query_storage_v1beta1.ts.baseline
+++ b/baselines/bigquery-storage-esm/esm/test/gapic_big_query_storage_v1beta1.ts.baseline
@@ -78,13 +78,37 @@ function stubServerStreamingCall<ResponseType>(response?: ResponseType, error?: 
 describe('v1beta1.BigQueryStorageClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = bigquerystorageModule.v1beta1.BigQueryStorageClient.servicePath;
-            assert(servicePath);
+            const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'bigquerystorage.googleapis.com');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = bigquerystorageModule.v1beta1.BigQueryStorageClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'bigquerystorage.googleapis.com');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'bigquerystorage.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'bigquerystorage.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new bigquerystorageModule.v1beta1.BigQueryStorageClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/bigquery-storage-esm/esm/test/gapic_big_query_storage_v1beta1.ts.baseline
+++ b/baselines/bigquery-storage-esm/esm/test/gapic_big_query_storage_v1beta1.ts.baseline
@@ -95,6 +95,23 @@ describe('v1beta1.BigQueryStorageClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = bigquerystorageModule.v1beta1.BigQueryStorageClient.servicePath;
+                assert.strictEqual(servicePath, 'bigquerystorage.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = bigquerystorageModule.v1beta1.BigQueryStorageClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'bigquerystorage.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({universeDomain: 'example.com'});
             const servicePath = client.servicePath;
@@ -106,7 +123,6 @@ describe('v1beta1.BigQueryStorageClient', () => {
             const servicePath = client.servicePath;
             assert.strictEqual(servicePath, 'bigquerystorage.example.com');
         });
-
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new bigquerystorageModule.v1beta1.BigQueryStorageClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/bigquery-storage/src/v1beta1/big_query_storage_client.ts.baseline
+++ b/baselines/bigquery-storage/src/v1beta1/big_query_storage_client.ts.baseline
@@ -46,6 +46,8 @@ export class BigQueryStorageClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -100,7 +102,12 @@ export class BigQueryStorageClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof BigQueryStorageClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'bigquerystorage.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -108,7 +115,7 @@ export class BigQueryStorageClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -133,10 +140,10 @@ export class BigQueryStorageClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -261,19 +268,47 @@ export class BigQueryStorageClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'bigquerystorage.googleapis.com';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'bigquerystorage.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/bigquery-storage/test/gapic_big_query_storage_v1beta1.ts.baseline
+++ b/baselines/bigquery-storage/test/gapic_big_query_storage_v1beta1.ts.baseline
@@ -86,6 +86,23 @@ describe('v1beta1.BigQueryStorageClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = bigquerystorageModule.v1beta1.BigQueryStorageClient.servicePath;
+                assert.strictEqual(servicePath, 'bigquerystorage.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = bigquerystorageModule.v1beta1.BigQueryStorageClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'bigquerystorage.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({universeDomain: 'example.com'});
             const servicePath = client.servicePath;
@@ -97,7 +114,6 @@ describe('v1beta1.BigQueryStorageClient', () => {
             const servicePath = client.servicePath;
             assert.strictEqual(servicePath, 'bigquerystorage.example.com');
         });
-
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new bigquerystorageModule.v1beta1.BigQueryStorageClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/bigquery-storage/test/gapic_big_query_storage_v1beta1.ts.baseline
+++ b/baselines/bigquery-storage/test/gapic_big_query_storage_v1beta1.ts.baseline
@@ -69,13 +69,37 @@ function stubServerStreamingCall<ResponseType>(response?: ResponseType, error?: 
 describe('v1beta1.BigQueryStorageClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = bigquerystorageModule.v1beta1.BigQueryStorageClient.servicePath;
-            assert(servicePath);
+            const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'bigquerystorage.googleapis.com');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = bigquerystorageModule.v1beta1.BigQueryStorageClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'bigquerystorage.googleapis.com');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'bigquerystorage.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'bigquerystorage.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new bigquerystorageModule.v1beta1.BigQueryStorageClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/compute-esm/esm/src/v1/addresses_client.ts.baseline
+++ b/baselines/compute-esm/esm/src/v1/addresses_client.ts.baseline
@@ -54,6 +54,8 @@ export class AddressesClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -108,7 +110,12 @@ export class AddressesClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof AddressesClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'compute.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -122,7 +129,7 @@ export class AddressesClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -144,10 +151,10 @@ export class AddressesClient {
     this.auth = (this._gaxGrpc.auth as gax.GoogleAuth);
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -265,19 +272,47 @@ export class AddressesClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'compute.googleapis.com';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'compute.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/compute-esm/esm/src/v1/region_operations_client.ts.baseline
+++ b/baselines/compute-esm/esm/src/v1/region_operations_client.ts.baseline
@@ -51,6 +51,8 @@ export class RegionOperationsClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -105,7 +107,12 @@ export class RegionOperationsClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof RegionOperationsClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'compute.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -119,7 +126,7 @@ export class RegionOperationsClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -141,10 +148,10 @@ export class RegionOperationsClient {
     this.auth = (this._gaxGrpc.auth as gax.GoogleAuth);
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -251,19 +258,47 @@ export class RegionOperationsClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'compute.googleapis.com';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'compute.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/compute-esm/esm/test/gapic_addresses_v1.ts.baseline
+++ b/baselines/compute-esm/esm/test/gapic_addresses_v1.ts.baseline
@@ -139,6 +139,23 @@ describe('v1.AddressesClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = addressesModule.v1.AddressesClient.servicePath;
+                assert.strictEqual(servicePath, 'compute.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = addressesModule.v1.AddressesClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'compute.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new addressesModule.v1.AddressesClient({universeDomain: 'example.com'});
             const servicePath = client.servicePath;
@@ -150,7 +167,6 @@ describe('v1.AddressesClient', () => {
             const servicePath = client.servicePath;
             assert.strictEqual(servicePath, 'compute.example.com');
         });
-
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new addressesModule.v1.AddressesClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/compute-esm/esm/test/gapic_addresses_v1.ts.baseline
+++ b/baselines/compute-esm/esm/test/gapic_addresses_v1.ts.baseline
@@ -122,13 +122,37 @@ describe('v1.AddressesClient', () => {
   });
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = addressesModule.v1.AddressesClient.servicePath;
-            assert(servicePath);
+            const client = new addressesModule.v1.AddressesClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'compute.googleapis.com');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = addressesModule.v1.AddressesClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new addressesModule.v1.AddressesClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'compute.googleapis.com');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new addressesModule.v1.AddressesClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new addressesModule.v1.AddressesClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'compute.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new addressesModule.v1.AddressesClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'compute.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new addressesModule.v1.AddressesClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/compute-esm/esm/test/gapic_region_operations_v1.ts.baseline
+++ b/baselines/compute-esm/esm/test/gapic_region_operations_v1.ts.baseline
@@ -75,13 +75,37 @@ describe('v1.RegionOperationsClient', () => {
   });
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = regionoperationsModule.v1.RegionOperationsClient.servicePath;
-            assert(servicePath);
+            const client = new regionoperationsModule.v1.RegionOperationsClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'compute.googleapis.com');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = regionoperationsModule.v1.RegionOperationsClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new regionoperationsModule.v1.RegionOperationsClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'compute.googleapis.com');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new regionoperationsModule.v1.RegionOperationsClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new regionoperationsModule.v1.RegionOperationsClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'compute.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new regionoperationsModule.v1.RegionOperationsClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'compute.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new regionoperationsModule.v1.RegionOperationsClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/compute-esm/esm/test/gapic_region_operations_v1.ts.baseline
+++ b/baselines/compute-esm/esm/test/gapic_region_operations_v1.ts.baseline
@@ -92,6 +92,23 @@ describe('v1.RegionOperationsClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = regionoperationsModule.v1.RegionOperationsClient.servicePath;
+                assert.strictEqual(servicePath, 'compute.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = regionoperationsModule.v1.RegionOperationsClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'compute.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new regionoperationsModule.v1.RegionOperationsClient({universeDomain: 'example.com'});
             const servicePath = client.servicePath;
@@ -103,7 +120,6 @@ describe('v1.RegionOperationsClient', () => {
             const servicePath = client.servicePath;
             assert.strictEqual(servicePath, 'compute.example.com');
         });
-
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new regionoperationsModule.v1.RegionOperationsClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/compute/src/v1/addresses_client.ts.baseline
+++ b/baselines/compute/src/v1/addresses_client.ts.baseline
@@ -47,6 +47,8 @@ export class AddressesClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -100,7 +102,12 @@ export class AddressesClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof AddressesClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'compute.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -114,7 +121,7 @@ export class AddressesClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -136,10 +143,10 @@ export class AddressesClient {
     this.auth = (this._gaxGrpc.auth as gax.GoogleAuth);
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -249,19 +256,47 @@ export class AddressesClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'compute.googleapis.com';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'compute.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/compute/src/v1/region_operations_client.ts.baseline
+++ b/baselines/compute/src/v1/region_operations_client.ts.baseline
@@ -44,6 +44,8 @@ export class RegionOperationsClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -97,7 +99,12 @@ export class RegionOperationsClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof RegionOperationsClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'compute.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -111,7 +118,7 @@ export class RegionOperationsClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -133,10 +140,10 @@ export class RegionOperationsClient {
     this.auth = (this._gaxGrpc.auth as gax.GoogleAuth);
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -235,19 +242,47 @@ export class RegionOperationsClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'compute.googleapis.com';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'compute.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/compute/test/gapic_addresses_v1.ts.baseline
+++ b/baselines/compute/test/gapic_addresses_v1.ts.baseline
@@ -130,6 +130,23 @@ describe('v1.AddressesClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = addressesModule.v1.AddressesClient.servicePath;
+                assert.strictEqual(servicePath, 'compute.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = addressesModule.v1.AddressesClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'compute.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new addressesModule.v1.AddressesClient({universeDomain: 'example.com'});
             const servicePath = client.servicePath;
@@ -141,7 +158,6 @@ describe('v1.AddressesClient', () => {
             const servicePath = client.servicePath;
             assert.strictEqual(servicePath, 'compute.example.com');
         });
-
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new addressesModule.v1.AddressesClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/compute/test/gapic_addresses_v1.ts.baseline
+++ b/baselines/compute/test/gapic_addresses_v1.ts.baseline
@@ -113,13 +113,37 @@ describe('v1.AddressesClient', () => {
   });
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = addressesModule.v1.AddressesClient.servicePath;
-            assert(servicePath);
+            const client = new addressesModule.v1.AddressesClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'compute.googleapis.com');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = addressesModule.v1.AddressesClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new addressesModule.v1.AddressesClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'compute.googleapis.com');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new addressesModule.v1.AddressesClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new addressesModule.v1.AddressesClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'compute.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new addressesModule.v1.AddressesClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'compute.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new addressesModule.v1.AddressesClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/compute/test/gapic_region_operations_v1.ts.baseline
+++ b/baselines/compute/test/gapic_region_operations_v1.ts.baseline
@@ -66,13 +66,37 @@ describe('v1.RegionOperationsClient', () => {
   });
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = regionoperationsModule.v1.RegionOperationsClient.servicePath;
-            assert(servicePath);
+            const client = new regionoperationsModule.v1.RegionOperationsClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'compute.googleapis.com');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = regionoperationsModule.v1.RegionOperationsClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new regionoperationsModule.v1.RegionOperationsClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'compute.googleapis.com');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new regionoperationsModule.v1.RegionOperationsClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new regionoperationsModule.v1.RegionOperationsClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'compute.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new regionoperationsModule.v1.RegionOperationsClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'compute.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new regionoperationsModule.v1.RegionOperationsClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/compute/test/gapic_region_operations_v1.ts.baseline
+++ b/baselines/compute/test/gapic_region_operations_v1.ts.baseline
@@ -83,6 +83,23 @@ describe('v1.RegionOperationsClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = regionoperationsModule.v1.RegionOperationsClient.servicePath;
+                assert.strictEqual(servicePath, 'compute.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = regionoperationsModule.v1.RegionOperationsClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'compute.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new regionoperationsModule.v1.RegionOperationsClient({universeDomain: 'example.com'});
             const servicePath = client.servicePath;
@@ -94,7 +111,6 @@ describe('v1.RegionOperationsClient', () => {
             const servicePath = client.servicePath;
             assert.strictEqual(servicePath, 'compute.example.com');
         });
-
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new regionoperationsModule.v1.RegionOperationsClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/deprecatedtest-esm/esm/src/v1/deprecated_service_client.ts.baseline
+++ b/baselines/deprecatedtest-esm/esm/src/v1/deprecated_service_client.ts.baseline
@@ -53,6 +53,8 @@ export class DeprecatedServiceClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -107,7 +109,12 @@ export class DeprecatedServiceClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof DeprecatedServiceClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'localhost.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -115,7 +122,7 @@ export class DeprecatedServiceClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -140,10 +147,10 @@ export class DeprecatedServiceClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -252,19 +259,47 @@ export class DeprecatedServiceClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/deprecatedtest-esm/esm/src/v1/deprecated_service_client.ts.baseline
+++ b/baselines/deprecatedtest-esm/esm/src/v1/deprecated_service_client.ts.baseline
@@ -113,7 +113,7 @@ export class DeprecatedServiceClient {
       throw new Error('Please set either universe_domain or universeDomain, but not both.');
     }
     this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
-    this._servicePath = 'localhost.' + this._universeDomain;
+    this._servicePath = 'localhost';
     const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;

--- a/baselines/deprecatedtest-esm/esm/test/gapic_deprecated_service_v1.ts.baseline
+++ b/baselines/deprecatedtest-esm/esm/test/gapic_deprecated_service_v1.ts.baseline
@@ -81,18 +81,23 @@ describe('v1.DeprecatedServiceClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
-        it('sets servicePath according to universe domain camelCase', () => {
-            const client = new deprecatedserviceModule.v1.DeprecatedServiceClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = deprecatedserviceModule.v1.DeprecatedServiceClient.servicePath;
+                assert.strictEqual(servicePath, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
-            const client = new deprecatedserviceModule.v1.DeprecatedServiceClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
-
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = deprecatedserviceModule.v1.DeprecatedServiceClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new deprecatedserviceModule.v1.DeprecatedServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/deprecatedtest-esm/esm/test/gapic_deprecated_service_v1.ts.baseline
+++ b/baselines/deprecatedtest-esm/esm/test/gapic_deprecated_service_v1.ts.baseline
@@ -64,13 +64,37 @@ function stubSimpleCallWithCallback<ResponseType>(response?: ResponseType, error
 describe('v1.DeprecatedServiceClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = deprecatedserviceModule.v1.DeprecatedServiceClient.servicePath;
-            assert(servicePath);
+            const client = new deprecatedserviceModule.v1.DeprecatedServiceClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = deprecatedserviceModule.v1.DeprecatedServiceClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new deprecatedserviceModule.v1.DeprecatedServiceClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'localhost');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new deprecatedserviceModule.v1.DeprecatedServiceClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new deprecatedserviceModule.v1.DeprecatedServiceClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new deprecatedserviceModule.v1.DeprecatedServiceClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new deprecatedserviceModule.v1.DeprecatedServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/deprecatedtest/src/v1/deprecated_service_client.ts.baseline
+++ b/baselines/deprecatedtest/src/v1/deprecated_service_client.ts.baseline
@@ -46,6 +46,8 @@ export class DeprecatedServiceClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -99,7 +101,12 @@ export class DeprecatedServiceClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof DeprecatedServiceClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'localhost.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -107,7 +114,7 @@ export class DeprecatedServiceClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -132,10 +139,10 @@ export class DeprecatedServiceClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -236,19 +243,47 @@ export class DeprecatedServiceClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/deprecatedtest/src/v1/deprecated_service_client.ts.baseline
+++ b/baselines/deprecatedtest/src/v1/deprecated_service_client.ts.baseline
@@ -105,7 +105,7 @@ export class DeprecatedServiceClient {
       throw new Error('Please set either universe_domain or universeDomain, but not both.');
     }
     this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
-    this._servicePath = 'localhost.' + this._universeDomain;
+    this._servicePath = 'localhost';
     const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;

--- a/baselines/deprecatedtest/test/gapic_deprecated_service_v1.ts.baseline
+++ b/baselines/deprecatedtest/test/gapic_deprecated_service_v1.ts.baseline
@@ -72,18 +72,23 @@ describe('v1.DeprecatedServiceClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
-        it('sets servicePath according to universe domain camelCase', () => {
-            const client = new deprecatedserviceModule.v1.DeprecatedServiceClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = deprecatedserviceModule.v1.DeprecatedServiceClient.servicePath;
+                assert.strictEqual(servicePath, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
-            const client = new deprecatedserviceModule.v1.DeprecatedServiceClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
-
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = deprecatedserviceModule.v1.DeprecatedServiceClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new deprecatedserviceModule.v1.DeprecatedServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/deprecatedtest/test/gapic_deprecated_service_v1.ts.baseline
+++ b/baselines/deprecatedtest/test/gapic_deprecated_service_v1.ts.baseline
@@ -55,13 +55,37 @@ function stubSimpleCallWithCallback<ResponseType>(response?: ResponseType, error
 describe('v1.DeprecatedServiceClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = deprecatedserviceModule.v1.DeprecatedServiceClient.servicePath;
-            assert(servicePath);
+            const client = new deprecatedserviceModule.v1.DeprecatedServiceClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = deprecatedserviceModule.v1.DeprecatedServiceClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new deprecatedserviceModule.v1.DeprecatedServiceClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'localhost');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new deprecatedserviceModule.v1.DeprecatedServiceClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new deprecatedserviceModule.v1.DeprecatedServiceClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new deprecatedserviceModule.v1.DeprecatedServiceClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new deprecatedserviceModule.v1.DeprecatedServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/compliance_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/compliance_client.ts.baseline
@@ -53,6 +53,8 @@ export class ComplianceClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -108,7 +110,12 @@ export class ComplianceClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof ComplianceClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'localhost.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -116,7 +123,7 @@ export class ComplianceClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -141,10 +148,10 @@ export class ComplianceClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -290,19 +297,47 @@ export class ComplianceClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/compliance_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/compliance_client.ts.baseline
@@ -114,7 +114,7 @@ export class ComplianceClient {
       throw new Error('Please set either universe_domain or universeDomain, but not both.');
     }
     this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
-    this._servicePath = 'localhost.' + this._universeDomain;
+    this._servicePath = 'localhost';
     const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/echo_client.ts.baseline
@@ -57,6 +57,8 @@ export class EchoClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -113,7 +115,12 @@ export class EchoClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof EchoClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'localhost.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -121,7 +128,7 @@ export class EchoClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -146,10 +153,10 @@ export class EchoClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -346,19 +353,47 @@ export class EchoClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/echo_client.ts.baseline
@@ -119,7 +119,7 @@ export class EchoClient {
       throw new Error('Please set either universe_domain or universeDomain, but not both.');
     }
     this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
-    this._servicePath = 'localhost.' + this._universeDomain;
+    this._servicePath = 'localhost';
     const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/identity_client.ts.baseline
@@ -51,6 +51,8 @@ export class IdentityClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -106,7 +108,12 @@ export class IdentityClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof IdentityClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'localhost.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -114,7 +121,7 @@ export class IdentityClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -139,10 +146,10 @@ export class IdentityClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -297,19 +304,47 @@ export class IdentityClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/identity_client.ts.baseline
@@ -112,7 +112,7 @@ export class IdentityClient {
       throw new Error('Please set either universe_domain or universeDomain, but not both.');
     }
     this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
-    this._servicePath = 'localhost.' + this._universeDomain;
+    this._servicePath = 'localhost';
     const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/messaging_client.ts.baseline
@@ -54,6 +54,8 @@ export class MessagingClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -110,7 +112,12 @@ export class MessagingClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof MessagingClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'localhost.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -118,7 +125,7 @@ export class MessagingClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -143,10 +150,10 @@ export class MessagingClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -345,19 +352,47 @@ export class MessagingClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/messaging_client.ts.baseline
@@ -116,7 +116,7 @@ export class MessagingClient {
       throw new Error('Please set either universe_domain or universeDomain, but not both.');
     }
     this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
-    this._servicePath = 'localhost.' + this._universeDomain;
+    this._servicePath = 'localhost';
     const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/sequence_service_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/sequence_service_client.ts.baseline
@@ -111,7 +111,7 @@ export class SequenceServiceClient {
       throw new Error('Please set either universe_domain or universeDomain, but not both.');
     }
     this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
-    this._servicePath = 'localhost.' + this._universeDomain;
+    this._servicePath = 'localhost';
     const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/sequence_service_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/sequence_service_client.ts.baseline
@@ -50,6 +50,8 @@ export class SequenceServiceClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -105,7 +107,12 @@ export class SequenceServiceClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof SequenceServiceClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'localhost.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -113,7 +120,7 @@ export class SequenceServiceClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -138,10 +145,10 @@ export class SequenceServiceClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -287,19 +294,47 @@ export class SequenceServiceClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/testing_client.ts.baseline
@@ -52,6 +52,8 @@ export class TestingClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -107,7 +109,12 @@ export class TestingClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof TestingClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'localhost.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -115,7 +122,7 @@ export class TestingClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -140,10 +147,10 @@ export class TestingClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -300,19 +307,47 @@ export class TestingClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/testing_client.ts.baseline
@@ -113,7 +113,7 @@ export class TestingClient {
       throw new Error('Please set either universe_domain or universeDomain, but not both.');
     }
     this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
-    this._servicePath = 'localhost.' + this._universeDomain;
+    this._servicePath = 'localhost';
     const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;

--- a/baselines/disable-packing-test-esm/esm/test/gapic_compliance_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/test/gapic_compliance_v1beta1.ts.baseline
@@ -64,13 +64,37 @@ function stubSimpleCallWithCallback<ResponseType>(response?: ResponseType, error
 describe('v1beta1.ComplianceClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = complianceModule.v1beta1.ComplianceClient.servicePath;
-            assert(servicePath);
+            const client = new complianceModule.v1beta1.ComplianceClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = complianceModule.v1beta1.ComplianceClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new complianceModule.v1beta1.ComplianceClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'localhost');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new complianceModule.v1beta1.ComplianceClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new complianceModule.v1beta1.ComplianceClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new complianceModule.v1beta1.ComplianceClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new complianceModule.v1beta1.ComplianceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/disable-packing-test-esm/esm/test/gapic_compliance_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/test/gapic_compliance_v1beta1.ts.baseline
@@ -81,18 +81,23 @@ describe('v1beta1.ComplianceClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
-        it('sets servicePath according to universe domain camelCase', () => {
-            const client = new complianceModule.v1beta1.ComplianceClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = complianceModule.v1beta1.ComplianceClient.servicePath;
+                assert.strictEqual(servicePath, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
-            const client = new complianceModule.v1beta1.ComplianceClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
-
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = complianceModule.v1beta1.ComplianceClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new complianceModule.v1beta1.ComplianceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/disable-packing-test-esm/esm/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/test/gapic_echo_v1beta1.ts.baseline
@@ -160,13 +160,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v1beta1.EchoClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = echoModule.v1beta1.EchoClient.servicePath;
-            assert(servicePath);
+            const client = new echoModule.v1beta1.EchoClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = echoModule.v1beta1.EchoClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new echoModule.v1beta1.EchoClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'localhost');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new echoModule.v1beta1.EchoClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new echoModule.v1beta1.EchoClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new echoModule.v1beta1.EchoClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new echoModule.v1beta1.EchoClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/disable-packing-test-esm/esm/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/test/gapic_echo_v1beta1.ts.baseline
@@ -177,18 +177,23 @@ describe('v1beta1.EchoClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
-        it('sets servicePath according to universe domain camelCase', () => {
-            const client = new echoModule.v1beta1.EchoClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = echoModule.v1beta1.EchoClient.servicePath;
+                assert.strictEqual(servicePath, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
-            const client = new echoModule.v1beta1.EchoClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
-
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = echoModule.v1beta1.EchoClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new echoModule.v1beta1.EchoClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/disable-packing-test-esm/esm/test/gapic_identity_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/test/gapic_identity_v1beta1.ts.baseline
@@ -128,18 +128,23 @@ describe('v1beta1.IdentityClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
-        it('sets servicePath according to universe domain camelCase', () => {
-            const client = new identityModule.v1beta1.IdentityClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = identityModule.v1beta1.IdentityClient.servicePath;
+                assert.strictEqual(servicePath, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
-            const client = new identityModule.v1beta1.IdentityClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
-
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = identityModule.v1beta1.IdentityClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new identityModule.v1beta1.IdentityClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/disable-packing-test-esm/esm/test/gapic_identity_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/test/gapic_identity_v1beta1.ts.baseline
@@ -111,13 +111,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v1beta1.IdentityClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = identityModule.v1beta1.IdentityClient.servicePath;
-            assert(servicePath);
+            const client = new identityModule.v1beta1.IdentityClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = identityModule.v1beta1.IdentityClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new identityModule.v1beta1.IdentityClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'localhost');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new identityModule.v1beta1.IdentityClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new identityModule.v1beta1.IdentityClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new identityModule.v1beta1.IdentityClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new identityModule.v1beta1.IdentityClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/disable-packing-test-esm/esm/test/gapic_messaging_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/test/gapic_messaging_v1beta1.ts.baseline
@@ -177,18 +177,23 @@ describe('v1beta1.MessagingClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
-        it('sets servicePath according to universe domain camelCase', () => {
-            const client = new messagingModule.v1beta1.MessagingClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = messagingModule.v1beta1.MessagingClient.servicePath;
+                assert.strictEqual(servicePath, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
-            const client = new messagingModule.v1beta1.MessagingClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
-
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = messagingModule.v1beta1.MessagingClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new messagingModule.v1beta1.MessagingClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/disable-packing-test-esm/esm/test/gapic_messaging_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/test/gapic_messaging_v1beta1.ts.baseline
@@ -160,13 +160,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v1beta1.MessagingClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = messagingModule.v1beta1.MessagingClient.servicePath;
-            assert(servicePath);
+            const client = new messagingModule.v1beta1.MessagingClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = messagingModule.v1beta1.MessagingClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new messagingModule.v1beta1.MessagingClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'localhost');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new messagingModule.v1beta1.MessagingClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new messagingModule.v1beta1.MessagingClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new messagingModule.v1beta1.MessagingClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new messagingModule.v1beta1.MessagingClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/disable-packing-test-esm/esm/test/gapic_sequence_service_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/test/gapic_sequence_service_v1beta1.ts.baseline
@@ -81,18 +81,23 @@ describe('v1beta1.SequenceServiceClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
-        it('sets servicePath according to universe domain camelCase', () => {
-            const client = new sequenceserviceModule.v1beta1.SequenceServiceClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = sequenceserviceModule.v1beta1.SequenceServiceClient.servicePath;
+                assert.strictEqual(servicePath, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
-            const client = new sequenceserviceModule.v1beta1.SequenceServiceClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
-
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = sequenceserviceModule.v1beta1.SequenceServiceClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new sequenceserviceModule.v1beta1.SequenceServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/disable-packing-test-esm/esm/test/gapic_sequence_service_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/test/gapic_sequence_service_v1beta1.ts.baseline
@@ -64,13 +64,37 @@ function stubSimpleCallWithCallback<ResponseType>(response?: ResponseType, error
 describe('v1beta1.SequenceServiceClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = sequenceserviceModule.v1beta1.SequenceServiceClient.servicePath;
-            assert(servicePath);
+            const client = new sequenceserviceModule.v1beta1.SequenceServiceClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = sequenceserviceModule.v1beta1.SequenceServiceClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new sequenceserviceModule.v1beta1.SequenceServiceClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'localhost');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new sequenceserviceModule.v1beta1.SequenceServiceClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new sequenceserviceModule.v1beta1.SequenceServiceClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new sequenceserviceModule.v1beta1.SequenceServiceClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new sequenceserviceModule.v1beta1.SequenceServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/disable-packing-test-esm/esm/test/gapic_testing_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/test/gapic_testing_v1beta1.ts.baseline
@@ -111,13 +111,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v1beta1.TestingClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = testingModule.v1beta1.TestingClient.servicePath;
-            assert(servicePath);
+            const client = new testingModule.v1beta1.TestingClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = testingModule.v1beta1.TestingClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new testingModule.v1beta1.TestingClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'localhost');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new testingModule.v1beta1.TestingClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new testingModule.v1beta1.TestingClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new testingModule.v1beta1.TestingClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new testingModule.v1beta1.TestingClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/disable-packing-test-esm/esm/test/gapic_testing_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/test/gapic_testing_v1beta1.ts.baseline
@@ -128,18 +128,23 @@ describe('v1beta1.TestingClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
-        it('sets servicePath according to universe domain camelCase', () => {
-            const client = new testingModule.v1beta1.TestingClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = testingModule.v1beta1.TestingClient.servicePath;
+                assert.strictEqual(servicePath, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
-            const client = new testingModule.v1beta1.TestingClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
-
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = testingModule.v1beta1.TestingClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new testingModule.v1beta1.TestingClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/disable-packing-test/src/v1beta1/compliance_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/compliance_client.ts.baseline
@@ -46,6 +46,8 @@ export class ComplianceClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -100,7 +102,12 @@ export class ComplianceClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof ComplianceClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'localhost.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -108,7 +115,7 @@ export class ComplianceClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -133,10 +140,10 @@ export class ComplianceClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -274,19 +281,47 @@ export class ComplianceClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/disable-packing-test/src/v1beta1/compliance_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/compliance_client.ts.baseline
@@ -106,7 +106,7 @@ export class ComplianceClient {
       throw new Error('Please set either universe_domain or universeDomain, but not both.');
     }
     this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
-    this._servicePath = 'localhost.' + this._universeDomain;
+    this._servicePath = 'localhost';
     const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;

--- a/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
@@ -111,7 +111,7 @@ export class EchoClient {
       throw new Error('Please set either universe_domain or universeDomain, but not both.');
     }
     this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
-    this._servicePath = 'localhost.' + this._universeDomain;
+    this._servicePath = 'localhost';
     const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;

--- a/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
@@ -50,6 +50,8 @@ export class EchoClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -105,7 +107,12 @@ export class EchoClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof EchoClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'localhost.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -113,7 +120,7 @@ export class EchoClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -138,10 +145,10 @@ export class EchoClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -330,19 +337,47 @@ export class EchoClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/disable-packing-test/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/identity_client.ts.baseline
@@ -44,6 +44,8 @@ export class IdentityClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -98,7 +100,12 @@ export class IdentityClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof IdentityClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'localhost.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -106,7 +113,7 @@ export class IdentityClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -131,10 +138,10 @@ export class IdentityClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -281,19 +288,47 @@ export class IdentityClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/disable-packing-test/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/identity_client.ts.baseline
@@ -104,7 +104,7 @@ export class IdentityClient {
       throw new Error('Please set either universe_domain or universeDomain, but not both.');
     }
     this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
-    this._servicePath = 'localhost.' + this._universeDomain;
+    this._servicePath = 'localhost';
     const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;

--- a/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
@@ -47,6 +47,8 @@ export class MessagingClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -102,7 +104,12 @@ export class MessagingClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof MessagingClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'localhost.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -110,7 +117,7 @@ export class MessagingClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -135,10 +142,10 @@ export class MessagingClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -329,19 +336,47 @@ export class MessagingClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
@@ -108,7 +108,7 @@ export class MessagingClient {
       throw new Error('Please set either universe_domain or universeDomain, but not both.');
     }
     this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
-    this._servicePath = 'localhost.' + this._universeDomain;
+    this._servicePath = 'localhost';
     const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;

--- a/baselines/disable-packing-test/src/v1beta1/sequence_service_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/sequence_service_client.ts.baseline
@@ -43,6 +43,8 @@ export class SequenceServiceClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -97,7 +99,12 @@ export class SequenceServiceClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof SequenceServiceClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'localhost.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -105,7 +112,7 @@ export class SequenceServiceClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -130,10 +137,10 @@ export class SequenceServiceClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -271,19 +278,47 @@ export class SequenceServiceClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/disable-packing-test/src/v1beta1/sequence_service_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/sequence_service_client.ts.baseline
@@ -103,7 +103,7 @@ export class SequenceServiceClient {
       throw new Error('Please set either universe_domain or universeDomain, but not both.');
     }
     this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
-    this._servicePath = 'localhost.' + this._universeDomain;
+    this._servicePath = 'localhost';
     const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;

--- a/baselines/disable-packing-test/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/testing_client.ts.baseline
@@ -105,7 +105,7 @@ export class TestingClient {
       throw new Error('Please set either universe_domain or universeDomain, but not both.');
     }
     this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
-    this._servicePath = 'localhost.' + this._universeDomain;
+    this._servicePath = 'localhost';
     const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;

--- a/baselines/disable-packing-test/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/testing_client.ts.baseline
@@ -45,6 +45,8 @@ export class TestingClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -99,7 +101,12 @@ export class TestingClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof TestingClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'localhost.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -107,7 +114,7 @@ export class TestingClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -132,10 +139,10 @@ export class TestingClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -284,19 +291,47 @@ export class TestingClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/disable-packing-test/test/gapic_compliance_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_compliance_v1beta1.ts.baseline
@@ -55,13 +55,37 @@ function stubSimpleCallWithCallback<ResponseType>(response?: ResponseType, error
 describe('v1beta1.ComplianceClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = complianceModule.v1beta1.ComplianceClient.servicePath;
-            assert(servicePath);
+            const client = new complianceModule.v1beta1.ComplianceClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = complianceModule.v1beta1.ComplianceClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new complianceModule.v1beta1.ComplianceClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'localhost');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new complianceModule.v1beta1.ComplianceClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new complianceModule.v1beta1.ComplianceClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new complianceModule.v1beta1.ComplianceClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new complianceModule.v1beta1.ComplianceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/disable-packing-test/test/gapic_compliance_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_compliance_v1beta1.ts.baseline
@@ -72,18 +72,23 @@ describe('v1beta1.ComplianceClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
-        it('sets servicePath according to universe domain camelCase', () => {
-            const client = new complianceModule.v1beta1.ComplianceClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = complianceModule.v1beta1.ComplianceClient.servicePath;
+                assert.strictEqual(servicePath, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
-            const client = new complianceModule.v1beta1.ComplianceClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
-
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = complianceModule.v1beta1.ComplianceClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new complianceModule.v1beta1.ComplianceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/disable-packing-test/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_echo_v1beta1.ts.baseline
@@ -151,13 +151,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v1beta1.EchoClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = echoModule.v1beta1.EchoClient.servicePath;
-            assert(servicePath);
+            const client = new echoModule.v1beta1.EchoClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = echoModule.v1beta1.EchoClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new echoModule.v1beta1.EchoClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'localhost');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new echoModule.v1beta1.EchoClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new echoModule.v1beta1.EchoClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new echoModule.v1beta1.EchoClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new echoModule.v1beta1.EchoClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/disable-packing-test/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_echo_v1beta1.ts.baseline
@@ -168,18 +168,23 @@ describe('v1beta1.EchoClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
-        it('sets servicePath according to universe domain camelCase', () => {
-            const client = new echoModule.v1beta1.EchoClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = echoModule.v1beta1.EchoClient.servicePath;
+                assert.strictEqual(servicePath, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
-            const client = new echoModule.v1beta1.EchoClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
-
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = echoModule.v1beta1.EchoClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new echoModule.v1beta1.EchoClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/disable-packing-test/test/gapic_identity_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_identity_v1beta1.ts.baseline
@@ -119,18 +119,23 @@ describe('v1beta1.IdentityClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
-        it('sets servicePath according to universe domain camelCase', () => {
-            const client = new identityModule.v1beta1.IdentityClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = identityModule.v1beta1.IdentityClient.servicePath;
+                assert.strictEqual(servicePath, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
-            const client = new identityModule.v1beta1.IdentityClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
-
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = identityModule.v1beta1.IdentityClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new identityModule.v1beta1.IdentityClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/disable-packing-test/test/gapic_identity_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_identity_v1beta1.ts.baseline
@@ -102,13 +102,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v1beta1.IdentityClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = identityModule.v1beta1.IdentityClient.servicePath;
-            assert(servicePath);
+            const client = new identityModule.v1beta1.IdentityClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = identityModule.v1beta1.IdentityClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new identityModule.v1beta1.IdentityClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'localhost');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new identityModule.v1beta1.IdentityClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new identityModule.v1beta1.IdentityClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new identityModule.v1beta1.IdentityClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new identityModule.v1beta1.IdentityClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/disable-packing-test/test/gapic_messaging_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_messaging_v1beta1.ts.baseline
@@ -168,18 +168,23 @@ describe('v1beta1.MessagingClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
-        it('sets servicePath according to universe domain camelCase', () => {
-            const client = new messagingModule.v1beta1.MessagingClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = messagingModule.v1beta1.MessagingClient.servicePath;
+                assert.strictEqual(servicePath, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
-            const client = new messagingModule.v1beta1.MessagingClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
-
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = messagingModule.v1beta1.MessagingClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new messagingModule.v1beta1.MessagingClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/disable-packing-test/test/gapic_messaging_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_messaging_v1beta1.ts.baseline
@@ -151,13 +151,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v1beta1.MessagingClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = messagingModule.v1beta1.MessagingClient.servicePath;
-            assert(servicePath);
+            const client = new messagingModule.v1beta1.MessagingClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = messagingModule.v1beta1.MessagingClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new messagingModule.v1beta1.MessagingClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'localhost');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new messagingModule.v1beta1.MessagingClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new messagingModule.v1beta1.MessagingClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new messagingModule.v1beta1.MessagingClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new messagingModule.v1beta1.MessagingClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/disable-packing-test/test/gapic_sequence_service_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_sequence_service_v1beta1.ts.baseline
@@ -72,18 +72,23 @@ describe('v1beta1.SequenceServiceClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
-        it('sets servicePath according to universe domain camelCase', () => {
-            const client = new sequenceserviceModule.v1beta1.SequenceServiceClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = sequenceserviceModule.v1beta1.SequenceServiceClient.servicePath;
+                assert.strictEqual(servicePath, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
-            const client = new sequenceserviceModule.v1beta1.SequenceServiceClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
-
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = sequenceserviceModule.v1beta1.SequenceServiceClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new sequenceserviceModule.v1beta1.SequenceServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/disable-packing-test/test/gapic_sequence_service_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_sequence_service_v1beta1.ts.baseline
@@ -55,13 +55,37 @@ function stubSimpleCallWithCallback<ResponseType>(response?: ResponseType, error
 describe('v1beta1.SequenceServiceClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = sequenceserviceModule.v1beta1.SequenceServiceClient.servicePath;
-            assert(servicePath);
+            const client = new sequenceserviceModule.v1beta1.SequenceServiceClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = sequenceserviceModule.v1beta1.SequenceServiceClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new sequenceserviceModule.v1beta1.SequenceServiceClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'localhost');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new sequenceserviceModule.v1beta1.SequenceServiceClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new sequenceserviceModule.v1beta1.SequenceServiceClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new sequenceserviceModule.v1beta1.SequenceServiceClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new sequenceserviceModule.v1beta1.SequenceServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/disable-packing-test/test/gapic_testing_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_testing_v1beta1.ts.baseline
@@ -102,13 +102,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v1beta1.TestingClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = testingModule.v1beta1.TestingClient.servicePath;
-            assert(servicePath);
+            const client = new testingModule.v1beta1.TestingClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = testingModule.v1beta1.TestingClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new testingModule.v1beta1.TestingClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'localhost');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new testingModule.v1beta1.TestingClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new testingModule.v1beta1.TestingClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new testingModule.v1beta1.TestingClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new testingModule.v1beta1.TestingClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/disable-packing-test/test/gapic_testing_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_testing_v1beta1.ts.baseline
@@ -119,18 +119,23 @@ describe('v1beta1.TestingClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
-        it('sets servicePath according to universe domain camelCase', () => {
-            const client = new testingModule.v1beta1.TestingClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = testingModule.v1beta1.TestingClient.servicePath;
+                assert.strictEqual(servicePath, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
-            const client = new testingModule.v1beta1.TestingClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
-
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = testingModule.v1beta1.TestingClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new testingModule.v1beta1.TestingClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/dlp-esm/esm/src/v2/dlp_service_client.ts.baseline
+++ b/baselines/dlp-esm/esm/src/v2/dlp_service_client.ts.baseline
@@ -59,6 +59,8 @@ export class DlpServiceClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -114,7 +116,12 @@ export class DlpServiceClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof DlpServiceClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'dlp.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -122,7 +129,7 @@ export class DlpServiceClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -147,10 +154,10 @@ export class DlpServiceClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -310,19 +317,47 @@ export class DlpServiceClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'dlp.googleapis.com';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'dlp.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/dlp-esm/esm/test/gapic_dlp_service_v2.ts.baseline
+++ b/baselines/dlp-esm/esm/test/gapic_dlp_service_v2.ts.baseline
@@ -128,6 +128,23 @@ describe('v2.DlpServiceClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = dlpserviceModule.v2.DlpServiceClient.servicePath;
+                assert.strictEqual(servicePath, 'dlp.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = dlpserviceModule.v2.DlpServiceClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'dlp.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new dlpserviceModule.v2.DlpServiceClient({universeDomain: 'example.com'});
             const servicePath = client.servicePath;
@@ -139,7 +156,6 @@ describe('v2.DlpServiceClient', () => {
             const servicePath = client.servicePath;
             assert.strictEqual(servicePath, 'dlp.example.com');
         });
-
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new dlpserviceModule.v2.DlpServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/dlp-esm/esm/test/gapic_dlp_service_v2.ts.baseline
+++ b/baselines/dlp-esm/esm/test/gapic_dlp_service_v2.ts.baseline
@@ -111,13 +111,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v2.DlpServiceClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = dlpserviceModule.v2.DlpServiceClient.servicePath;
-            assert(servicePath);
+            const client = new dlpserviceModule.v2.DlpServiceClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'dlp.googleapis.com');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = dlpserviceModule.v2.DlpServiceClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new dlpserviceModule.v2.DlpServiceClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'dlp.googleapis.com');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new dlpserviceModule.v2.DlpServiceClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new dlpserviceModule.v2.DlpServiceClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'dlp.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new dlpserviceModule.v2.DlpServiceClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'dlp.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new dlpserviceModule.v2.DlpServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/dlp/src/v2/dlp_service_client.ts.baseline
+++ b/baselines/dlp/src/v2/dlp_service_client.ts.baseline
@@ -52,6 +52,8 @@ export class DlpServiceClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -106,7 +108,12 @@ export class DlpServiceClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof DlpServiceClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'dlp.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -114,7 +121,7 @@ export class DlpServiceClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -139,10 +146,10 @@ export class DlpServiceClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -294,19 +301,47 @@ export class DlpServiceClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'dlp.googleapis.com';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'dlp.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/dlp/test/gapic_dlp_service_v2.ts.baseline
+++ b/baselines/dlp/test/gapic_dlp_service_v2.ts.baseline
@@ -102,13 +102,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v2.DlpServiceClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = dlpserviceModule.v2.DlpServiceClient.servicePath;
-            assert(servicePath);
+            const client = new dlpserviceModule.v2.DlpServiceClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'dlp.googleapis.com');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = dlpserviceModule.v2.DlpServiceClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new dlpserviceModule.v2.DlpServiceClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'dlp.googleapis.com');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new dlpserviceModule.v2.DlpServiceClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new dlpserviceModule.v2.DlpServiceClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'dlp.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new dlpserviceModule.v2.DlpServiceClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'dlp.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new dlpserviceModule.v2.DlpServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/dlp/test/gapic_dlp_service_v2.ts.baseline
+++ b/baselines/dlp/test/gapic_dlp_service_v2.ts.baseline
@@ -119,6 +119,23 @@ describe('v2.DlpServiceClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = dlpserviceModule.v2.DlpServiceClient.servicePath;
+                assert.strictEqual(servicePath, 'dlp.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = dlpserviceModule.v2.DlpServiceClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'dlp.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new dlpserviceModule.v2.DlpServiceClient({universeDomain: 'example.com'});
             const servicePath = client.servicePath;
@@ -130,7 +147,6 @@ describe('v2.DlpServiceClient', () => {
             const servicePath = client.servicePath;
             assert.strictEqual(servicePath, 'dlp.example.com');
         });
-
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new dlpserviceModule.v2.DlpServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/kms-esm/esm/src/v1/key_management_service_client.ts.baseline
+++ b/baselines/kms-esm/esm/src/v1/key_management_service_client.ts.baseline
@@ -61,6 +61,8 @@ export class KeyManagementServiceClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -116,7 +118,12 @@ export class KeyManagementServiceClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof KeyManagementServiceClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'cloudkms.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -124,7 +131,7 @@ export class KeyManagementServiceClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -149,10 +156,10 @@ export class KeyManagementServiceClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
     this.iamClient = new this._gaxModule.IamClient(this._gaxGrpc, opts);
@@ -276,19 +283,47 @@ export class KeyManagementServiceClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'cloudkms.googleapis.com';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'cloudkms.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/kms-esm/esm/test/gapic_key_management_service_v1.ts.baseline
+++ b/baselines/kms-esm/esm/test/gapic_key_management_service_v1.ts.baseline
@@ -111,13 +111,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v1.KeyManagementServiceClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = keymanagementserviceModule.v1.KeyManagementServiceClient.servicePath;
-            assert(servicePath);
+            const client = new keymanagementserviceModule.v1.KeyManagementServiceClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'cloudkms.googleapis.com');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = keymanagementserviceModule.v1.KeyManagementServiceClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new keymanagementserviceModule.v1.KeyManagementServiceClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'cloudkms.googleapis.com');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new keymanagementserviceModule.v1.KeyManagementServiceClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new keymanagementserviceModule.v1.KeyManagementServiceClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'cloudkms.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new keymanagementserviceModule.v1.KeyManagementServiceClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'cloudkms.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new keymanagementserviceModule.v1.KeyManagementServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/kms-esm/esm/test/gapic_key_management_service_v1.ts.baseline
+++ b/baselines/kms-esm/esm/test/gapic_key_management_service_v1.ts.baseline
@@ -128,6 +128,23 @@ describe('v1.KeyManagementServiceClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = keymanagementserviceModule.v1.KeyManagementServiceClient.servicePath;
+                assert.strictEqual(servicePath, 'cloudkms.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = keymanagementserviceModule.v1.KeyManagementServiceClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'cloudkms.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new keymanagementserviceModule.v1.KeyManagementServiceClient({universeDomain: 'example.com'});
             const servicePath = client.servicePath;
@@ -139,7 +156,6 @@ describe('v1.KeyManagementServiceClient', () => {
             const servicePath = client.servicePath;
             assert.strictEqual(servicePath, 'cloudkms.example.com');
         });
-
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new keymanagementserviceModule.v1.KeyManagementServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/kms/src/v1/key_management_service_client.ts.baseline
+++ b/baselines/kms/src/v1/key_management_service_client.ts.baseline
@@ -54,6 +54,8 @@ export class KeyManagementServiceClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -108,7 +110,12 @@ export class KeyManagementServiceClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof KeyManagementServiceClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'cloudkms.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -116,7 +123,7 @@ export class KeyManagementServiceClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -141,10 +148,10 @@ export class KeyManagementServiceClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
     this.iamClient = new this._gaxModule.IamClient(this._gaxGrpc, opts);
@@ -260,19 +267,47 @@ export class KeyManagementServiceClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'cloudkms.googleapis.com';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'cloudkms.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/kms/test/gapic_key_management_service_v1.ts.baseline
+++ b/baselines/kms/test/gapic_key_management_service_v1.ts.baseline
@@ -102,13 +102,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v1.KeyManagementServiceClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = keymanagementserviceModule.v1.KeyManagementServiceClient.servicePath;
-            assert(servicePath);
+            const client = new keymanagementserviceModule.v1.KeyManagementServiceClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'cloudkms.googleapis.com');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = keymanagementserviceModule.v1.KeyManagementServiceClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new keymanagementserviceModule.v1.KeyManagementServiceClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'cloudkms.googleapis.com');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new keymanagementserviceModule.v1.KeyManagementServiceClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new keymanagementserviceModule.v1.KeyManagementServiceClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'cloudkms.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new keymanagementserviceModule.v1.KeyManagementServiceClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'cloudkms.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new keymanagementserviceModule.v1.KeyManagementServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/kms/test/gapic_key_management_service_v1.ts.baseline
+++ b/baselines/kms/test/gapic_key_management_service_v1.ts.baseline
@@ -119,6 +119,23 @@ describe('v1.KeyManagementServiceClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = keymanagementserviceModule.v1.KeyManagementServiceClient.servicePath;
+                assert.strictEqual(servicePath, 'cloudkms.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = keymanagementserviceModule.v1.KeyManagementServiceClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'cloudkms.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new keymanagementserviceModule.v1.KeyManagementServiceClient({universeDomain: 'example.com'});
             const servicePath = client.servicePath;
@@ -130,7 +147,6 @@ describe('v1.KeyManagementServiceClient', () => {
             const servicePath = client.servicePath;
             assert.strictEqual(servicePath, 'cloudkms.example.com');
         });
-
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new keymanagementserviceModule.v1.KeyManagementServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/logging-esm/esm/src/v2/config_service_v2_client.ts.baseline
+++ b/baselines/logging-esm/esm/src/v2/config_service_v2_client.ts.baseline
@@ -51,6 +51,8 @@ export class ConfigServiceV2Client {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -107,7 +109,12 @@ export class ConfigServiceV2Client {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof ConfigServiceV2Client;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'logging.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -115,7 +122,7 @@ export class ConfigServiceV2Client {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -140,10 +147,10 @@ export class ConfigServiceV2Client {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -390,19 +397,47 @@ export class ConfigServiceV2Client {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'logging.googleapis.com';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'logging.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/logging-esm/esm/src/v2/logging_service_v2_client.ts.baseline
+++ b/baselines/logging-esm/esm/src/v2/logging_service_v2_client.ts.baseline
@@ -51,6 +51,8 @@ export class LoggingServiceV2Client {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -106,7 +108,12 @@ export class LoggingServiceV2Client {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof LoggingServiceV2Client;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'logging.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -114,7 +121,7 @@ export class LoggingServiceV2Client {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -139,10 +146,10 @@ export class LoggingServiceV2Client {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -389,19 +396,47 @@ export class LoggingServiceV2Client {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'logging.googleapis.com';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'logging.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/logging-esm/esm/src/v2/metrics_service_v2_client.ts.baseline
+++ b/baselines/logging-esm/esm/src/v2/metrics_service_v2_client.ts.baseline
@@ -51,6 +51,8 @@ export class MetricsServiceV2Client {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -106,7 +108,12 @@ export class MetricsServiceV2Client {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof MetricsServiceV2Client;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'logging.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -114,7 +121,7 @@ export class MetricsServiceV2Client {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -139,10 +146,10 @@ export class MetricsServiceV2Client {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -354,19 +361,47 @@ export class MetricsServiceV2Client {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'logging.googleapis.com';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'logging.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/logging-esm/esm/test/gapic_config_service_v2_v2.ts.baseline
+++ b/baselines/logging-esm/esm/test/gapic_config_service_v2_v2.ts.baseline
@@ -127,13 +127,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v2.ConfigServiceV2Client', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = configservicev2Module.v2.ConfigServiceV2Client.servicePath;
-            assert(servicePath);
+            const client = new configservicev2Module.v2.ConfigServiceV2Client();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'logging.googleapis.com');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = configservicev2Module.v2.ConfigServiceV2Client.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new configservicev2Module.v2.ConfigServiceV2Client();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'logging.googleapis.com');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'logging.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'logging.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new configservicev2Module.v2.ConfigServiceV2Client({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/logging-esm/esm/test/gapic_config_service_v2_v2.ts.baseline
+++ b/baselines/logging-esm/esm/test/gapic_config_service_v2_v2.ts.baseline
@@ -144,6 +144,23 @@ describe('v2.ConfigServiceV2Client', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = configservicev2Module.v2.ConfigServiceV2Client.servicePath;
+                assert.strictEqual(servicePath, 'logging.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = configservicev2Module.v2.ConfigServiceV2Client.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'logging.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new configservicev2Module.v2.ConfigServiceV2Client({universeDomain: 'example.com'});
             const servicePath = client.servicePath;
@@ -155,7 +172,6 @@ describe('v2.ConfigServiceV2Client', () => {
             const servicePath = client.servicePath;
             assert.strictEqual(servicePath, 'logging.example.com');
         });
-
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new configservicev2Module.v2.ConfigServiceV2Client({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/logging-esm/esm/test/gapic_logging_service_v2_v2.ts.baseline
+++ b/baselines/logging-esm/esm/test/gapic_logging_service_v2_v2.ts.baseline
@@ -137,6 +137,23 @@ describe('v2.LoggingServiceV2Client', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = loggingservicev2Module.v2.LoggingServiceV2Client.servicePath;
+                assert.strictEqual(servicePath, 'logging.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = loggingservicev2Module.v2.LoggingServiceV2Client.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'logging.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new loggingservicev2Module.v2.LoggingServiceV2Client({universeDomain: 'example.com'});
             const servicePath = client.servicePath;
@@ -148,7 +165,6 @@ describe('v2.LoggingServiceV2Client', () => {
             const servicePath = client.servicePath;
             assert.strictEqual(servicePath, 'logging.example.com');
         });
-
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new loggingservicev2Module.v2.LoggingServiceV2Client({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/logging-esm/esm/test/gapic_logging_service_v2_v2.ts.baseline
+++ b/baselines/logging-esm/esm/test/gapic_logging_service_v2_v2.ts.baseline
@@ -120,13 +120,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v2.LoggingServiceV2Client', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = loggingservicev2Module.v2.LoggingServiceV2Client.servicePath;
-            assert(servicePath);
+            const client = new loggingservicev2Module.v2.LoggingServiceV2Client();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'logging.googleapis.com');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = loggingservicev2Module.v2.LoggingServiceV2Client.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new loggingservicev2Module.v2.LoggingServiceV2Client();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'logging.googleapis.com');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new loggingservicev2Module.v2.LoggingServiceV2Client();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new loggingservicev2Module.v2.LoggingServiceV2Client({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'logging.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new loggingservicev2Module.v2.LoggingServiceV2Client({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'logging.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new loggingservicev2Module.v2.LoggingServiceV2Client({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/logging-esm/esm/test/gapic_metrics_service_v2_v2.ts.baseline
+++ b/baselines/logging-esm/esm/test/gapic_metrics_service_v2_v2.ts.baseline
@@ -111,13 +111,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v2.MetricsServiceV2Client', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = metricsservicev2Module.v2.MetricsServiceV2Client.servicePath;
-            assert(servicePath);
+            const client = new metricsservicev2Module.v2.MetricsServiceV2Client();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'logging.googleapis.com');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = metricsservicev2Module.v2.MetricsServiceV2Client.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new metricsservicev2Module.v2.MetricsServiceV2Client();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'logging.googleapis.com');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new metricsservicev2Module.v2.MetricsServiceV2Client();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new metricsservicev2Module.v2.MetricsServiceV2Client({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'logging.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new metricsservicev2Module.v2.MetricsServiceV2Client({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'logging.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new metricsservicev2Module.v2.MetricsServiceV2Client({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/logging-esm/esm/test/gapic_metrics_service_v2_v2.ts.baseline
+++ b/baselines/logging-esm/esm/test/gapic_metrics_service_v2_v2.ts.baseline
@@ -128,6 +128,23 @@ describe('v2.MetricsServiceV2Client', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = metricsservicev2Module.v2.MetricsServiceV2Client.servicePath;
+                assert.strictEqual(servicePath, 'logging.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = metricsservicev2Module.v2.MetricsServiceV2Client.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'logging.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new metricsservicev2Module.v2.MetricsServiceV2Client({universeDomain: 'example.com'});
             const servicePath = client.servicePath;
@@ -139,7 +156,6 @@ describe('v2.MetricsServiceV2Client', () => {
             const servicePath = client.servicePath;
             assert.strictEqual(servicePath, 'logging.example.com');
         });
-
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new metricsservicev2Module.v2.MetricsServiceV2Client({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/logging/src/v2/config_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/config_service_v2_client.ts.baseline
@@ -44,6 +44,8 @@ export class ConfigServiceV2Client {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -99,7 +101,12 @@ export class ConfigServiceV2Client {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof ConfigServiceV2Client;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'logging.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -107,7 +114,7 @@ export class ConfigServiceV2Client {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -132,10 +139,10 @@ export class ConfigServiceV2Client {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -374,19 +381,47 @@ export class ConfigServiceV2Client {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'logging.googleapis.com';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'logging.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
@@ -44,6 +44,8 @@ export class LoggingServiceV2Client {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -98,7 +100,12 @@ export class LoggingServiceV2Client {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof LoggingServiceV2Client;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'logging.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -106,7 +113,7 @@ export class LoggingServiceV2Client {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -131,10 +138,10 @@ export class LoggingServiceV2Client {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -373,19 +380,47 @@ export class LoggingServiceV2Client {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'logging.googleapis.com';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'logging.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/logging/src/v2/metrics_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/metrics_service_v2_client.ts.baseline
@@ -44,6 +44,8 @@ export class MetricsServiceV2Client {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -98,7 +100,12 @@ export class MetricsServiceV2Client {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof MetricsServiceV2Client;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'logging.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -106,7 +113,7 @@ export class MetricsServiceV2Client {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -131,10 +138,10 @@ export class MetricsServiceV2Client {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -338,19 +345,47 @@ export class MetricsServiceV2Client {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'logging.googleapis.com';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'logging.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/logging/test/gapic_config_service_v2_v2.ts.baseline
+++ b/baselines/logging/test/gapic_config_service_v2_v2.ts.baseline
@@ -135,6 +135,23 @@ describe('v2.ConfigServiceV2Client', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = configservicev2Module.v2.ConfigServiceV2Client.servicePath;
+                assert.strictEqual(servicePath, 'logging.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = configservicev2Module.v2.ConfigServiceV2Client.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'logging.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new configservicev2Module.v2.ConfigServiceV2Client({universeDomain: 'example.com'});
             const servicePath = client.servicePath;
@@ -146,7 +163,6 @@ describe('v2.ConfigServiceV2Client', () => {
             const servicePath = client.servicePath;
             assert.strictEqual(servicePath, 'logging.example.com');
         });
-
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new configservicev2Module.v2.ConfigServiceV2Client({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/logging/test/gapic_config_service_v2_v2.ts.baseline
+++ b/baselines/logging/test/gapic_config_service_v2_v2.ts.baseline
@@ -118,13 +118,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v2.ConfigServiceV2Client', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = configservicev2Module.v2.ConfigServiceV2Client.servicePath;
-            assert(servicePath);
+            const client = new configservicev2Module.v2.ConfigServiceV2Client();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'logging.googleapis.com');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = configservicev2Module.v2.ConfigServiceV2Client.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new configservicev2Module.v2.ConfigServiceV2Client();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'logging.googleapis.com');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'logging.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'logging.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new configservicev2Module.v2.ConfigServiceV2Client({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/logging/test/gapic_logging_service_v2_v2.ts.baseline
+++ b/baselines/logging/test/gapic_logging_service_v2_v2.ts.baseline
@@ -128,6 +128,23 @@ describe('v2.LoggingServiceV2Client', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = loggingservicev2Module.v2.LoggingServiceV2Client.servicePath;
+                assert.strictEqual(servicePath, 'logging.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = loggingservicev2Module.v2.LoggingServiceV2Client.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'logging.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new loggingservicev2Module.v2.LoggingServiceV2Client({universeDomain: 'example.com'});
             const servicePath = client.servicePath;
@@ -139,7 +156,6 @@ describe('v2.LoggingServiceV2Client', () => {
             const servicePath = client.servicePath;
             assert.strictEqual(servicePath, 'logging.example.com');
         });
-
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new loggingservicev2Module.v2.LoggingServiceV2Client({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/logging/test/gapic_logging_service_v2_v2.ts.baseline
+++ b/baselines/logging/test/gapic_logging_service_v2_v2.ts.baseline
@@ -111,13 +111,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v2.LoggingServiceV2Client', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = loggingservicev2Module.v2.LoggingServiceV2Client.servicePath;
-            assert(servicePath);
+            const client = new loggingservicev2Module.v2.LoggingServiceV2Client();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'logging.googleapis.com');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = loggingservicev2Module.v2.LoggingServiceV2Client.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new loggingservicev2Module.v2.LoggingServiceV2Client();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'logging.googleapis.com');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new loggingservicev2Module.v2.LoggingServiceV2Client();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new loggingservicev2Module.v2.LoggingServiceV2Client({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'logging.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new loggingservicev2Module.v2.LoggingServiceV2Client({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'logging.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new loggingservicev2Module.v2.LoggingServiceV2Client({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/logging/test/gapic_metrics_service_v2_v2.ts.baseline
+++ b/baselines/logging/test/gapic_metrics_service_v2_v2.ts.baseline
@@ -102,13 +102,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v2.MetricsServiceV2Client', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = metricsservicev2Module.v2.MetricsServiceV2Client.servicePath;
-            assert(servicePath);
+            const client = new metricsservicev2Module.v2.MetricsServiceV2Client();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'logging.googleapis.com');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = metricsservicev2Module.v2.MetricsServiceV2Client.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new metricsservicev2Module.v2.MetricsServiceV2Client();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'logging.googleapis.com');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new metricsservicev2Module.v2.MetricsServiceV2Client();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new metricsservicev2Module.v2.MetricsServiceV2Client({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'logging.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new metricsservicev2Module.v2.MetricsServiceV2Client({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'logging.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new metricsservicev2Module.v2.MetricsServiceV2Client({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/logging/test/gapic_metrics_service_v2_v2.ts.baseline
+++ b/baselines/logging/test/gapic_metrics_service_v2_v2.ts.baseline
@@ -119,6 +119,23 @@ describe('v2.MetricsServiceV2Client', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = metricsservicev2Module.v2.MetricsServiceV2Client.servicePath;
+                assert.strictEqual(servicePath, 'logging.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = metricsservicev2Module.v2.MetricsServiceV2Client.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'logging.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new metricsservicev2Module.v2.MetricsServiceV2Client({universeDomain: 'example.com'});
             const servicePath = client.servicePath;
@@ -130,7 +147,6 @@ describe('v2.MetricsServiceV2Client', () => {
             const servicePath = client.servicePath;
             assert.strictEqual(servicePath, 'logging.example.com');
         });
-
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new metricsservicev2Module.v2.MetricsServiceV2Client({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/monitoring-esm/esm/src/v3/alert_policy_service_client.ts.baseline
+++ b/baselines/monitoring-esm/esm/src/v3/alert_policy_service_client.ts.baseline
@@ -59,6 +59,8 @@ export class AlertPolicyServiceClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -114,7 +116,12 @@ export class AlertPolicyServiceClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof AlertPolicyServiceClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'monitoring.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -122,7 +129,7 @@ export class AlertPolicyServiceClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -147,10 +154,10 @@ export class AlertPolicyServiceClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -344,19 +351,47 @@ export class AlertPolicyServiceClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'monitoring.googleapis.com';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'monitoring.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/monitoring-esm/esm/src/v3/group_service_client.ts.baseline
+++ b/baselines/monitoring-esm/esm/src/v3/group_service_client.ts.baseline
@@ -62,6 +62,8 @@ export class GroupServiceClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -117,7 +119,12 @@ export class GroupServiceClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof GroupServiceClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'monitoring.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -125,7 +132,7 @@ export class GroupServiceClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -150,10 +157,10 @@ export class GroupServiceClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -349,19 +356,47 @@ export class GroupServiceClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'monitoring.googleapis.com';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'monitoring.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/monitoring-esm/esm/src/v3/metric_service_client.ts.baseline
+++ b/baselines/monitoring-esm/esm/src/v3/metric_service_client.ts.baseline
@@ -52,6 +52,8 @@ export class MetricServiceClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -107,7 +109,12 @@ export class MetricServiceClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof MetricServiceClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'monitoring.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -115,7 +122,7 @@ export class MetricServiceClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -140,10 +147,10 @@ export class MetricServiceClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -359,19 +366,47 @@ export class MetricServiceClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'monitoring.googleapis.com';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'monitoring.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/monitoring-esm/esm/src/v3/notification_channel_service_client.ts.baseline
+++ b/baselines/monitoring-esm/esm/src/v3/notification_channel_service_client.ts.baseline
@@ -52,6 +52,8 @@ export class NotificationChannelServiceClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -107,7 +109,12 @@ export class NotificationChannelServiceClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof NotificationChannelServiceClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'monitoring.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -115,7 +122,7 @@ export class NotificationChannelServiceClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -140,10 +147,10 @@ export class NotificationChannelServiceClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -339,19 +346,47 @@ export class NotificationChannelServiceClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'monitoring.googleapis.com';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'monitoring.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/monitoring-esm/esm/src/v3/service_monitoring_service_client.ts.baseline
+++ b/baselines/monitoring-esm/esm/src/v3/service_monitoring_service_client.ts.baseline
@@ -54,6 +54,8 @@ export class ServiceMonitoringServiceClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -109,7 +111,12 @@ export class ServiceMonitoringServiceClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof ServiceMonitoringServiceClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'monitoring.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -117,7 +124,7 @@ export class ServiceMonitoringServiceClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -142,10 +149,10 @@ export class ServiceMonitoringServiceClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -341,19 +348,47 @@ export class ServiceMonitoringServiceClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'monitoring.googleapis.com';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'monitoring.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/monitoring-esm/esm/src/v3/uptime_check_service_client.ts.baseline
+++ b/baselines/monitoring-esm/esm/src/v3/uptime_check_service_client.ts.baseline
@@ -58,6 +58,8 @@ export class UptimeCheckServiceClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -113,7 +115,12 @@ export class UptimeCheckServiceClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof UptimeCheckServiceClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'monitoring.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -121,7 +128,7 @@ export class UptimeCheckServiceClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -146,10 +153,10 @@ export class UptimeCheckServiceClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -345,19 +352,47 @@ export class UptimeCheckServiceClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'monitoring.googleapis.com';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'monitoring.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/monitoring-esm/esm/test/gapic_alert_policy_service_v3.ts.baseline
+++ b/baselines/monitoring-esm/esm/test/gapic_alert_policy_service_v3.ts.baseline
@@ -111,13 +111,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v3.AlertPolicyServiceClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = alertpolicyserviceModule.v3.AlertPolicyServiceClient.servicePath;
-            assert(servicePath);
+            const client = new alertpolicyserviceModule.v3.AlertPolicyServiceClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'monitoring.googleapis.com');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = alertpolicyserviceModule.v3.AlertPolicyServiceClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new alertpolicyserviceModule.v3.AlertPolicyServiceClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'monitoring.googleapis.com');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new alertpolicyserviceModule.v3.AlertPolicyServiceClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new alertpolicyserviceModule.v3.AlertPolicyServiceClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'monitoring.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new alertpolicyserviceModule.v3.AlertPolicyServiceClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'monitoring.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new alertpolicyserviceModule.v3.AlertPolicyServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/monitoring-esm/esm/test/gapic_alert_policy_service_v3.ts.baseline
+++ b/baselines/monitoring-esm/esm/test/gapic_alert_policy_service_v3.ts.baseline
@@ -128,6 +128,23 @@ describe('v3.AlertPolicyServiceClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = alertpolicyserviceModule.v3.AlertPolicyServiceClient.servicePath;
+                assert.strictEqual(servicePath, 'monitoring.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = alertpolicyserviceModule.v3.AlertPolicyServiceClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'monitoring.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new alertpolicyserviceModule.v3.AlertPolicyServiceClient({universeDomain: 'example.com'});
             const servicePath = client.servicePath;
@@ -139,7 +156,6 @@ describe('v3.AlertPolicyServiceClient', () => {
             const servicePath = client.servicePath;
             assert.strictEqual(servicePath, 'monitoring.example.com');
         });
-
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new alertpolicyserviceModule.v3.AlertPolicyServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/monitoring-esm/esm/test/gapic_group_service_v3.ts.baseline
+++ b/baselines/monitoring-esm/esm/test/gapic_group_service_v3.ts.baseline
@@ -111,13 +111,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v3.GroupServiceClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = groupserviceModule.v3.GroupServiceClient.servicePath;
-            assert(servicePath);
+            const client = new groupserviceModule.v3.GroupServiceClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'monitoring.googleapis.com');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = groupserviceModule.v3.GroupServiceClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new groupserviceModule.v3.GroupServiceClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'monitoring.googleapis.com');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new groupserviceModule.v3.GroupServiceClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new groupserviceModule.v3.GroupServiceClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'monitoring.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new groupserviceModule.v3.GroupServiceClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'monitoring.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new groupserviceModule.v3.GroupServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/monitoring-esm/esm/test/gapic_group_service_v3.ts.baseline
+++ b/baselines/monitoring-esm/esm/test/gapic_group_service_v3.ts.baseline
@@ -128,6 +128,23 @@ describe('v3.GroupServiceClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = groupserviceModule.v3.GroupServiceClient.servicePath;
+                assert.strictEqual(servicePath, 'monitoring.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = groupserviceModule.v3.GroupServiceClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'monitoring.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new groupserviceModule.v3.GroupServiceClient({universeDomain: 'example.com'});
             const servicePath = client.servicePath;
@@ -139,7 +156,6 @@ describe('v3.GroupServiceClient', () => {
             const servicePath = client.servicePath;
             assert.strictEqual(servicePath, 'monitoring.example.com');
         });
-
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new groupserviceModule.v3.GroupServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/monitoring-esm/esm/test/gapic_metric_service_v3.ts.baseline
+++ b/baselines/monitoring-esm/esm/test/gapic_metric_service_v3.ts.baseline
@@ -128,6 +128,23 @@ describe('v3.MetricServiceClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = metricserviceModule.v3.MetricServiceClient.servicePath;
+                assert.strictEqual(servicePath, 'monitoring.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = metricserviceModule.v3.MetricServiceClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'monitoring.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new metricserviceModule.v3.MetricServiceClient({universeDomain: 'example.com'});
             const servicePath = client.servicePath;
@@ -139,7 +156,6 @@ describe('v3.MetricServiceClient', () => {
             const servicePath = client.servicePath;
             assert.strictEqual(servicePath, 'monitoring.example.com');
         });
-
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new metricserviceModule.v3.MetricServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/monitoring-esm/esm/test/gapic_metric_service_v3.ts.baseline
+++ b/baselines/monitoring-esm/esm/test/gapic_metric_service_v3.ts.baseline
@@ -111,13 +111,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v3.MetricServiceClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = metricserviceModule.v3.MetricServiceClient.servicePath;
-            assert(servicePath);
+            const client = new metricserviceModule.v3.MetricServiceClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'monitoring.googleapis.com');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = metricserviceModule.v3.MetricServiceClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new metricserviceModule.v3.MetricServiceClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'monitoring.googleapis.com');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new metricserviceModule.v3.MetricServiceClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new metricserviceModule.v3.MetricServiceClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'monitoring.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new metricserviceModule.v3.MetricServiceClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'monitoring.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new metricserviceModule.v3.MetricServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/monitoring-esm/esm/test/gapic_notification_channel_service_v3.ts.baseline
+++ b/baselines/monitoring-esm/esm/test/gapic_notification_channel_service_v3.ts.baseline
@@ -128,6 +128,23 @@ describe('v3.NotificationChannelServiceClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = notificationchannelserviceModule.v3.NotificationChannelServiceClient.servicePath;
+                assert.strictEqual(servicePath, 'monitoring.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = notificationchannelserviceModule.v3.NotificationChannelServiceClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'monitoring.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new notificationchannelserviceModule.v3.NotificationChannelServiceClient({universeDomain: 'example.com'});
             const servicePath = client.servicePath;
@@ -139,7 +156,6 @@ describe('v3.NotificationChannelServiceClient', () => {
             const servicePath = client.servicePath;
             assert.strictEqual(servicePath, 'monitoring.example.com');
         });
-
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new notificationchannelserviceModule.v3.NotificationChannelServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/monitoring-esm/esm/test/gapic_notification_channel_service_v3.ts.baseline
+++ b/baselines/monitoring-esm/esm/test/gapic_notification_channel_service_v3.ts.baseline
@@ -111,13 +111,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v3.NotificationChannelServiceClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = notificationchannelserviceModule.v3.NotificationChannelServiceClient.servicePath;
-            assert(servicePath);
+            const client = new notificationchannelserviceModule.v3.NotificationChannelServiceClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'monitoring.googleapis.com');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = notificationchannelserviceModule.v3.NotificationChannelServiceClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new notificationchannelserviceModule.v3.NotificationChannelServiceClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'monitoring.googleapis.com');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new notificationchannelserviceModule.v3.NotificationChannelServiceClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new notificationchannelserviceModule.v3.NotificationChannelServiceClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'monitoring.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new notificationchannelserviceModule.v3.NotificationChannelServiceClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'monitoring.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new notificationchannelserviceModule.v3.NotificationChannelServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/monitoring-esm/esm/test/gapic_service_monitoring_service_v3.ts.baseline
+++ b/baselines/monitoring-esm/esm/test/gapic_service_monitoring_service_v3.ts.baseline
@@ -128,6 +128,23 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = servicemonitoringserviceModule.v3.ServiceMonitoringServiceClient.servicePath;
+                assert.strictEqual(servicePath, 'monitoring.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = servicemonitoringserviceModule.v3.ServiceMonitoringServiceClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'monitoring.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new servicemonitoringserviceModule.v3.ServiceMonitoringServiceClient({universeDomain: 'example.com'});
             const servicePath = client.servicePath;
@@ -139,7 +156,6 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             const servicePath = client.servicePath;
             assert.strictEqual(servicePath, 'monitoring.example.com');
         });
-
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new servicemonitoringserviceModule.v3.ServiceMonitoringServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/monitoring-esm/esm/test/gapic_service_monitoring_service_v3.ts.baseline
+++ b/baselines/monitoring-esm/esm/test/gapic_service_monitoring_service_v3.ts.baseline
@@ -111,13 +111,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v3.ServiceMonitoringServiceClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = servicemonitoringserviceModule.v3.ServiceMonitoringServiceClient.servicePath;
-            assert(servicePath);
+            const client = new servicemonitoringserviceModule.v3.ServiceMonitoringServiceClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'monitoring.googleapis.com');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = servicemonitoringserviceModule.v3.ServiceMonitoringServiceClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new servicemonitoringserviceModule.v3.ServiceMonitoringServiceClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'monitoring.googleapis.com');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new servicemonitoringserviceModule.v3.ServiceMonitoringServiceClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new servicemonitoringserviceModule.v3.ServiceMonitoringServiceClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'monitoring.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new servicemonitoringserviceModule.v3.ServiceMonitoringServiceClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'monitoring.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new servicemonitoringserviceModule.v3.ServiceMonitoringServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/monitoring-esm/esm/test/gapic_uptime_check_service_v3.ts.baseline
+++ b/baselines/monitoring-esm/esm/test/gapic_uptime_check_service_v3.ts.baseline
@@ -111,13 +111,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v3.UptimeCheckServiceClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = uptimecheckserviceModule.v3.UptimeCheckServiceClient.servicePath;
-            assert(servicePath);
+            const client = new uptimecheckserviceModule.v3.UptimeCheckServiceClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'monitoring.googleapis.com');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = uptimecheckserviceModule.v3.UptimeCheckServiceClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new uptimecheckserviceModule.v3.UptimeCheckServiceClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'monitoring.googleapis.com');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new uptimecheckserviceModule.v3.UptimeCheckServiceClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new uptimecheckserviceModule.v3.UptimeCheckServiceClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'monitoring.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new uptimecheckserviceModule.v3.UptimeCheckServiceClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'monitoring.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new uptimecheckserviceModule.v3.UptimeCheckServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/monitoring-esm/esm/test/gapic_uptime_check_service_v3.ts.baseline
+++ b/baselines/monitoring-esm/esm/test/gapic_uptime_check_service_v3.ts.baseline
@@ -128,6 +128,23 @@ describe('v3.UptimeCheckServiceClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = uptimecheckserviceModule.v3.UptimeCheckServiceClient.servicePath;
+                assert.strictEqual(servicePath, 'monitoring.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = uptimecheckserviceModule.v3.UptimeCheckServiceClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'monitoring.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new uptimecheckserviceModule.v3.UptimeCheckServiceClient({universeDomain: 'example.com'});
             const servicePath = client.servicePath;
@@ -139,7 +156,6 @@ describe('v3.UptimeCheckServiceClient', () => {
             const servicePath = client.servicePath;
             assert.strictEqual(servicePath, 'monitoring.example.com');
         });
-
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new uptimecheckserviceModule.v3.UptimeCheckServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/monitoring/src/v3/alert_policy_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/alert_policy_service_client.ts.baseline
@@ -52,6 +52,8 @@ export class AlertPolicyServiceClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -106,7 +108,12 @@ export class AlertPolicyServiceClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof AlertPolicyServiceClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'monitoring.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -114,7 +121,7 @@ export class AlertPolicyServiceClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -139,10 +146,10 @@ export class AlertPolicyServiceClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -328,19 +335,47 @@ export class AlertPolicyServiceClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'monitoring.googleapis.com';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'monitoring.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/monitoring/src/v3/group_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/group_service_client.ts.baseline
@@ -55,6 +55,8 @@ export class GroupServiceClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -109,7 +111,12 @@ export class GroupServiceClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof GroupServiceClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'monitoring.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -117,7 +124,7 @@ export class GroupServiceClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -142,10 +149,10 @@ export class GroupServiceClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -333,19 +340,47 @@ export class GroupServiceClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'monitoring.googleapis.com';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'monitoring.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/monitoring/src/v3/metric_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/metric_service_client.ts.baseline
@@ -45,6 +45,8 @@ export class MetricServiceClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -99,7 +101,12 @@ export class MetricServiceClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof MetricServiceClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'monitoring.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -107,7 +114,7 @@ export class MetricServiceClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -132,10 +139,10 @@ export class MetricServiceClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -343,19 +350,47 @@ export class MetricServiceClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'monitoring.googleapis.com';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'monitoring.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/monitoring/src/v3/notification_channel_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/notification_channel_service_client.ts.baseline
@@ -45,6 +45,8 @@ export class NotificationChannelServiceClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -99,7 +101,12 @@ export class NotificationChannelServiceClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof NotificationChannelServiceClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'monitoring.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -107,7 +114,7 @@ export class NotificationChannelServiceClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -132,10 +139,10 @@ export class NotificationChannelServiceClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -323,19 +330,47 @@ export class NotificationChannelServiceClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'monitoring.googleapis.com';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'monitoring.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/monitoring/src/v3/service_monitoring_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/service_monitoring_service_client.ts.baseline
@@ -47,6 +47,8 @@ export class ServiceMonitoringServiceClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -101,7 +103,12 @@ export class ServiceMonitoringServiceClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof ServiceMonitoringServiceClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'monitoring.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -109,7 +116,7 @@ export class ServiceMonitoringServiceClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -134,10 +141,10 @@ export class ServiceMonitoringServiceClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -325,19 +332,47 @@ export class ServiceMonitoringServiceClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'monitoring.googleapis.com';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'monitoring.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/monitoring/src/v3/uptime_check_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/uptime_check_service_client.ts.baseline
@@ -51,6 +51,8 @@ export class UptimeCheckServiceClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -105,7 +107,12 @@ export class UptimeCheckServiceClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof UptimeCheckServiceClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'monitoring.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -113,7 +120,7 @@ export class UptimeCheckServiceClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -138,10 +145,10 @@ export class UptimeCheckServiceClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -329,19 +336,47 @@ export class UptimeCheckServiceClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'monitoring.googleapis.com';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'monitoring.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/monitoring/test/gapic_alert_policy_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_alert_policy_service_v3.ts.baseline
@@ -119,6 +119,23 @@ describe('v3.AlertPolicyServiceClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = alertpolicyserviceModule.v3.AlertPolicyServiceClient.servicePath;
+                assert.strictEqual(servicePath, 'monitoring.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = alertpolicyserviceModule.v3.AlertPolicyServiceClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'monitoring.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new alertpolicyserviceModule.v3.AlertPolicyServiceClient({universeDomain: 'example.com'});
             const servicePath = client.servicePath;
@@ -130,7 +147,6 @@ describe('v3.AlertPolicyServiceClient', () => {
             const servicePath = client.servicePath;
             assert.strictEqual(servicePath, 'monitoring.example.com');
         });
-
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new alertpolicyserviceModule.v3.AlertPolicyServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/monitoring/test/gapic_alert_policy_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_alert_policy_service_v3.ts.baseline
@@ -102,13 +102,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v3.AlertPolicyServiceClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = alertpolicyserviceModule.v3.AlertPolicyServiceClient.servicePath;
-            assert(servicePath);
+            const client = new alertpolicyserviceModule.v3.AlertPolicyServiceClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'monitoring.googleapis.com');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = alertpolicyserviceModule.v3.AlertPolicyServiceClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new alertpolicyserviceModule.v3.AlertPolicyServiceClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'monitoring.googleapis.com');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new alertpolicyserviceModule.v3.AlertPolicyServiceClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new alertpolicyserviceModule.v3.AlertPolicyServiceClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'monitoring.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new alertpolicyserviceModule.v3.AlertPolicyServiceClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'monitoring.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new alertpolicyserviceModule.v3.AlertPolicyServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/monitoring/test/gapic_group_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_group_service_v3.ts.baseline
@@ -119,6 +119,23 @@ describe('v3.GroupServiceClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = groupserviceModule.v3.GroupServiceClient.servicePath;
+                assert.strictEqual(servicePath, 'monitoring.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = groupserviceModule.v3.GroupServiceClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'monitoring.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new groupserviceModule.v3.GroupServiceClient({universeDomain: 'example.com'});
             const servicePath = client.servicePath;
@@ -130,7 +147,6 @@ describe('v3.GroupServiceClient', () => {
             const servicePath = client.servicePath;
             assert.strictEqual(servicePath, 'monitoring.example.com');
         });
-
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new groupserviceModule.v3.GroupServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/monitoring/test/gapic_group_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_group_service_v3.ts.baseline
@@ -102,13 +102,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v3.GroupServiceClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = groupserviceModule.v3.GroupServiceClient.servicePath;
-            assert(servicePath);
+            const client = new groupserviceModule.v3.GroupServiceClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'monitoring.googleapis.com');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = groupserviceModule.v3.GroupServiceClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new groupserviceModule.v3.GroupServiceClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'monitoring.googleapis.com');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new groupserviceModule.v3.GroupServiceClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new groupserviceModule.v3.GroupServiceClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'monitoring.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new groupserviceModule.v3.GroupServiceClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'monitoring.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new groupserviceModule.v3.GroupServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/monitoring/test/gapic_metric_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_metric_service_v3.ts.baseline
@@ -102,13 +102,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v3.MetricServiceClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = metricserviceModule.v3.MetricServiceClient.servicePath;
-            assert(servicePath);
+            const client = new metricserviceModule.v3.MetricServiceClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'monitoring.googleapis.com');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = metricserviceModule.v3.MetricServiceClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new metricserviceModule.v3.MetricServiceClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'monitoring.googleapis.com');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new metricserviceModule.v3.MetricServiceClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new metricserviceModule.v3.MetricServiceClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'monitoring.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new metricserviceModule.v3.MetricServiceClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'monitoring.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new metricserviceModule.v3.MetricServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/monitoring/test/gapic_metric_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_metric_service_v3.ts.baseline
@@ -119,6 +119,23 @@ describe('v3.MetricServiceClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = metricserviceModule.v3.MetricServiceClient.servicePath;
+                assert.strictEqual(servicePath, 'monitoring.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = metricserviceModule.v3.MetricServiceClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'monitoring.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new metricserviceModule.v3.MetricServiceClient({universeDomain: 'example.com'});
             const servicePath = client.servicePath;
@@ -130,7 +147,6 @@ describe('v3.MetricServiceClient', () => {
             const servicePath = client.servicePath;
             assert.strictEqual(servicePath, 'monitoring.example.com');
         });
-
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new metricserviceModule.v3.MetricServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/monitoring/test/gapic_notification_channel_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_notification_channel_service_v3.ts.baseline
@@ -102,13 +102,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v3.NotificationChannelServiceClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = notificationchannelserviceModule.v3.NotificationChannelServiceClient.servicePath;
-            assert(servicePath);
+            const client = new notificationchannelserviceModule.v3.NotificationChannelServiceClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'monitoring.googleapis.com');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = notificationchannelserviceModule.v3.NotificationChannelServiceClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new notificationchannelserviceModule.v3.NotificationChannelServiceClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'monitoring.googleapis.com');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new notificationchannelserviceModule.v3.NotificationChannelServiceClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new notificationchannelserviceModule.v3.NotificationChannelServiceClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'monitoring.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new notificationchannelserviceModule.v3.NotificationChannelServiceClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'monitoring.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new notificationchannelserviceModule.v3.NotificationChannelServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/monitoring/test/gapic_notification_channel_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_notification_channel_service_v3.ts.baseline
@@ -119,6 +119,23 @@ describe('v3.NotificationChannelServiceClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = notificationchannelserviceModule.v3.NotificationChannelServiceClient.servicePath;
+                assert.strictEqual(servicePath, 'monitoring.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = notificationchannelserviceModule.v3.NotificationChannelServiceClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'monitoring.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new notificationchannelserviceModule.v3.NotificationChannelServiceClient({universeDomain: 'example.com'});
             const servicePath = client.servicePath;
@@ -130,7 +147,6 @@ describe('v3.NotificationChannelServiceClient', () => {
             const servicePath = client.servicePath;
             assert.strictEqual(servicePath, 'monitoring.example.com');
         });
-
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new notificationchannelserviceModule.v3.NotificationChannelServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/monitoring/test/gapic_service_monitoring_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_service_monitoring_service_v3.ts.baseline
@@ -119,6 +119,23 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = servicemonitoringserviceModule.v3.ServiceMonitoringServiceClient.servicePath;
+                assert.strictEqual(servicePath, 'monitoring.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = servicemonitoringserviceModule.v3.ServiceMonitoringServiceClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'monitoring.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new servicemonitoringserviceModule.v3.ServiceMonitoringServiceClient({universeDomain: 'example.com'});
             const servicePath = client.servicePath;
@@ -130,7 +147,6 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             const servicePath = client.servicePath;
             assert.strictEqual(servicePath, 'monitoring.example.com');
         });
-
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new servicemonitoringserviceModule.v3.ServiceMonitoringServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/monitoring/test/gapic_service_monitoring_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_service_monitoring_service_v3.ts.baseline
@@ -102,13 +102,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v3.ServiceMonitoringServiceClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = servicemonitoringserviceModule.v3.ServiceMonitoringServiceClient.servicePath;
-            assert(servicePath);
+            const client = new servicemonitoringserviceModule.v3.ServiceMonitoringServiceClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'monitoring.googleapis.com');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = servicemonitoringserviceModule.v3.ServiceMonitoringServiceClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new servicemonitoringserviceModule.v3.ServiceMonitoringServiceClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'monitoring.googleapis.com');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new servicemonitoringserviceModule.v3.ServiceMonitoringServiceClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new servicemonitoringserviceModule.v3.ServiceMonitoringServiceClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'monitoring.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new servicemonitoringserviceModule.v3.ServiceMonitoringServiceClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'monitoring.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new servicemonitoringserviceModule.v3.ServiceMonitoringServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/monitoring/test/gapic_uptime_check_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_uptime_check_service_v3.ts.baseline
@@ -119,6 +119,23 @@ describe('v3.UptimeCheckServiceClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = uptimecheckserviceModule.v3.UptimeCheckServiceClient.servicePath;
+                assert.strictEqual(servicePath, 'monitoring.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = uptimecheckserviceModule.v3.UptimeCheckServiceClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'monitoring.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new uptimecheckserviceModule.v3.UptimeCheckServiceClient({universeDomain: 'example.com'});
             const servicePath = client.servicePath;
@@ -130,7 +147,6 @@ describe('v3.UptimeCheckServiceClient', () => {
             const servicePath = client.servicePath;
             assert.strictEqual(servicePath, 'monitoring.example.com');
         });
-
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new uptimecheckserviceModule.v3.UptimeCheckServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/monitoring/test/gapic_uptime_check_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_uptime_check_service_v3.ts.baseline
@@ -102,13 +102,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v3.UptimeCheckServiceClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = uptimecheckserviceModule.v3.UptimeCheckServiceClient.servicePath;
-            assert(servicePath);
+            const client = new uptimecheckserviceModule.v3.UptimeCheckServiceClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'monitoring.googleapis.com');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = uptimecheckserviceModule.v3.UptimeCheckServiceClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new uptimecheckserviceModule.v3.UptimeCheckServiceClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'monitoring.googleapis.com');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new uptimecheckserviceModule.v3.UptimeCheckServiceClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new uptimecheckserviceModule.v3.UptimeCheckServiceClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'monitoring.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new uptimecheckserviceModule.v3.UptimeCheckServiceClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'monitoring.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new uptimecheckserviceModule.v3.UptimeCheckServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/naming-esm/esm/src/v1beta1/naming_client.ts.baseline
+++ b/baselines/naming-esm/esm/src/v1beta1/naming_client.ts.baseline
@@ -113,7 +113,7 @@ export class NamingClient {
       throw new Error('Please set either universe_domain or universeDomain, but not both.');
     }
     this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
-    this._servicePath = 'localhost.' + this._universeDomain;
+    this._servicePath = 'localhost';
     const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port1;

--- a/baselines/naming-esm/esm/src/v1beta1/naming_client.ts.baseline
+++ b/baselines/naming-esm/esm/src/v1beta1/naming_client.ts.baseline
@@ -51,6 +51,8 @@ export class NamingClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -107,7 +109,12 @@ export class NamingClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof NamingClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath1;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'localhost.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port1;
     const clientConfig = opts?.clientConfig ?? {};
@@ -115,7 +122,7 @@ export class NamingClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath1 && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes1;
     }
 
@@ -140,10 +147,10 @@ export class NamingClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath1;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath1) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes1;
     }
 
@@ -297,19 +304,47 @@ export class NamingClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath1() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath1 is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath1(),
+   * The DNS address for this API service - same as servicePath1,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint1() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint1 is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath1() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath1().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint1() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/naming-esm/esm/test/gapic_naming_v1beta1.ts.baseline
+++ b/baselines/naming-esm/esm/test/gapic_naming_v1beta1.ts.baseline
@@ -144,18 +144,23 @@ describe('v1beta1.NamingClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
-        it('sets servicePath according to universe domain camelCase', () => {
-            const client = new namingModule.v1beta1.NamingClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath1;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath1 is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = namingModule.v1beta1.NamingClient.servicePath1;
+                assert.strictEqual(servicePath, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
-            const client = new namingModule.v1beta1.NamingClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath1;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
-
+            it('throws DeprecationWarning if static apiEndpoint1 is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = namingModule.v1beta1.NamingClient.apiEndpoint1;
+                assert.strictEqual(apiEndpoint, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new namingModule.v1beta1.NamingClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/naming-esm/esm/test/gapic_naming_v1beta1.ts.baseline
+++ b/baselines/naming-esm/esm/test/gapic_naming_v1beta1.ts.baseline
@@ -127,13 +127,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v1beta1.NamingClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = namingModule.v1beta1.NamingClient.servicePath1;
-            assert(servicePath);
+            const client = new namingModule.v1beta1.NamingClient();
+            const servicePath = client.servicePath1;
+            assert.strictEqual(servicePath, 'localhost');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = namingModule.v1beta1.NamingClient.apiEndpoint1;
-            assert(apiEndpoint);
+            const client = new namingModule.v1beta1.NamingClient();
+            const apiEndpoint = client.apiEndpoint1;
+            assert.strictEqual(apiEndpoint, 'localhost');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new namingModule.v1beta1.NamingClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new namingModule.v1beta1.NamingClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath1;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new namingModule.v1beta1.NamingClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath1;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new namingModule.v1beta1.NamingClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/naming/src/v1beta1/naming_client.ts.baseline
+++ b/baselines/naming/src/v1beta1/naming_client.ts.baseline
@@ -44,6 +44,8 @@ export class NamingClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -99,7 +101,12 @@ export class NamingClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof NamingClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath1;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'localhost.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port1;
     const clientConfig = opts?.clientConfig ?? {};
@@ -107,7 +114,7 @@ export class NamingClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath1 && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes1;
     }
 
@@ -132,10 +139,10 @@ export class NamingClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath1;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath1) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes1;
     }
 
@@ -281,19 +288,47 @@ export class NamingClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath1() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath1 is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath1(),
+   * The DNS address for this API service - same as servicePath1,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint1() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint1 is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath1() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath1().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint1() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/naming/src/v1beta1/naming_client.ts.baseline
+++ b/baselines/naming/src/v1beta1/naming_client.ts.baseline
@@ -105,7 +105,7 @@ export class NamingClient {
       throw new Error('Please set either universe_domain or universeDomain, but not both.');
     }
     this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
-    this._servicePath = 'localhost.' + this._universeDomain;
+    this._servicePath = 'localhost';
     const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port1;

--- a/baselines/naming/test/gapic_naming_v1beta1.ts.baseline
+++ b/baselines/naming/test/gapic_naming_v1beta1.ts.baseline
@@ -118,13 +118,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v1beta1.NamingClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = namingModule.v1beta1.NamingClient.servicePath1;
-            assert(servicePath);
+            const client = new namingModule.v1beta1.NamingClient();
+            const servicePath = client.servicePath1;
+            assert.strictEqual(servicePath, 'localhost');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = namingModule.v1beta1.NamingClient.apiEndpoint1;
-            assert(apiEndpoint);
+            const client = new namingModule.v1beta1.NamingClient();
+            const apiEndpoint = client.apiEndpoint1;
+            assert.strictEqual(apiEndpoint, 'localhost');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new namingModule.v1beta1.NamingClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new namingModule.v1beta1.NamingClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath1;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new namingModule.v1beta1.NamingClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath1;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new namingModule.v1beta1.NamingClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/naming/test/gapic_naming_v1beta1.ts.baseline
+++ b/baselines/naming/test/gapic_naming_v1beta1.ts.baseline
@@ -135,18 +135,23 @@ describe('v1beta1.NamingClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
-        it('sets servicePath according to universe domain camelCase', () => {
-            const client = new namingModule.v1beta1.NamingClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath1;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath1 is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = namingModule.v1beta1.NamingClient.servicePath1;
+                assert.strictEqual(servicePath, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
-            const client = new namingModule.v1beta1.NamingClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath1;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
-
+            it('throws DeprecationWarning if static apiEndpoint1 is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = namingModule.v1beta1.NamingClient.apiEndpoint1;
+                assert.strictEqual(apiEndpoint, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new namingModule.v1beta1.NamingClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/redis-esm/esm/src/v1beta1/cloud_redis_client.ts.baseline
+++ b/baselines/redis-esm/esm/src/v1beta1/cloud_redis_client.ts.baseline
@@ -65,6 +65,8 @@ export class CloudRedisClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -121,7 +123,12 @@ export class CloudRedisClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof CloudRedisClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'redis.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -129,7 +136,7 @@ export class CloudRedisClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -154,10 +161,10 @@ export class CloudRedisClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -351,19 +358,47 @@ export class CloudRedisClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'redis.googleapis.com';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'redis.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/redis-esm/esm/test/gapic_cloud_redis_v1beta1.ts.baseline
+++ b/baselines/redis-esm/esm/test/gapic_cloud_redis_v1beta1.ts.baseline
@@ -144,6 +144,23 @@ describe('v1beta1.CloudRedisClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = cloudredisModule.v1beta1.CloudRedisClient.servicePath;
+                assert.strictEqual(servicePath, 'redis.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = cloudredisModule.v1beta1.CloudRedisClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'redis.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new cloudredisModule.v1beta1.CloudRedisClient({universeDomain: 'example.com'});
             const servicePath = client.servicePath;
@@ -155,7 +172,6 @@ describe('v1beta1.CloudRedisClient', () => {
             const servicePath = client.servicePath;
             assert.strictEqual(servicePath, 'redis.example.com');
         });
-
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new cloudredisModule.v1beta1.CloudRedisClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/redis-esm/esm/test/gapic_cloud_redis_v1beta1.ts.baseline
+++ b/baselines/redis-esm/esm/test/gapic_cloud_redis_v1beta1.ts.baseline
@@ -127,13 +127,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v1beta1.CloudRedisClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = cloudredisModule.v1beta1.CloudRedisClient.servicePath;
-            assert(servicePath);
+            const client = new cloudredisModule.v1beta1.CloudRedisClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'redis.googleapis.com');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = cloudredisModule.v1beta1.CloudRedisClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new cloudredisModule.v1beta1.CloudRedisClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'redis.googleapis.com');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new cloudredisModule.v1beta1.CloudRedisClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new cloudredisModule.v1beta1.CloudRedisClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'redis.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new cloudredisModule.v1beta1.CloudRedisClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'redis.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new cloudredisModule.v1beta1.CloudRedisClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/redis/src/v1beta1/cloud_redis_client.ts.baseline
+++ b/baselines/redis/src/v1beta1/cloud_redis_client.ts.baseline
@@ -58,6 +58,8 @@ export class CloudRedisClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -113,7 +115,12 @@ export class CloudRedisClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof CloudRedisClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'redis.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -121,7 +128,7 @@ export class CloudRedisClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -146,10 +153,10 @@ export class CloudRedisClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -335,19 +342,47 @@ export class CloudRedisClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'redis.googleapis.com';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'redis.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/redis/test/gapic_cloud_redis_v1beta1.ts.baseline
+++ b/baselines/redis/test/gapic_cloud_redis_v1beta1.ts.baseline
@@ -118,13 +118,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v1beta1.CloudRedisClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = cloudredisModule.v1beta1.CloudRedisClient.servicePath;
-            assert(servicePath);
+            const client = new cloudredisModule.v1beta1.CloudRedisClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'redis.googleapis.com');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = cloudredisModule.v1beta1.CloudRedisClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new cloudredisModule.v1beta1.CloudRedisClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'redis.googleapis.com');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new cloudredisModule.v1beta1.CloudRedisClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new cloudredisModule.v1beta1.CloudRedisClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'redis.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new cloudredisModule.v1beta1.CloudRedisClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'redis.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new cloudredisModule.v1beta1.CloudRedisClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/redis/test/gapic_cloud_redis_v1beta1.ts.baseline
+++ b/baselines/redis/test/gapic_cloud_redis_v1beta1.ts.baseline
@@ -135,6 +135,23 @@ describe('v1beta1.CloudRedisClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = cloudredisModule.v1beta1.CloudRedisClient.servicePath;
+                assert.strictEqual(servicePath, 'redis.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = cloudredisModule.v1beta1.CloudRedisClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'redis.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new cloudredisModule.v1beta1.CloudRedisClient({universeDomain: 'example.com'});
             const servicePath = client.servicePath;
@@ -146,7 +163,6 @@ describe('v1beta1.CloudRedisClient', () => {
             const servicePath = client.servicePath;
             assert.strictEqual(servicePath, 'redis.example.com');
         });
-
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new cloudredisModule.v1beta1.CloudRedisClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/routingtest-esm/esm/src/v1/test_service_client.ts.baseline
+++ b/baselines/routingtest-esm/esm/src/v1/test_service_client.ts.baseline
@@ -52,6 +52,8 @@ export class TestServiceClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -106,7 +108,12 @@ export class TestServiceClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof TestServiceClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'localhost.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -114,7 +121,7 @@ export class TestServiceClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -139,10 +146,10 @@ export class TestServiceClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -249,19 +256,47 @@ export class TestServiceClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/routingtest-esm/esm/src/v1/test_service_client.ts.baseline
+++ b/baselines/routingtest-esm/esm/src/v1/test_service_client.ts.baseline
@@ -112,7 +112,7 @@ export class TestServiceClient {
       throw new Error('Please set either universe_domain or universeDomain, but not both.');
     }
     this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
-    this._servicePath = 'localhost.' + this._universeDomain;
+    this._servicePath = 'localhost';
     const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;

--- a/baselines/routingtest-esm/esm/test/gapic_test_service_v1.ts.baseline
+++ b/baselines/routingtest-esm/esm/test/gapic_test_service_v1.ts.baseline
@@ -81,18 +81,23 @@ describe('v1.TestServiceClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
-        it('sets servicePath according to universe domain camelCase', () => {
-            const client = new testserviceModule.v1.TestServiceClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = testserviceModule.v1.TestServiceClient.servicePath;
+                assert.strictEqual(servicePath, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
-            const client = new testserviceModule.v1.TestServiceClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
-
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = testserviceModule.v1.TestServiceClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new testserviceModule.v1.TestServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/routingtest-esm/esm/test/gapic_test_service_v1.ts.baseline
+++ b/baselines/routingtest-esm/esm/test/gapic_test_service_v1.ts.baseline
@@ -64,13 +64,37 @@ function stubSimpleCallWithCallback<ResponseType>(response?: ResponseType, error
 describe('v1.TestServiceClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = testserviceModule.v1.TestServiceClient.servicePath;
-            assert(servicePath);
+            const client = new testserviceModule.v1.TestServiceClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = testserviceModule.v1.TestServiceClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new testserviceModule.v1.TestServiceClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'localhost');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new testserviceModule.v1.TestServiceClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new testserviceModule.v1.TestServiceClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new testserviceModule.v1.TestServiceClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new testserviceModule.v1.TestServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/routingtest/src/v1/test_service_client.ts.baseline
+++ b/baselines/routingtest/src/v1/test_service_client.ts.baseline
@@ -45,6 +45,8 @@ export class TestServiceClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -98,7 +100,12 @@ export class TestServiceClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof TestServiceClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'localhost.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -106,7 +113,7 @@ export class TestServiceClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -131,10 +138,10 @@ export class TestServiceClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -233,19 +240,47 @@ export class TestServiceClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/routingtest/src/v1/test_service_client.ts.baseline
+++ b/baselines/routingtest/src/v1/test_service_client.ts.baseline
@@ -104,7 +104,7 @@ export class TestServiceClient {
       throw new Error('Please set either universe_domain or universeDomain, but not both.');
     }
     this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
-    this._servicePath = 'localhost.' + this._universeDomain;
+    this._servicePath = 'localhost';
     const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;

--- a/baselines/routingtest/test/gapic_test_service_v1.ts.baseline
+++ b/baselines/routingtest/test/gapic_test_service_v1.ts.baseline
@@ -72,18 +72,23 @@ describe('v1.TestServiceClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
-        it('sets servicePath according to universe domain camelCase', () => {
-            const client = new testserviceModule.v1.TestServiceClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = testserviceModule.v1.TestServiceClient.servicePath;
+                assert.strictEqual(servicePath, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
-            const client = new testserviceModule.v1.TestServiceClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
-
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = testserviceModule.v1.TestServiceClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new testserviceModule.v1.TestServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/routingtest/test/gapic_test_service_v1.ts.baseline
+++ b/baselines/routingtest/test/gapic_test_service_v1.ts.baseline
@@ -55,13 +55,37 @@ function stubSimpleCallWithCallback<ResponseType>(response?: ResponseType, error
 describe('v1.TestServiceClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = testserviceModule.v1.TestServiceClient.servicePath;
-            assert(servicePath);
+            const client = new testserviceModule.v1.TestServiceClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = testserviceModule.v1.TestServiceClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new testserviceModule.v1.TestServiceClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'localhost');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new testserviceModule.v1.TestServiceClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new testserviceModule.v1.TestServiceClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new testserviceModule.v1.TestServiceClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new testserviceModule.v1.TestServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/showcase-esm/esm/src/v1beta1/compliance_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/compliance_client.ts.baseline
@@ -53,6 +53,8 @@ export class ComplianceClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -108,7 +110,12 @@ export class ComplianceClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof ComplianceClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'localhost.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -119,7 +126,7 @@ export class ComplianceClient {
     opts.numericEnums = true;
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -144,10 +151,10 @@ export class ComplianceClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -293,19 +300,47 @@ export class ComplianceClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/showcase-esm/esm/src/v1beta1/compliance_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/compliance_client.ts.baseline
@@ -114,7 +114,7 @@ export class ComplianceClient {
       throw new Error('Please set either universe_domain or universeDomain, but not both.');
     }
     this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
-    this._servicePath = 'localhost.' + this._universeDomain;
+    this._servicePath = 'localhost';
     const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;

--- a/baselines/showcase-esm/esm/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/echo_client.ts.baseline
@@ -57,6 +57,8 @@ export class EchoClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -113,7 +115,12 @@ export class EchoClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof EchoClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'localhost.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -124,7 +131,7 @@ export class EchoClient {
     opts.numericEnums = true;
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -149,10 +156,10 @@ export class EchoClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -352,19 +359,47 @@ export class EchoClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/showcase-esm/esm/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/echo_client.ts.baseline
@@ -119,7 +119,7 @@ export class EchoClient {
       throw new Error('Please set either universe_domain or universeDomain, but not both.');
     }
     this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
-    this._servicePath = 'localhost.' + this._universeDomain;
+    this._servicePath = 'localhost';
     const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;

--- a/baselines/showcase-esm/esm/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/identity_client.ts.baseline
@@ -112,7 +112,7 @@ export class IdentityClient {
       throw new Error('Please set either universe_domain or universeDomain, but not both.');
     }
     this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
-    this._servicePath = 'localhost.' + this._universeDomain;
+    this._servicePath = 'localhost';
     const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;

--- a/baselines/showcase-esm/esm/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/identity_client.ts.baseline
@@ -51,6 +51,8 @@ export class IdentityClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -106,7 +108,12 @@ export class IdentityClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof IdentityClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'localhost.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -117,7 +124,7 @@ export class IdentityClient {
     opts.numericEnums = true;
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -142,10 +149,10 @@ export class IdentityClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -300,19 +307,47 @@ export class IdentityClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/showcase-esm/esm/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/messaging_client.ts.baseline
@@ -116,7 +116,7 @@ export class MessagingClient {
       throw new Error('Please set either universe_domain or universeDomain, but not both.');
     }
     this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
-    this._servicePath = 'localhost.' + this._universeDomain;
+    this._servicePath = 'localhost';
     const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;

--- a/baselines/showcase-esm/esm/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/messaging_client.ts.baseline
@@ -54,6 +54,8 @@ export class MessagingClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -110,7 +112,12 @@ export class MessagingClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof MessagingClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'localhost.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -121,7 +128,7 @@ export class MessagingClient {
     opts.numericEnums = true;
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -146,10 +153,10 @@ export class MessagingClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -351,19 +358,47 @@ export class MessagingClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/showcase-esm/esm/src/v1beta1/sequence_service_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/sequence_service_client.ts.baseline
@@ -111,7 +111,7 @@ export class SequenceServiceClient {
       throw new Error('Please set either universe_domain or universeDomain, but not both.');
     }
     this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
-    this._servicePath = 'localhost.' + this._universeDomain;
+    this._servicePath = 'localhost';
     const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;

--- a/baselines/showcase-esm/esm/src/v1beta1/sequence_service_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/sequence_service_client.ts.baseline
@@ -50,6 +50,8 @@ export class SequenceServiceClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -105,7 +107,12 @@ export class SequenceServiceClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof SequenceServiceClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'localhost.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -116,7 +123,7 @@ export class SequenceServiceClient {
     opts.numericEnums = true;
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -141,10 +148,10 @@ export class SequenceServiceClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -290,19 +297,47 @@ export class SequenceServiceClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/showcase-esm/esm/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/testing_client.ts.baseline
@@ -52,6 +52,8 @@ export class TestingClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -107,7 +109,12 @@ export class TestingClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof TestingClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'localhost.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -118,7 +125,7 @@ export class TestingClient {
     opts.numericEnums = true;
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -143,10 +150,10 @@ export class TestingClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -303,19 +310,47 @@ export class TestingClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/showcase-esm/esm/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/testing_client.ts.baseline
@@ -113,7 +113,7 @@ export class TestingClient {
       throw new Error('Please set either universe_domain or universeDomain, but not both.');
     }
     this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
-    this._servicePath = 'localhost.' + this._universeDomain;
+    this._servicePath = 'localhost';
     const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;

--- a/baselines/showcase-esm/esm/test/gapic_compliance_v1beta1.ts.baseline
+++ b/baselines/showcase-esm/esm/test/gapic_compliance_v1beta1.ts.baseline
@@ -64,13 +64,37 @@ function stubSimpleCallWithCallback<ResponseType>(response?: ResponseType, error
 describe('v1beta1.ComplianceClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = complianceModule.v1beta1.ComplianceClient.servicePath;
-            assert(servicePath);
+            const client = new complianceModule.v1beta1.ComplianceClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = complianceModule.v1beta1.ComplianceClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new complianceModule.v1beta1.ComplianceClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'localhost');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new complianceModule.v1beta1.ComplianceClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new complianceModule.v1beta1.ComplianceClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new complianceModule.v1beta1.ComplianceClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new complianceModule.v1beta1.ComplianceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/showcase-esm/esm/test/gapic_compliance_v1beta1.ts.baseline
+++ b/baselines/showcase-esm/esm/test/gapic_compliance_v1beta1.ts.baseline
@@ -81,18 +81,23 @@ describe('v1beta1.ComplianceClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
-        it('sets servicePath according to universe domain camelCase', () => {
-            const client = new complianceModule.v1beta1.ComplianceClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = complianceModule.v1beta1.ComplianceClient.servicePath;
+                assert.strictEqual(servicePath, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
-            const client = new complianceModule.v1beta1.ComplianceClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
-
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = complianceModule.v1beta1.ComplianceClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new complianceModule.v1beta1.ComplianceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/showcase-esm/esm/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase-esm/esm/test/gapic_echo_v1beta1.ts.baseline
@@ -160,13 +160,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v1beta1.EchoClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = echoModule.v1beta1.EchoClient.servicePath;
-            assert(servicePath);
+            const client = new echoModule.v1beta1.EchoClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = echoModule.v1beta1.EchoClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new echoModule.v1beta1.EchoClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'localhost');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new echoModule.v1beta1.EchoClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new echoModule.v1beta1.EchoClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new echoModule.v1beta1.EchoClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new echoModule.v1beta1.EchoClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/showcase-esm/esm/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase-esm/esm/test/gapic_echo_v1beta1.ts.baseline
@@ -177,18 +177,23 @@ describe('v1beta1.EchoClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
-        it('sets servicePath according to universe domain camelCase', () => {
-            const client = new echoModule.v1beta1.EchoClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = echoModule.v1beta1.EchoClient.servicePath;
+                assert.strictEqual(servicePath, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
-            const client = new echoModule.v1beta1.EchoClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
-
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = echoModule.v1beta1.EchoClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new echoModule.v1beta1.EchoClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/showcase-esm/esm/test/gapic_identity_v1beta1.ts.baseline
+++ b/baselines/showcase-esm/esm/test/gapic_identity_v1beta1.ts.baseline
@@ -128,18 +128,23 @@ describe('v1beta1.IdentityClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
-        it('sets servicePath according to universe domain camelCase', () => {
-            const client = new identityModule.v1beta1.IdentityClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = identityModule.v1beta1.IdentityClient.servicePath;
+                assert.strictEqual(servicePath, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
-            const client = new identityModule.v1beta1.IdentityClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
-
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = identityModule.v1beta1.IdentityClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new identityModule.v1beta1.IdentityClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/showcase-esm/esm/test/gapic_identity_v1beta1.ts.baseline
+++ b/baselines/showcase-esm/esm/test/gapic_identity_v1beta1.ts.baseline
@@ -111,13 +111,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v1beta1.IdentityClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = identityModule.v1beta1.IdentityClient.servicePath;
-            assert(servicePath);
+            const client = new identityModule.v1beta1.IdentityClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = identityModule.v1beta1.IdentityClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new identityModule.v1beta1.IdentityClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'localhost');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new identityModule.v1beta1.IdentityClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new identityModule.v1beta1.IdentityClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new identityModule.v1beta1.IdentityClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new identityModule.v1beta1.IdentityClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/showcase-esm/esm/test/gapic_messaging_v1beta1.ts.baseline
+++ b/baselines/showcase-esm/esm/test/gapic_messaging_v1beta1.ts.baseline
@@ -177,18 +177,23 @@ describe('v1beta1.MessagingClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
-        it('sets servicePath according to universe domain camelCase', () => {
-            const client = new messagingModule.v1beta1.MessagingClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = messagingModule.v1beta1.MessagingClient.servicePath;
+                assert.strictEqual(servicePath, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
-            const client = new messagingModule.v1beta1.MessagingClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
-
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = messagingModule.v1beta1.MessagingClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new messagingModule.v1beta1.MessagingClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/showcase-esm/esm/test/gapic_messaging_v1beta1.ts.baseline
+++ b/baselines/showcase-esm/esm/test/gapic_messaging_v1beta1.ts.baseline
@@ -160,13 +160,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v1beta1.MessagingClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = messagingModule.v1beta1.MessagingClient.servicePath;
-            assert(servicePath);
+            const client = new messagingModule.v1beta1.MessagingClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = messagingModule.v1beta1.MessagingClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new messagingModule.v1beta1.MessagingClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'localhost');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new messagingModule.v1beta1.MessagingClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new messagingModule.v1beta1.MessagingClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new messagingModule.v1beta1.MessagingClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new messagingModule.v1beta1.MessagingClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/showcase-esm/esm/test/gapic_sequence_service_v1beta1.ts.baseline
+++ b/baselines/showcase-esm/esm/test/gapic_sequence_service_v1beta1.ts.baseline
@@ -81,18 +81,23 @@ describe('v1beta1.SequenceServiceClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
-        it('sets servicePath according to universe domain camelCase', () => {
-            const client = new sequenceserviceModule.v1beta1.SequenceServiceClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = sequenceserviceModule.v1beta1.SequenceServiceClient.servicePath;
+                assert.strictEqual(servicePath, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
-            const client = new sequenceserviceModule.v1beta1.SequenceServiceClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
-
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = sequenceserviceModule.v1beta1.SequenceServiceClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new sequenceserviceModule.v1beta1.SequenceServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/showcase-esm/esm/test/gapic_sequence_service_v1beta1.ts.baseline
+++ b/baselines/showcase-esm/esm/test/gapic_sequence_service_v1beta1.ts.baseline
@@ -64,13 +64,37 @@ function stubSimpleCallWithCallback<ResponseType>(response?: ResponseType, error
 describe('v1beta1.SequenceServiceClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = sequenceserviceModule.v1beta1.SequenceServiceClient.servicePath;
-            assert(servicePath);
+            const client = new sequenceserviceModule.v1beta1.SequenceServiceClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = sequenceserviceModule.v1beta1.SequenceServiceClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new sequenceserviceModule.v1beta1.SequenceServiceClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'localhost');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new sequenceserviceModule.v1beta1.SequenceServiceClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new sequenceserviceModule.v1beta1.SequenceServiceClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new sequenceserviceModule.v1beta1.SequenceServiceClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new sequenceserviceModule.v1beta1.SequenceServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/showcase-esm/esm/test/gapic_testing_v1beta1.ts.baseline
+++ b/baselines/showcase-esm/esm/test/gapic_testing_v1beta1.ts.baseline
@@ -111,13 +111,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v1beta1.TestingClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = testingModule.v1beta1.TestingClient.servicePath;
-            assert(servicePath);
+            const client = new testingModule.v1beta1.TestingClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = testingModule.v1beta1.TestingClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new testingModule.v1beta1.TestingClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'localhost');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new testingModule.v1beta1.TestingClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new testingModule.v1beta1.TestingClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new testingModule.v1beta1.TestingClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new testingModule.v1beta1.TestingClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/showcase-esm/esm/test/gapic_testing_v1beta1.ts.baseline
+++ b/baselines/showcase-esm/esm/test/gapic_testing_v1beta1.ts.baseline
@@ -128,18 +128,23 @@ describe('v1beta1.TestingClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
-        it('sets servicePath according to universe domain camelCase', () => {
-            const client = new testingModule.v1beta1.TestingClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = testingModule.v1beta1.TestingClient.servicePath;
+                assert.strictEqual(servicePath, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
-            const client = new testingModule.v1beta1.TestingClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
-
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = testingModule.v1beta1.TestingClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new testingModule.v1beta1.TestingClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/showcase-legacy-esm/esm/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase-legacy-esm/esm/src/v1beta1/echo_client.ts.baseline
@@ -55,6 +55,8 @@ export class EchoClient {
   private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -99,14 +101,19 @@ export class EchoClient {
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof EchoClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'localhost.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
     opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -126,10 +133,10 @@ export class EchoClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -283,19 +290,47 @@ export class EchoClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/showcase-legacy-esm/esm/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase-legacy-esm/esm/src/v1beta1/echo_client.ts.baseline
@@ -105,7 +105,7 @@ export class EchoClient {
       throw new Error('Please set either universe_domain or universeDomain, but not both.');
     }
     this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
-    this._servicePath = 'localhost.' + this._universeDomain;
+    this._servicePath = 'localhost';
     const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;

--- a/baselines/showcase-legacy-esm/esm/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase-legacy-esm/esm/test/gapic_echo_v1beta1.ts.baseline
@@ -163,18 +163,23 @@ describe('v1beta1.EchoClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
-        it('sets servicePath according to universe domain camelCase', () => {
-            const client = new echoModule.v1beta1.EchoClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = echoModule.v1beta1.EchoClient.servicePath;
+                assert.strictEqual(servicePath, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
-            const client = new echoModule.v1beta1.EchoClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
-
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = echoModule.v1beta1.EchoClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new echoModule.v1beta1.EchoClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/showcase-legacy-esm/esm/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase-legacy-esm/esm/test/gapic_echo_v1beta1.ts.baseline
@@ -146,13 +146,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v1beta1.EchoClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = echoModule.v1beta1.EchoClient.servicePath;
-            assert(servicePath);
+            const client = new echoModule.v1beta1.EchoClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = echoModule.v1beta1.EchoClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new echoModule.v1beta1.EchoClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'localhost');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new echoModule.v1beta1.EchoClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new echoModule.v1beta1.EchoClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new echoModule.v1beta1.EchoClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new echoModule.v1beta1.EchoClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
@@ -99,7 +99,7 @@ export class EchoClient {
       throw new Error('Please set either universe_domain or universeDomain, but not both.');
     }
     this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
-    this._servicePath = 'localhost.' + this._universeDomain;
+    this._servicePath = 'localhost';
     const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;

--- a/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
@@ -49,6 +49,8 @@ export class EchoClient {
   private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -93,14 +95,19 @@ export class EchoClient {
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof EchoClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'localhost.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
     opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -120,10 +127,10 @@ export class EchoClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -269,19 +276,47 @@ export class EchoClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/showcase-legacy/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase-legacy/test/gapic_echo_v1beta1.ts.baseline
@@ -145,13 +145,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v1beta1.EchoClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = echoModule.v1beta1.EchoClient.servicePath;
-            assert(servicePath);
+            const client = new echoModule.v1beta1.EchoClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = echoModule.v1beta1.EchoClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new echoModule.v1beta1.EchoClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'localhost');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new echoModule.v1beta1.EchoClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new echoModule.v1beta1.EchoClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new echoModule.v1beta1.EchoClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new echoModule.v1beta1.EchoClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/showcase-legacy/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase-legacy/test/gapic_echo_v1beta1.ts.baseline
@@ -162,18 +162,23 @@ describe('v1beta1.EchoClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
-        it('sets servicePath according to universe domain camelCase', () => {
-            const client = new echoModule.v1beta1.EchoClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = echoModule.v1beta1.EchoClient.servicePath;
+                assert.strictEqual(servicePath, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
-            const client = new echoModule.v1beta1.EchoClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
-
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = echoModule.v1beta1.EchoClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new echoModule.v1beta1.EchoClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/showcase/src/v1beta1/compliance_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/compliance_client.ts.baseline
@@ -106,7 +106,7 @@ export class ComplianceClient {
       throw new Error('Please set either universe_domain or universeDomain, but not both.');
     }
     this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
-    this._servicePath = 'localhost.' + this._universeDomain;
+    this._servicePath = 'localhost';
     const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;

--- a/baselines/showcase/src/v1beta1/compliance_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/compliance_client.ts.baseline
@@ -46,6 +46,8 @@ export class ComplianceClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -100,7 +102,12 @@ export class ComplianceClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof ComplianceClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'localhost.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -111,7 +118,7 @@ export class ComplianceClient {
     opts.numericEnums = true;
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -136,10 +143,10 @@ export class ComplianceClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -277,19 +284,47 @@ export class ComplianceClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/showcase/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/echo_client.ts.baseline
@@ -111,7 +111,7 @@ export class EchoClient {
       throw new Error('Please set either universe_domain or universeDomain, but not both.');
     }
     this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
-    this._servicePath = 'localhost.' + this._universeDomain;
+    this._servicePath = 'localhost';
     const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;

--- a/baselines/showcase/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/echo_client.ts.baseline
@@ -50,6 +50,8 @@ export class EchoClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -105,7 +107,12 @@ export class EchoClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof EchoClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'localhost.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -116,7 +123,7 @@ export class EchoClient {
     opts.numericEnums = true;
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -141,10 +148,10 @@ export class EchoClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -336,19 +343,47 @@ export class EchoClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/showcase/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/identity_client.ts.baseline
@@ -104,7 +104,7 @@ export class IdentityClient {
       throw new Error('Please set either universe_domain or universeDomain, but not both.');
     }
     this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
-    this._servicePath = 'localhost.' + this._universeDomain;
+    this._servicePath = 'localhost';
     const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;

--- a/baselines/showcase/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/identity_client.ts.baseline
@@ -44,6 +44,8 @@ export class IdentityClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -98,7 +100,12 @@ export class IdentityClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof IdentityClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'localhost.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -109,7 +116,7 @@ export class IdentityClient {
     opts.numericEnums = true;
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -134,10 +141,10 @@ export class IdentityClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -284,19 +291,47 @@ export class IdentityClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
@@ -47,6 +47,8 @@ export class MessagingClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -102,7 +104,12 @@ export class MessagingClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof MessagingClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'localhost.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -113,7 +120,7 @@ export class MessagingClient {
     opts.numericEnums = true;
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -138,10 +145,10 @@ export class MessagingClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -335,19 +342,47 @@ export class MessagingClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
@@ -108,7 +108,7 @@ export class MessagingClient {
       throw new Error('Please set either universe_domain or universeDomain, but not both.');
     }
     this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
-    this._servicePath = 'localhost.' + this._universeDomain;
+    this._servicePath = 'localhost';
     const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;

--- a/baselines/showcase/src/v1beta1/sequence_service_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/sequence_service_client.ts.baseline
@@ -43,6 +43,8 @@ export class SequenceServiceClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -97,7 +99,12 @@ export class SequenceServiceClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof SequenceServiceClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'localhost.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -108,7 +115,7 @@ export class SequenceServiceClient {
     opts.numericEnums = true;
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -133,10 +140,10 @@ export class SequenceServiceClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -274,19 +281,47 @@ export class SequenceServiceClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/showcase/src/v1beta1/sequence_service_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/sequence_service_client.ts.baseline
@@ -103,7 +103,7 @@ export class SequenceServiceClient {
       throw new Error('Please set either universe_domain or universeDomain, but not both.');
     }
     this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
-    this._servicePath = 'localhost.' + this._universeDomain;
+    this._servicePath = 'localhost';
     const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;

--- a/baselines/showcase/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/testing_client.ts.baseline
@@ -105,7 +105,7 @@ export class TestingClient {
       throw new Error('Please set either universe_domain or universeDomain, but not both.');
     }
     this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
-    this._servicePath = 'localhost.' + this._universeDomain;
+    this._servicePath = 'localhost';
     const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;

--- a/baselines/showcase/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/testing_client.ts.baseline
@@ -45,6 +45,8 @@ export class TestingClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -99,7 +101,12 @@ export class TestingClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof TestingClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'localhost.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -110,7 +117,7 @@ export class TestingClient {
     opts.numericEnums = true;
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -135,10 +142,10 @@ export class TestingClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -287,19 +294,47 @@ export class TestingClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'localhost';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/showcase/test/gapic_compliance_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_compliance_v1beta1.ts.baseline
@@ -55,13 +55,37 @@ function stubSimpleCallWithCallback<ResponseType>(response?: ResponseType, error
 describe('v1beta1.ComplianceClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = complianceModule.v1beta1.ComplianceClient.servicePath;
-            assert(servicePath);
+            const client = new complianceModule.v1beta1.ComplianceClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = complianceModule.v1beta1.ComplianceClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new complianceModule.v1beta1.ComplianceClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'localhost');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new complianceModule.v1beta1.ComplianceClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new complianceModule.v1beta1.ComplianceClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new complianceModule.v1beta1.ComplianceClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new complianceModule.v1beta1.ComplianceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/showcase/test/gapic_compliance_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_compliance_v1beta1.ts.baseline
@@ -72,18 +72,23 @@ describe('v1beta1.ComplianceClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
-        it('sets servicePath according to universe domain camelCase', () => {
-            const client = new complianceModule.v1beta1.ComplianceClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = complianceModule.v1beta1.ComplianceClient.servicePath;
+                assert.strictEqual(servicePath, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
-            const client = new complianceModule.v1beta1.ComplianceClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
-
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = complianceModule.v1beta1.ComplianceClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new complianceModule.v1beta1.ComplianceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/showcase/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_echo_v1beta1.ts.baseline
@@ -151,13 +151,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v1beta1.EchoClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = echoModule.v1beta1.EchoClient.servicePath;
-            assert(servicePath);
+            const client = new echoModule.v1beta1.EchoClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = echoModule.v1beta1.EchoClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new echoModule.v1beta1.EchoClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'localhost');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new echoModule.v1beta1.EchoClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new echoModule.v1beta1.EchoClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new echoModule.v1beta1.EchoClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new echoModule.v1beta1.EchoClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/showcase/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_echo_v1beta1.ts.baseline
@@ -168,18 +168,23 @@ describe('v1beta1.EchoClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
-        it('sets servicePath according to universe domain camelCase', () => {
-            const client = new echoModule.v1beta1.EchoClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = echoModule.v1beta1.EchoClient.servicePath;
+                assert.strictEqual(servicePath, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
-            const client = new echoModule.v1beta1.EchoClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
-
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = echoModule.v1beta1.EchoClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new echoModule.v1beta1.EchoClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/showcase/test/gapic_identity_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_identity_v1beta1.ts.baseline
@@ -119,18 +119,23 @@ describe('v1beta1.IdentityClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
-        it('sets servicePath according to universe domain camelCase', () => {
-            const client = new identityModule.v1beta1.IdentityClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = identityModule.v1beta1.IdentityClient.servicePath;
+                assert.strictEqual(servicePath, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
-            const client = new identityModule.v1beta1.IdentityClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
-
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = identityModule.v1beta1.IdentityClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new identityModule.v1beta1.IdentityClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/showcase/test/gapic_identity_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_identity_v1beta1.ts.baseline
@@ -102,13 +102,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v1beta1.IdentityClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = identityModule.v1beta1.IdentityClient.servicePath;
-            assert(servicePath);
+            const client = new identityModule.v1beta1.IdentityClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = identityModule.v1beta1.IdentityClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new identityModule.v1beta1.IdentityClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'localhost');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new identityModule.v1beta1.IdentityClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new identityModule.v1beta1.IdentityClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new identityModule.v1beta1.IdentityClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new identityModule.v1beta1.IdentityClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/showcase/test/gapic_messaging_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_messaging_v1beta1.ts.baseline
@@ -168,18 +168,23 @@ describe('v1beta1.MessagingClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
-        it('sets servicePath according to universe domain camelCase', () => {
-            const client = new messagingModule.v1beta1.MessagingClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = messagingModule.v1beta1.MessagingClient.servicePath;
+                assert.strictEqual(servicePath, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
-            const client = new messagingModule.v1beta1.MessagingClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
-
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = messagingModule.v1beta1.MessagingClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new messagingModule.v1beta1.MessagingClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/showcase/test/gapic_messaging_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_messaging_v1beta1.ts.baseline
@@ -151,13 +151,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v1beta1.MessagingClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = messagingModule.v1beta1.MessagingClient.servicePath;
-            assert(servicePath);
+            const client = new messagingModule.v1beta1.MessagingClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = messagingModule.v1beta1.MessagingClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new messagingModule.v1beta1.MessagingClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'localhost');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new messagingModule.v1beta1.MessagingClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new messagingModule.v1beta1.MessagingClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new messagingModule.v1beta1.MessagingClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new messagingModule.v1beta1.MessagingClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/showcase/test/gapic_sequence_service_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_sequence_service_v1beta1.ts.baseline
@@ -72,18 +72,23 @@ describe('v1beta1.SequenceServiceClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
-        it('sets servicePath according to universe domain camelCase', () => {
-            const client = new sequenceserviceModule.v1beta1.SequenceServiceClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = sequenceserviceModule.v1beta1.SequenceServiceClient.servicePath;
+                assert.strictEqual(servicePath, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
-            const client = new sequenceserviceModule.v1beta1.SequenceServiceClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
-
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = sequenceserviceModule.v1beta1.SequenceServiceClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new sequenceserviceModule.v1beta1.SequenceServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/showcase/test/gapic_sequence_service_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_sequence_service_v1beta1.ts.baseline
@@ -55,13 +55,37 @@ function stubSimpleCallWithCallback<ResponseType>(response?: ResponseType, error
 describe('v1beta1.SequenceServiceClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = sequenceserviceModule.v1beta1.SequenceServiceClient.servicePath;
-            assert(servicePath);
+            const client = new sequenceserviceModule.v1beta1.SequenceServiceClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = sequenceserviceModule.v1beta1.SequenceServiceClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new sequenceserviceModule.v1beta1.SequenceServiceClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'localhost');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new sequenceserviceModule.v1beta1.SequenceServiceClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new sequenceserviceModule.v1beta1.SequenceServiceClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new sequenceserviceModule.v1beta1.SequenceServiceClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new sequenceserviceModule.v1beta1.SequenceServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/showcase/test/gapic_testing_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_testing_v1beta1.ts.baseline
@@ -102,13 +102,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v1beta1.TestingClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = testingModule.v1beta1.TestingClient.servicePath;
-            assert(servicePath);
+            const client = new testingModule.v1beta1.TestingClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = testingModule.v1beta1.TestingClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new testingModule.v1beta1.TestingClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'localhost');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new testingModule.v1beta1.TestingClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new testingModule.v1beta1.TestingClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new testingModule.v1beta1.TestingClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'localhost.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new testingModule.v1beta1.TestingClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/showcase/test/gapic_testing_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_testing_v1beta1.ts.baseline
@@ -119,18 +119,23 @@ describe('v1beta1.TestingClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
-        it('sets servicePath according to universe domain camelCase', () => {
-            const client = new testingModule.v1beta1.TestingClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = testingModule.v1beta1.TestingClient.servicePath;
+                assert.strictEqual(servicePath, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
-            const client = new testingModule.v1beta1.TestingClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost.example.com');
-        });
-
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = testingModule.v1beta1.TestingClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'localhost');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new testingModule.v1beta1.TestingClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/tasks-esm/esm/src/v2/cloud_tasks_client.ts.baseline
+++ b/baselines/tasks-esm/esm/src/v2/cloud_tasks_client.ts.baseline
@@ -52,6 +52,8 @@ export class CloudTasksClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -107,7 +109,12 @@ export class CloudTasksClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof CloudTasksClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'cloudtasks.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -115,7 +122,7 @@ export class CloudTasksClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -140,10 +147,10 @@ export class CloudTasksClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -273,19 +280,47 @@ export class CloudTasksClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'cloudtasks.googleapis.com';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'cloudtasks.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/tasks-esm/esm/test/gapic_cloud_tasks_v2.ts.baseline
+++ b/baselines/tasks-esm/esm/test/gapic_cloud_tasks_v2.ts.baseline
@@ -111,13 +111,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v2.CloudTasksClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = cloudtasksModule.v2.CloudTasksClient.servicePath;
-            assert(servicePath);
+            const client = new cloudtasksModule.v2.CloudTasksClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'cloudtasks.googleapis.com');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = cloudtasksModule.v2.CloudTasksClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new cloudtasksModule.v2.CloudTasksClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'cloudtasks.googleapis.com');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new cloudtasksModule.v2.CloudTasksClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new cloudtasksModule.v2.CloudTasksClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'cloudtasks.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new cloudtasksModule.v2.CloudTasksClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'cloudtasks.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new cloudtasksModule.v2.CloudTasksClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/tasks-esm/esm/test/gapic_cloud_tasks_v2.ts.baseline
+++ b/baselines/tasks-esm/esm/test/gapic_cloud_tasks_v2.ts.baseline
@@ -128,6 +128,23 @@ describe('v2.CloudTasksClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = cloudtasksModule.v2.CloudTasksClient.servicePath;
+                assert.strictEqual(servicePath, 'cloudtasks.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = cloudtasksModule.v2.CloudTasksClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'cloudtasks.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new cloudtasksModule.v2.CloudTasksClient({universeDomain: 'example.com'});
             const servicePath = client.servicePath;
@@ -139,7 +156,6 @@ describe('v2.CloudTasksClient', () => {
             const servicePath = client.servicePath;
             assert.strictEqual(servicePath, 'cloudtasks.example.com');
         });
-
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new cloudtasksModule.v2.CloudTasksClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/tasks/src/v2/cloud_tasks_client.ts.baseline
+++ b/baselines/tasks/src/v2/cloud_tasks_client.ts.baseline
@@ -45,6 +45,8 @@ export class CloudTasksClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -99,7 +101,12 @@ export class CloudTasksClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof CloudTasksClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'cloudtasks.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -107,7 +114,7 @@ export class CloudTasksClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -132,10 +139,10 @@ export class CloudTasksClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -257,19 +264,47 @@ export class CloudTasksClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'cloudtasks.googleapis.com';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'cloudtasks.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/tasks/test/gapic_cloud_tasks_v2.ts.baseline
+++ b/baselines/tasks/test/gapic_cloud_tasks_v2.ts.baseline
@@ -102,13 +102,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v2.CloudTasksClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = cloudtasksModule.v2.CloudTasksClient.servicePath;
-            assert(servicePath);
+            const client = new cloudtasksModule.v2.CloudTasksClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'cloudtasks.googleapis.com');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = cloudtasksModule.v2.CloudTasksClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new cloudtasksModule.v2.CloudTasksClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'cloudtasks.googleapis.com');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new cloudtasksModule.v2.CloudTasksClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new cloudtasksModule.v2.CloudTasksClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'cloudtasks.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new cloudtasksModule.v2.CloudTasksClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'cloudtasks.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new cloudtasksModule.v2.CloudTasksClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/tasks/test/gapic_cloud_tasks_v2.ts.baseline
+++ b/baselines/tasks/test/gapic_cloud_tasks_v2.ts.baseline
@@ -119,6 +119,23 @@ describe('v2.CloudTasksClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = cloudtasksModule.v2.CloudTasksClient.servicePath;
+                assert.strictEqual(servicePath, 'cloudtasks.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = cloudtasksModule.v2.CloudTasksClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'cloudtasks.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new cloudtasksModule.v2.CloudTasksClient({universeDomain: 'example.com'});
             const servicePath = client.servicePath;
@@ -130,7 +147,6 @@ describe('v2.CloudTasksClient', () => {
             const servicePath = client.servicePath;
             assert.strictEqual(servicePath, 'cloudtasks.example.com');
         });
-
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new cloudtasksModule.v2.CloudTasksClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/texttospeech-esm/esm/src/v1/text_to_speech_client.ts.baseline
+++ b/baselines/texttospeech-esm/esm/src/v1/text_to_speech_client.ts.baseline
@@ -51,6 +51,8 @@ export class TextToSpeechClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -105,7 +107,12 @@ export class TextToSpeechClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof TextToSpeechClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'texttospeech.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -113,7 +120,7 @@ export class TextToSpeechClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -138,10 +145,10 @@ export class TextToSpeechClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -248,19 +255,47 @@ export class TextToSpeechClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'texttospeech.googleapis.com';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'texttospeech.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/texttospeech-esm/esm/test/gapic_text_to_speech_v1.ts.baseline
+++ b/baselines/texttospeech-esm/esm/test/gapic_text_to_speech_v1.ts.baseline
@@ -81,6 +81,23 @@ describe('v1.TextToSpeechClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = texttospeechModule.v1.TextToSpeechClient.servicePath;
+                assert.strictEqual(servicePath, 'texttospeech.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = texttospeechModule.v1.TextToSpeechClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'texttospeech.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new texttospeechModule.v1.TextToSpeechClient({universeDomain: 'example.com'});
             const servicePath = client.servicePath;
@@ -92,7 +109,6 @@ describe('v1.TextToSpeechClient', () => {
             const servicePath = client.servicePath;
             assert.strictEqual(servicePath, 'texttospeech.example.com');
         });
-
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new texttospeechModule.v1.TextToSpeechClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/texttospeech-esm/esm/test/gapic_text_to_speech_v1.ts.baseline
+++ b/baselines/texttospeech-esm/esm/test/gapic_text_to_speech_v1.ts.baseline
@@ -64,13 +64,37 @@ function stubSimpleCallWithCallback<ResponseType>(response?: ResponseType, error
 describe('v1.TextToSpeechClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = texttospeechModule.v1.TextToSpeechClient.servicePath;
-            assert(servicePath);
+            const client = new texttospeechModule.v1.TextToSpeechClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'texttospeech.googleapis.com');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = texttospeechModule.v1.TextToSpeechClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new texttospeechModule.v1.TextToSpeechClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'texttospeech.googleapis.com');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new texttospeechModule.v1.TextToSpeechClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new texttospeechModule.v1.TextToSpeechClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'texttospeech.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new texttospeechModule.v1.TextToSpeechClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'texttospeech.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new texttospeechModule.v1.TextToSpeechClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/texttospeech/src/v1/text_to_speech_client.ts.baseline
+++ b/baselines/texttospeech/src/v1/text_to_speech_client.ts.baseline
@@ -44,6 +44,8 @@ export class TextToSpeechClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -97,7 +99,12 @@ export class TextToSpeechClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof TextToSpeechClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'texttospeech.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -105,7 +112,7 @@ export class TextToSpeechClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -130,10 +137,10 @@ export class TextToSpeechClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -232,19 +239,47 @@ export class TextToSpeechClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'texttospeech.googleapis.com';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'texttospeech.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/texttospeech/test/gapic_text_to_speech_v1.ts.baseline
+++ b/baselines/texttospeech/test/gapic_text_to_speech_v1.ts.baseline
@@ -55,13 +55,37 @@ function stubSimpleCallWithCallback<ResponseType>(response?: ResponseType, error
 describe('v1.TextToSpeechClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = texttospeechModule.v1.TextToSpeechClient.servicePath;
-            assert(servicePath);
+            const client = new texttospeechModule.v1.TextToSpeechClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'texttospeech.googleapis.com');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = texttospeechModule.v1.TextToSpeechClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new texttospeechModule.v1.TextToSpeechClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'texttospeech.googleapis.com');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new texttospeechModule.v1.TextToSpeechClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new texttospeechModule.v1.TextToSpeechClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'texttospeech.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new texttospeechModule.v1.TextToSpeechClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'texttospeech.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new texttospeechModule.v1.TextToSpeechClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/texttospeech/test/gapic_text_to_speech_v1.ts.baseline
+++ b/baselines/texttospeech/test/gapic_text_to_speech_v1.ts.baseline
@@ -72,6 +72,23 @@ describe('v1.TextToSpeechClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = texttospeechModule.v1.TextToSpeechClient.servicePath;
+                assert.strictEqual(servicePath, 'texttospeech.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = texttospeechModule.v1.TextToSpeechClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'texttospeech.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new texttospeechModule.v1.TextToSpeechClient({universeDomain: 'example.com'});
             const servicePath = client.servicePath;
@@ -83,7 +100,6 @@ describe('v1.TextToSpeechClient', () => {
             const servicePath = client.servicePath;
             assert.strictEqual(servicePath, 'texttospeech.example.com');
         });
-
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new texttospeechModule.v1.TextToSpeechClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/translate-esm/esm/src/v3beta1/translation_service_client.ts.baseline
+++ b/baselines/translate-esm/esm/src/v3beta1/translation_service_client.ts.baseline
@@ -51,6 +51,8 @@ export class TranslationServiceClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -107,7 +109,12 @@ export class TranslationServiceClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof TranslationServiceClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'translate.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -115,7 +122,7 @@ export class TranslationServiceClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -140,10 +147,10 @@ export class TranslationServiceClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -313,19 +320,47 @@ export class TranslationServiceClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'translate.googleapis.com';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'translate.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/translate-esm/esm/test/gapic_translation_service_v3beta1.ts.baseline
+++ b/baselines/translate-esm/esm/test/gapic_translation_service_v3beta1.ts.baseline
@@ -127,13 +127,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v3beta1.TranslationServiceClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = translationserviceModule.v3beta1.TranslationServiceClient.servicePath;
-            assert(servicePath);
+            const client = new translationserviceModule.v3beta1.TranslationServiceClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'translate.googleapis.com');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = translationserviceModule.v3beta1.TranslationServiceClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new translationserviceModule.v3beta1.TranslationServiceClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'translate.googleapis.com');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new translationserviceModule.v3beta1.TranslationServiceClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new translationserviceModule.v3beta1.TranslationServiceClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'translate.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new translationserviceModule.v3beta1.TranslationServiceClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'translate.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new translationserviceModule.v3beta1.TranslationServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/translate-esm/esm/test/gapic_translation_service_v3beta1.ts.baseline
+++ b/baselines/translate-esm/esm/test/gapic_translation_service_v3beta1.ts.baseline
@@ -144,6 +144,23 @@ describe('v3beta1.TranslationServiceClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = translationserviceModule.v3beta1.TranslationServiceClient.servicePath;
+                assert.strictEqual(servicePath, 'translate.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = translationserviceModule.v3beta1.TranslationServiceClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'translate.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new translationserviceModule.v3beta1.TranslationServiceClient({universeDomain: 'example.com'});
             const servicePath = client.servicePath;
@@ -155,7 +172,6 @@ describe('v3beta1.TranslationServiceClient', () => {
             const servicePath = client.servicePath;
             assert.strictEqual(servicePath, 'translate.example.com');
         });
-
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new translationserviceModule.v3beta1.TranslationServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/translate/src/v3beta1/translation_service_client.ts.baseline
+++ b/baselines/translate/src/v3beta1/translation_service_client.ts.baseline
@@ -44,6 +44,8 @@ export class TranslationServiceClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -99,7 +101,12 @@ export class TranslationServiceClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof TranslationServiceClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'translate.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -107,7 +114,7 @@ export class TranslationServiceClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -132,10 +139,10 @@ export class TranslationServiceClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -297,19 +304,47 @@ export class TranslationServiceClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'translate.googleapis.com';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'translate.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/translate/test/gapic_translation_service_v3beta1.ts.baseline
+++ b/baselines/translate/test/gapic_translation_service_v3beta1.ts.baseline
@@ -135,6 +135,23 @@ describe('v3beta1.TranslationServiceClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = translationserviceModule.v3beta1.TranslationServiceClient.servicePath;
+                assert.strictEqual(servicePath, 'translate.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = translationserviceModule.v3beta1.TranslationServiceClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'translate.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new translationserviceModule.v3beta1.TranslationServiceClient({universeDomain: 'example.com'});
             const servicePath = client.servicePath;
@@ -146,7 +163,6 @@ describe('v3beta1.TranslationServiceClient', () => {
             const servicePath = client.servicePath;
             assert.strictEqual(servicePath, 'translate.example.com');
         });
-
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new translationserviceModule.v3beta1.TranslationServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/translate/test/gapic_translation_service_v3beta1.ts.baseline
+++ b/baselines/translate/test/gapic_translation_service_v3beta1.ts.baseline
@@ -118,13 +118,37 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 describe('v3beta1.TranslationServiceClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = translationserviceModule.v3beta1.TranslationServiceClient.servicePath;
-            assert(servicePath);
+            const client = new translationserviceModule.v3beta1.TranslationServiceClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'translate.googleapis.com');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = translationserviceModule.v3beta1.TranslationServiceClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new translationserviceModule.v3beta1.TranslationServiceClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'translate.googleapis.com');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new translationserviceModule.v3beta1.TranslationServiceClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new translationserviceModule.v3beta1.TranslationServiceClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'translate.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new translationserviceModule.v3beta1.TranslationServiceClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'translate.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new translationserviceModule.v3beta1.TranslationServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/videointelligence-esm/esm/src/v1/video_intelligence_service_client.ts.baseline
+++ b/baselines/videointelligence-esm/esm/src/v1/video_intelligence_service_client.ts.baseline
@@ -51,6 +51,8 @@ export class VideoIntelligenceServiceClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -106,7 +108,12 @@ export class VideoIntelligenceServiceClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof VideoIntelligenceServiceClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'videointelligence.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -114,7 +121,7 @@ export class VideoIntelligenceServiceClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -139,10 +146,10 @@ export class VideoIntelligenceServiceClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -275,19 +282,47 @@ export class VideoIntelligenceServiceClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'videointelligence.googleapis.com';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'videointelligence.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/videointelligence-esm/esm/test/gapic_video_intelligence_service_v1.ts.baseline
+++ b/baselines/videointelligence-esm/esm/test/gapic_video_intelligence_service_v1.ts.baseline
@@ -76,13 +76,37 @@ function stubLongRunningCallWithCallback<ResponseType>(response?: ResponseType, 
 describe('v1.VideoIntelligenceServiceClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = videointelligenceserviceModule.v1.VideoIntelligenceServiceClient.servicePath;
-            assert(servicePath);
+            const client = new videointelligenceserviceModule.v1.VideoIntelligenceServiceClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'videointelligence.googleapis.com');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = videointelligenceserviceModule.v1.VideoIntelligenceServiceClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new videointelligenceserviceModule.v1.VideoIntelligenceServiceClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'videointelligence.googleapis.com');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new videointelligenceserviceModule.v1.VideoIntelligenceServiceClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new videointelligenceserviceModule.v1.VideoIntelligenceServiceClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'videointelligence.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new videointelligenceserviceModule.v1.VideoIntelligenceServiceClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'videointelligence.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new videointelligenceserviceModule.v1.VideoIntelligenceServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/baselines/videointelligence-esm/esm/test/gapic_video_intelligence_service_v1.ts.baseline
+++ b/baselines/videointelligence-esm/esm/test/gapic_video_intelligence_service_v1.ts.baseline
@@ -93,6 +93,23 @@ describe('v1.VideoIntelligenceServiceClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = videointelligenceserviceModule.v1.VideoIntelligenceServiceClient.servicePath;
+                assert.strictEqual(servicePath, 'videointelligence.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = videointelligenceserviceModule.v1.VideoIntelligenceServiceClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'videointelligence.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new videointelligenceserviceModule.v1.VideoIntelligenceServiceClient({universeDomain: 'example.com'});
             const servicePath = client.servicePath;
@@ -104,7 +121,6 @@ describe('v1.VideoIntelligenceServiceClient', () => {
             const servicePath = client.servicePath;
             assert.strictEqual(servicePath, 'videointelligence.example.com');
         });
-
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new videointelligenceserviceModule.v1.VideoIntelligenceServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/videointelligence/src/v1/video_intelligence_service_client.ts.baseline
+++ b/baselines/videointelligence/src/v1/video_intelligence_service_client.ts.baseline
@@ -44,6 +44,8 @@ export class VideoIntelligenceServiceClient {
   private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -98,7 +100,12 @@ export class VideoIntelligenceServiceClient {
   constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof VideoIntelligenceServiceClient;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = 'videointelligence.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
@@ -106,7 +113,7 @@ export class VideoIntelligenceServiceClient {
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.scopes;
     }
 
@@ -131,10 +138,10 @@ export class VideoIntelligenceServiceClient {
     this.auth.useJWTAccessWithScope = true;
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.servicePath;
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.servicePath) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
 
@@ -259,19 +266,47 @@ export class VideoIntelligenceServiceClient {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static servicePath is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'videointelligence.googleapis.com';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static apiEndpoint is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return 'videointelligence.googleapis.com';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get servicePath() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as servicePath().
+   * @returns {string} The DNS address for this service.
+   */
+  get apiEndpoint() {
+    return this._servicePath;
+  }
+
+  get universeDomain() {
+    return this._universeDomain;
   }
 
   /**

--- a/baselines/videointelligence/test/gapic_video_intelligence_service_v1.ts.baseline
+++ b/baselines/videointelligence/test/gapic_video_intelligence_service_v1.ts.baseline
@@ -84,6 +84,23 @@ describe('v1.VideoIntelligenceServiceClient', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static servicePath is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = videointelligenceserviceModule.v1.VideoIntelligenceServiceClient.servicePath;
+                assert.strictEqual(servicePath, 'videointelligence.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static apiEndpoint is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = videointelligenceserviceModule.v1.VideoIntelligenceServiceClient.apiEndpoint;
+                assert.strictEqual(apiEndpoint, 'videointelligence.googleapis.com');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new videointelligenceserviceModule.v1.VideoIntelligenceServiceClient({universeDomain: 'example.com'});
             const servicePath = client.servicePath;
@@ -95,7 +112,6 @@ describe('v1.VideoIntelligenceServiceClient', () => {
             const servicePath = client.servicePath;
             assert.strictEqual(servicePath, 'videointelligence.example.com');
         });
-
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new videointelligenceserviceModule.v1.VideoIntelligenceServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/baselines/videointelligence/test/gapic_video_intelligence_service_v1.ts.baseline
+++ b/baselines/videointelligence/test/gapic_video_intelligence_service_v1.ts.baseline
@@ -67,13 +67,37 @@ function stubLongRunningCallWithCallback<ResponseType>(response?: ResponseType, 
 describe('v1.VideoIntelligenceServiceClient', () => {
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = videointelligenceserviceModule.v1.VideoIntelligenceServiceClient.servicePath;
-            assert(servicePath);
+            const client = new videointelligenceserviceModule.v1.VideoIntelligenceServiceClient();
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'videointelligence.googleapis.com');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = videointelligenceserviceModule.v1.VideoIntelligenceServiceClient.apiEndpoint;
-            assert(apiEndpoint);
+            const client = new videointelligenceserviceModule.v1.VideoIntelligenceServiceClient();
+            const apiEndpoint = client.apiEndpoint;
+            assert.strictEqual(apiEndpoint, 'videointelligence.googleapis.com');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new videointelligenceserviceModule.v1.VideoIntelligenceServiceClient();
+            const universeDomain = client.universeDomain;
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new videointelligenceserviceModule.v1.VideoIntelligenceServiceClient({universeDomain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'videointelligence.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new videointelligenceserviceModule.v1.VideoIntelligenceServiceClient({universe_domain: 'example.com'});
+            const servicePath = client.servicePath;
+            assert.strictEqual(servicePath, 'videointelligence.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new videointelligenceserviceModule.v1.VideoIntelligenceServiceClient({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/templates/cjs/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/cjs/typescript_gapic/src/$version/$service_client.ts.njk
@@ -78,6 +78,8 @@ export class {{ service.name }}Client {
   private _gaxGrpc: gax.GrpcClient{% if not api.legacyProtoLoad %} | gax.fallback.GrpcClient{% endif %};
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -145,7 +147,12 @@ export class {{ service.name }}Client {
   constructor(opts?: ClientOptions{% if not api.legacyProtoLoad %}, gaxInstance?: typeof gax | typeof gax.fallback{% endif %}) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof {{ service.name }}Client;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.{{ id.get("servicePath") }};
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = '{{ api.shortName }}.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.{{ id.get("port") }};
     const clientConfig = opts?.clientConfig ?? {};
@@ -170,7 +177,7 @@ export class {{ service.name }}Client {
     {%- endif %}
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.{{ id.get("servicePath") }} && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.{{ id.get("scopes") }};
     }
     {%- if not api.legacyProtoLoad %}
@@ -200,10 +207,10 @@ export class {{ service.name }}Client {
 {%- endif %}
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.{{ id.get("servicePath") }};
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.{{ id.get("servicePath") }}) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.{{ id.get("scopes") }};
     }
   {%- if service.IAMPolicyMixin > 0 %}
@@ -479,19 +486,47 @@ export class {{ service.name }}Client {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get {{ id.get("servicePath") }}() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static {{ id.get("servicePath") }} is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return '{{ api.hostName }}';
   }
 
   /**
-   * The DNS address for this API service - same as {{ id.get("servicePath") }}(),
+   * The DNS address for this API service - same as {{ id.get("servicePath") }},
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get {{ id.get("apiEndpoint") }}() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static {{ id.get("apiEndpoint") }} is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return '{{ api.hostName }}';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get {{ id.get("servicePath") }}() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as {{ id.get("servicePath") }}().
+   * @returns {string} The DNS address for this service.
+   */
+  get {{ id.get("apiEndpoint") }}() {
+    return this._servicePath;
+  }
+
+  get {{ id.get("universeDomain") }}() {
+    return this._universeDomain;
   }
 
   /**

--- a/templates/cjs/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/cjs/typescript_gapic/src/$version/$service_client.ts.njk
@@ -151,7 +151,11 @@ export class {{ service.name }}Client {
       throw new Error('Please set either universe_domain or universeDomain, but not both.');
     }
     this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    {%- if api.hostName.endsWith("googleapis.com") %}
     this._servicePath = '{{ api.shortName }}.' + this._universeDomain;
+    {%- else %}
+    this._servicePath = '{{ api.hostName }}';
+    {%- endif %}
     const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.{{ id.get("port") }};

--- a/templates/cjs/typescript_gapic/test/gapic_$service_$version.ts.njk
+++ b/templates/cjs/typescript_gapic/test/gapic_$service_$version.ts.njk
@@ -215,13 +215,37 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
 {%- endif %}
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client.{{ id.get("servicePath") }};
-            assert(servicePath);
+            const client = new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client();
+            const servicePath = client.{{ id.get("servicePath") }};
+            assert.strictEqual(servicePath, '{{ api.hostName }}');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client.{{ id.get("apiEndpoint") }};
-            assert(apiEndpoint);
+            const client = new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client();
+            const apiEndpoint = client.{{ id.get("apiEndpoint") }};
+            assert.strictEqual(apiEndpoint, '{{ api.hostName }}');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client();
+            const universeDomain = client.{{ id.get("universeDomain") }};
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client({universeDomain: 'example.com'});
+            const servicePath = client.{{ id.get("servicePath") }};
+            assert.strictEqual(servicePath, '{{ api.shortName }}.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client({universe_domain: 'example.com'});
+            const servicePath = client.{{ id.get("servicePath") }};
+            assert.strictEqual(servicePath, '{{ api.shortName }}.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/templates/cjs/typescript_gapic/test/gapic_$service_$version.ts.njk
+++ b/templates/cjs/typescript_gapic/test/gapic_$service_$version.ts.njk
@@ -232,6 +232,25 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static {{ id.get("servicePath") }} is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client.{{ id.get("servicePath") }};
+                assert.strictEqual(servicePath, '{{ api.hostName }}');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static {{ id.get("apiEndpoint") }} is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client.{{ id.get("apiEndpoint") }};
+                assert.strictEqual(apiEndpoint, '{{ api.hostName }}');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
+
+        {%- if api.hostName.endsWith("googleapis.com") %}
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client({universeDomain: 'example.com'});
             const servicePath = client.{{ id.get("servicePath") }};
@@ -244,6 +263,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             assert.strictEqual(servicePath, '{{ api.shortName }}.example.com');
         });
 
+        {%- endif %}
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/templates/esm/typescript_gapic/esm/src/$version/$service_client.ts.njk
+++ b/templates/esm/typescript_gapic/esm/src/$version/$service_client.ts.njk
@@ -77,6 +77,8 @@ export class {{ service.name }}Client {
   private _gaxGrpc: gax.GrpcClient{% if not api.legacyProtoLoad %} | gax.fallback.GrpcClient{% endif %};
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
+  private _universeDomain: string;
+  private _servicePath: string;
   auth: gax.GoogleAuth;
   descriptors: Descriptors = {
     page: {},
@@ -145,7 +147,12 @@ export class {{ service.name }}Client {
   constructor(opts?: ClientOptions{% if not api.legacyProtoLoad %}, gaxInstance?: typeof gax | typeof gax.fallback{% endif %}) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof {{ service.name }}Client;
-    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.{{ id.get("servicePath") }};
+    if (opts?.universe_domain && opts?.universeDomain && opts?.universe_domain !== opts?.universeDomain) {
+      throw new Error('Please set either universe_domain or universeDomain, but not both.');
+    }
+    this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    this._servicePath = '{{ api.shortName }}.' + this._universeDomain;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.{{ id.get("port") }};
     const clientConfig = opts?.clientConfig ?? {};
@@ -170,7 +177,7 @@ export class {{ service.name }}Client {
     {%- endif %}
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
-    if (servicePath !== staticMembers.{{ id.get("servicePath") }} && !('scopes' in opts)) {
+    if (servicePath !== this._servicePath && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.{{ id.get("scopes") }};
     }
     {%- if not api.legacyProtoLoad %}
@@ -200,10 +207,10 @@ export class {{ service.name }}Client {
 {%- endif %}
 
     // Set defaultServicePath on the auth object.
-    this.auth.defaultServicePath = staticMembers.{{ id.get("servicePath") }};
+    this.auth.defaultServicePath = this._servicePath;
 
     // Set the default scopes in auth client if needed.
-    if (servicePath === staticMembers.{{ id.get("servicePath") }}) {
+    if (servicePath === this._servicePath) {
       this.auth.defaultScopes = staticMembers.{{ id.get("scopes") }};
     }
   {%- if service.IAMPolicyMixin > 0 %}
@@ -487,19 +494,47 @@ export class {{ service.name }}Client {
 
   /**
    * The DNS address for this API service.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get {{ id.get("servicePath") }}() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static {{ id.get("servicePath") }} is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return '{{ api.hostName }}';
   }
 
   /**
-   * The DNS address for this API service - same as {{ id.get("servicePath") }}(),
+   * The DNS address for this API service - same as {{ id.get("servicePath") }},
    * exists for compatibility reasons.
+   * @deprecated
    * @returns {string} The DNS address for this service.
    */
   static get {{ id.get("apiEndpoint") }}() {
+    if (typeof process !== undefined && typeof process.emitWarning === 'function') {
+      process.emitWarning('Static {{ id.get("apiEndpoint") }} is deprecated, please use the instance method instead.', 'DeprecationWarning');
+    }
     return '{{ api.hostName }}';
+  }
+
+  /**
+   * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
+   */
+  get {{ id.get("servicePath") }}() {
+    return this._servicePath;
+  }
+
+  /**
+   * The DNS address for this API service - same as {{ id.get("servicePath") }}().
+   * @returns {string} The DNS address for this service.
+   */
+  get {{ id.get("apiEndpoint") }}() {
+    return this._servicePath;
+  }
+
+  get {{ id.get("universeDomain") }}() {
+    return this._universeDomain;
   }
 
   /**

--- a/templates/esm/typescript_gapic/esm/src/$version/$service_client.ts.njk
+++ b/templates/esm/typescript_gapic/esm/src/$version/$service_client.ts.njk
@@ -151,7 +151,11 @@ export class {{ service.name }}Client {
       throw new Error('Please set either universe_domain or universeDomain, but not both.');
     }
     this._universeDomain = opts?.universeDomain ?? opts?.universe_domain ?? 'googleapis.com';
+    {%- if api.hostName.endsWith("googleapis.com") %}
     this._servicePath = '{{ api.shortName }}.' + this._universeDomain;
+    {%- else %}
+    this._servicePath = '{{ api.hostName }}';
+    {%- endif %}
     const servicePath = opts?.servicePath || opts?.apiEndpoint || this._servicePath;
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.{{ id.get("port") }};

--- a/templates/esm/typescript_gapic/esm/test/gapic_$service_$version.ts.njk
+++ b/templates/esm/typescript_gapic/esm/test/gapic_$service_$version.ts.njk
@@ -223,13 +223,37 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
 {%- endif %}
     describe('Common methods', () => {
         it('has servicePath', () => {
-            const servicePath = {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client.{{ id.get("servicePath") }};
-            assert(servicePath);
+            const client = new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client();
+            const servicePath = client.{{ id.get("servicePath") }};
+            assert.strictEqual(servicePath, '{{ api.hostName }}');
         });
 
         it('has apiEndpoint', () => {
-            const apiEndpoint = {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client.{{ id.get("apiEndpoint") }};
-            assert(apiEndpoint);
+            const client = new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client();
+            const apiEndpoint = client.{{ id.get("apiEndpoint") }};
+            assert.strictEqual(apiEndpoint, '{{ api.hostName }}');
+        });
+        
+        it('has universeDomain', () => {
+            const client = new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client();
+            const universeDomain = client.{{ id.get("universeDomain") }};
+            assert.strictEqual(universeDomain, "googleapis.com");
+        });
+
+        it('sets servicePath according to universe domain camelCase', () => {
+            const client = new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client({universeDomain: 'example.com'});
+            const servicePath = client.{{ id.get("servicePath") }};
+            assert.strictEqual(servicePath, '{{ api.shortName }}.example.com');
+        });
+
+        it('sets servicePath according to universe domain snakeCase', () => {
+            const client = new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client({universe_domain: 'example.com'});
+            const servicePath = client.{{ id.get("servicePath") }};
+            assert.strictEqual(servicePath, '{{ api.shortName }}.example.com');
+        });
+
+        it('does not allow setting both universeDomain and universe_domain', () => {
+            assert.throws(() => { new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });
 
         it('has port', () => {

--- a/templates/esm/typescript_gapic/esm/test/gapic_$service_$version.ts.njk
+++ b/templates/esm/typescript_gapic/esm/test/gapic_$service_$version.ts.njk
@@ -240,6 +240,25 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             assert.strictEqual(universeDomain, "googleapis.com");
         });
 
+        if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+            it('throws DeprecationWarning if static {{ id.get("servicePath") }} is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const servicePath = {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client.{{ id.get("servicePath") }};
+                assert.strictEqual(servicePath, '{{ api.hostName }}');
+                assert(stub.called);
+                stub.restore();
+            });
+
+            it('throws DeprecationWarning if static {{ id.get("apiEndpoint") }} is used', () => {
+                const stub = sinon.stub(process, 'emitWarning');
+                const apiEndpoint = {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client.{{ id.get("apiEndpoint") }};
+                assert.strictEqual(apiEndpoint, '{{ api.hostName }}');
+                assert(stub.called);
+                stub.restore();
+            });
+        }
+
+        {%- if api.hostName.endsWith("googleapis.com") %}
         it('sets servicePath according to universe domain camelCase', () => {
             const client = new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client({universeDomain: 'example.com'});
             const servicePath = client.{{ id.get("servicePath") }};
@@ -252,6 +271,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             assert.strictEqual(servicePath, '{{ api.shortName }}.example.com');
         });
 
+        {%- endif %}
         it('does not allow setting both universeDomain and universe_domain', () => {
             assert.throws(() => { new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client({universe_domain: 'example.com', universeDomain: 'example.net'}); });
         });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "moduleResolution": "node",
     "esModuleInterop": true,
     "sourceMap": false,
-    "lib": ["esnext",  "DOM"]
+    "lib": ["esnext",  "DOM"],
+    "target": "esnext"
   },
   "include": [
     "typescript/**/*.ts",

--- a/typescript/src/schema/api.ts
+++ b/typescript/src/schema/api.ts
@@ -27,6 +27,7 @@ export class API {
   naming: Naming;
   protos: ProtosMap;
   hostName?: string;
+  shortName?: string;
   port?: string;
   // This field is for users passing proper publish package name like @google-cloud/text-to-speech.
   publishName: string;
@@ -166,6 +167,7 @@ export class API {
         );
       }
       this.hostName = hostname || this.hostName || 'localhost';
+      this.shortName = this.hostName?.replace(/\.googleapis\.com$/, '');
       this.port = port ?? this.port ?? '443';
       serviceNamesList.push(service.name || this.naming.name);
     }


### PR DESCRIPTION
Following https://github.com/googleapis/gax-nodejs/pull/1552, implementing support for `universeDomain` option in the client libraries constructor.

The static getters `servicePath` and `apiEndpoint` are deprecated; universe-aware instance methods `servicePath` and `apiEndpoint` are introduced instead.