### PR TITLE
fix: remove name conflict for APIs that have servicePath

### DIFF
--- a/baselines/asset-esm/esm/src/v1/asset_service_client.ts.baseline
+++ b/baselines/asset-esm/esm/src/v1/asset_service_client.ts.baseline
@@ -298,7 +298,7 @@ export class AssetServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -311,7 +311,7 @@ export class AssetServiceClient {
   /**
    * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -323,14 +323,6 @@ export class AssetServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/asset-esm/esm/test/gapic_asset_service_v1.ts.baseline
+++ b/baselines/asset-esm/esm/test/gapic_asset_service_v1.ts.baseline
@@ -79,18 +79,12 @@ function stubLongRunningCallWithCallback<ResponseType>(response?: ResponseType, 
 
 describe('v1.AssetServiceClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new assetserviceModule.v1.AssetServiceClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'cloudasset.googleapis.com');
-        });
-
         it('has apiEndpoint', () => {
             const client = new assetserviceModule.v1.AssetServiceClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'cloudasset.googleapis.com');
         });
-        
+
         it('has universeDomain', () => {
             const client = new assetserviceModule.v1.AssetServiceClient();
             const universeDomain = client.universeDomain;

--- a/baselines/asset-esm/esm/test/gapic_asset_service_v1.ts.baseline
+++ b/baselines/asset-esm/esm/test/gapic_asset_service_v1.ts.baseline
@@ -108,15 +108,15 @@ describe('v1.AssetServiceClient', () => {
                 stub.restore();
             });
         }
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new assetserviceModule.v1.AssetServiceClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'cloudasset.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new assetserviceModule.v1.AssetServiceClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'cloudasset.example.com');
         });
         it('does not allow setting both universeDomain and universe_domain', () => {

--- a/baselines/asset/src/v1/asset_service_client.ts.baseline
+++ b/baselines/asset/src/v1/asset_service_client.ts.baseline
@@ -282,7 +282,7 @@ export class AssetServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -293,9 +293,8 @@ export class AssetServiceClient {
   }
 
   /**
-   * The DNS address for this API service - same as servicePath,
-   * exists for compatibility reasons.
-   * @deprecated
+   * The DNS address for this API service - same as servicePath.
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -307,14 +306,6 @@ export class AssetServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/asset/test/gapic_asset_service_v1.ts.baseline
+++ b/baselines/asset/test/gapic_asset_service_v1.ts.baseline
@@ -99,15 +99,15 @@ describe('v1.AssetServiceClient', () => {
                 stub.restore();
             });
         }
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new assetserviceModule.v1.AssetServiceClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'cloudasset.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new assetserviceModule.v1.AssetServiceClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'cloudasset.example.com');
         });
         it('does not allow setting both universeDomain and universe_domain', () => {

--- a/baselines/asset/test/gapic_asset_service_v1.ts.baseline
+++ b/baselines/asset/test/gapic_asset_service_v1.ts.baseline
@@ -70,18 +70,12 @@ function stubLongRunningCallWithCallback<ResponseType>(response?: ResponseType, 
 
 describe('v1.AssetServiceClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new assetserviceModule.v1.AssetServiceClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'cloudasset.googleapis.com');
-        });
-
         it('has apiEndpoint', () => {
             const client = new assetserviceModule.v1.AssetServiceClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'cloudasset.googleapis.com');
         });
-        
+
         it('has universeDomain', () => {
             const client = new assetserviceModule.v1.AssetServiceClient();
             const universeDomain = client.universeDomain;

--- a/baselines/bigquery-storage-esm/esm/src/v1beta1/big_query_storage_client.ts.baseline
+++ b/baselines/bigquery-storage-esm/esm/src/v1beta1/big_query_storage_client.ts.baseline
@@ -284,7 +284,7 @@ export class BigQueryStorageClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -297,7 +297,7 @@ export class BigQueryStorageClient {
   /**
    * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -309,14 +309,6 @@ export class BigQueryStorageClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/bigquery-storage-esm/esm/test/gapic_big_query_storage_v1beta1.ts.baseline
+++ b/baselines/bigquery-storage-esm/esm/test/gapic_big_query_storage_v1beta1.ts.baseline
@@ -77,18 +77,12 @@ function stubServerStreamingCall<ResponseType>(response?: ResponseType, error?: 
 
 describe('v1beta1.BigQueryStorageClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'bigquerystorage.googleapis.com');
-        });
-
         it('has apiEndpoint', () => {
             const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'bigquerystorage.googleapis.com');
         });
-        
+
         it('has universeDomain', () => {
             const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient();
             const universeDomain = client.universeDomain;

--- a/baselines/bigquery-storage-esm/esm/test/gapic_big_query_storage_v1beta1.ts.baseline
+++ b/baselines/bigquery-storage-esm/esm/test/gapic_big_query_storage_v1beta1.ts.baseline
@@ -106,15 +106,15 @@ describe('v1beta1.BigQueryStorageClient', () => {
                 stub.restore();
             });
         }
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'bigquerystorage.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'bigquerystorage.example.com');
         });
         it('does not allow setting both universeDomain and universe_domain', () => {

--- a/baselines/bigquery-storage/src/v1beta1/big_query_storage_client.ts.baseline
+++ b/baselines/bigquery-storage/src/v1beta1/big_query_storage_client.ts.baseline
@@ -268,7 +268,7 @@ export class BigQueryStorageClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -279,9 +279,8 @@ export class BigQueryStorageClient {
   }
 
   /**
-   * The DNS address for this API service - same as servicePath,
-   * exists for compatibility reasons.
-   * @deprecated
+   * The DNS address for this API service - same as servicePath.
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -293,14 +292,6 @@ export class BigQueryStorageClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/bigquery-storage/test/gapic_big_query_storage_v1beta1.ts.baseline
+++ b/baselines/bigquery-storage/test/gapic_big_query_storage_v1beta1.ts.baseline
@@ -68,18 +68,12 @@ function stubServerStreamingCall<ResponseType>(response?: ResponseType, error?: 
 
 describe('v1beta1.BigQueryStorageClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'bigquerystorage.googleapis.com');
-        });
-
         it('has apiEndpoint', () => {
             const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'bigquerystorage.googleapis.com');
         });
-        
+
         it('has universeDomain', () => {
             const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient();
             const universeDomain = client.universeDomain;

--- a/baselines/bigquery-storage/test/gapic_big_query_storage_v1beta1.ts.baseline
+++ b/baselines/bigquery-storage/test/gapic_big_query_storage_v1beta1.ts.baseline
@@ -97,15 +97,15 @@ describe('v1beta1.BigQueryStorageClient', () => {
                 stub.restore();
             });
         }
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'bigquerystorage.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'bigquerystorage.example.com');
         });
         it('does not allow setting both universeDomain and universe_domain', () => {

--- a/baselines/compute-esm/esm/src/v1/addresses_client.ts.baseline
+++ b/baselines/compute-esm/esm/src/v1/addresses_client.ts.baseline
@@ -272,7 +272,7 @@ export class AddressesClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -285,7 +285,7 @@ export class AddressesClient {
   /**
    * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -297,14 +297,6 @@ export class AddressesClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/compute-esm/esm/src/v1/region_operations_client.ts.baseline
+++ b/baselines/compute-esm/esm/src/v1/region_operations_client.ts.baseline
@@ -258,7 +258,7 @@ export class RegionOperationsClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -271,7 +271,7 @@ export class RegionOperationsClient {
   /**
    * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -283,14 +283,6 @@ export class RegionOperationsClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/compute-esm/esm/test/gapic_addresses_v1.ts.baseline
+++ b/baselines/compute-esm/esm/test/gapic_addresses_v1.ts.baseline
@@ -150,15 +150,15 @@ describe('v1.AddressesClient', () => {
                 stub.restore();
             });
         }
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new addressesModule.v1.AddressesClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'compute.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new addressesModule.v1.AddressesClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'compute.example.com');
         });
         it('does not allow setting both universeDomain and universe_domain', () => {

--- a/baselines/compute-esm/esm/test/gapic_addresses_v1.ts.baseline
+++ b/baselines/compute-esm/esm/test/gapic_addresses_v1.ts.baseline
@@ -121,18 +121,12 @@ describe('v1.AddressesClient', () => {
     sinon.restore();
   });
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new addressesModule.v1.AddressesClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'compute.googleapis.com');
-        });
-
         it('has apiEndpoint', () => {
             const client = new addressesModule.v1.AddressesClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'compute.googleapis.com');
         });
-        
+
         it('has universeDomain', () => {
             const client = new addressesModule.v1.AddressesClient();
             const universeDomain = client.universeDomain;

--- a/baselines/compute-esm/esm/test/gapic_region_operations_v1.ts.baseline
+++ b/baselines/compute-esm/esm/test/gapic_region_operations_v1.ts.baseline
@@ -103,15 +103,15 @@ describe('v1.RegionOperationsClient', () => {
                 stub.restore();
             });
         }
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new regionoperationsModule.v1.RegionOperationsClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'compute.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new regionoperationsModule.v1.RegionOperationsClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'compute.example.com');
         });
         it('does not allow setting both universeDomain and universe_domain', () => {

--- a/baselines/compute-esm/esm/test/gapic_region_operations_v1.ts.baseline
+++ b/baselines/compute-esm/esm/test/gapic_region_operations_v1.ts.baseline
@@ -74,18 +74,12 @@ describe('v1.RegionOperationsClient', () => {
     sinon.restore();
   });
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new regionoperationsModule.v1.RegionOperationsClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'compute.googleapis.com');
-        });
-
         it('has apiEndpoint', () => {
             const client = new regionoperationsModule.v1.RegionOperationsClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'compute.googleapis.com');
         });
-        
+
         it('has universeDomain', () => {
             const client = new regionoperationsModule.v1.RegionOperationsClient();
             const universeDomain = client.universeDomain;

--- a/baselines/compute/src/v1/addresses_client.ts.baseline
+++ b/baselines/compute/src/v1/addresses_client.ts.baseline
@@ -256,7 +256,7 @@ export class AddressesClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -267,9 +267,8 @@ export class AddressesClient {
   }
 
   /**
-   * The DNS address for this API service - same as servicePath,
-   * exists for compatibility reasons.
-   * @deprecated
+   * The DNS address for this API service - same as servicePath.
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -281,14 +280,6 @@ export class AddressesClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/compute/src/v1/region_operations_client.ts.baseline
+++ b/baselines/compute/src/v1/region_operations_client.ts.baseline
@@ -242,7 +242,7 @@ export class RegionOperationsClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -253,9 +253,8 @@ export class RegionOperationsClient {
   }
 
   /**
-   * The DNS address for this API service - same as servicePath,
-   * exists for compatibility reasons.
-   * @deprecated
+   * The DNS address for this API service - same as servicePath.
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -267,14 +266,6 @@ export class RegionOperationsClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/compute/test/gapic_addresses_v1.ts.baseline
+++ b/baselines/compute/test/gapic_addresses_v1.ts.baseline
@@ -112,18 +112,12 @@ describe('v1.AddressesClient', () => {
     sinon.restore();
   });
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new addressesModule.v1.AddressesClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'compute.googleapis.com');
-        });
-
         it('has apiEndpoint', () => {
             const client = new addressesModule.v1.AddressesClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'compute.googleapis.com');
         });
-        
+
         it('has universeDomain', () => {
             const client = new addressesModule.v1.AddressesClient();
             const universeDomain = client.universeDomain;

--- a/baselines/compute/test/gapic_addresses_v1.ts.baseline
+++ b/baselines/compute/test/gapic_addresses_v1.ts.baseline
@@ -141,15 +141,15 @@ describe('v1.AddressesClient', () => {
                 stub.restore();
             });
         }
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new addressesModule.v1.AddressesClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'compute.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new addressesModule.v1.AddressesClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'compute.example.com');
         });
         it('does not allow setting both universeDomain and universe_domain', () => {

--- a/baselines/compute/test/gapic_region_operations_v1.ts.baseline
+++ b/baselines/compute/test/gapic_region_operations_v1.ts.baseline
@@ -94,15 +94,15 @@ describe('v1.RegionOperationsClient', () => {
                 stub.restore();
             });
         }
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new regionoperationsModule.v1.RegionOperationsClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'compute.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new regionoperationsModule.v1.RegionOperationsClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'compute.example.com');
         });
         it('does not allow setting both universeDomain and universe_domain', () => {

--- a/baselines/compute/test/gapic_region_operations_v1.ts.baseline
+++ b/baselines/compute/test/gapic_region_operations_v1.ts.baseline
@@ -65,18 +65,12 @@ describe('v1.RegionOperationsClient', () => {
     sinon.restore();
   });
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new regionoperationsModule.v1.RegionOperationsClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'compute.googleapis.com');
-        });
-
         it('has apiEndpoint', () => {
             const client = new regionoperationsModule.v1.RegionOperationsClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'compute.googleapis.com');
         });
-        
+
         it('has universeDomain', () => {
             const client = new regionoperationsModule.v1.RegionOperationsClient();
             const universeDomain = client.universeDomain;

--- a/baselines/deprecatedtest-esm/esm/src/v1/deprecated_service_client.ts.baseline
+++ b/baselines/deprecatedtest-esm/esm/src/v1/deprecated_service_client.ts.baseline
@@ -259,7 +259,7 @@ export class DeprecatedServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -272,7 +272,7 @@ export class DeprecatedServiceClient {
   /**
    * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -284,14 +284,6 @@ export class DeprecatedServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/deprecatedtest-esm/esm/test/gapic_deprecated_service_v1.ts.baseline
+++ b/baselines/deprecatedtest-esm/esm/test/gapic_deprecated_service_v1.ts.baseline
@@ -63,18 +63,12 @@ function stubSimpleCallWithCallback<ResponseType>(response?: ResponseType, error
 
 describe('v1.DeprecatedServiceClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new deprecatedserviceModule.v1.DeprecatedServiceClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost');
-        });
-
         it('has apiEndpoint', () => {
             const client = new deprecatedserviceModule.v1.DeprecatedServiceClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'localhost');
         });
-        
+
         it('has universeDomain', () => {
             const client = new deprecatedserviceModule.v1.DeprecatedServiceClient();
             const universeDomain = client.universeDomain;

--- a/baselines/deprecatedtest/src/v1/deprecated_service_client.ts.baseline
+++ b/baselines/deprecatedtest/src/v1/deprecated_service_client.ts.baseline
@@ -243,7 +243,7 @@ export class DeprecatedServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -254,9 +254,8 @@ export class DeprecatedServiceClient {
   }
 
   /**
-   * The DNS address for this API service - same as servicePath,
-   * exists for compatibility reasons.
-   * @deprecated
+   * The DNS address for this API service - same as servicePath.
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -268,14 +267,6 @@ export class DeprecatedServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/deprecatedtest/test/gapic_deprecated_service_v1.ts.baseline
+++ b/baselines/deprecatedtest/test/gapic_deprecated_service_v1.ts.baseline
@@ -54,18 +54,12 @@ function stubSimpleCallWithCallback<ResponseType>(response?: ResponseType, error
 
 describe('v1.DeprecatedServiceClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new deprecatedserviceModule.v1.DeprecatedServiceClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost');
-        });
-
         it('has apiEndpoint', () => {
             const client = new deprecatedserviceModule.v1.DeprecatedServiceClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'localhost');
         });
-        
+
         it('has universeDomain', () => {
             const client = new deprecatedserviceModule.v1.DeprecatedServiceClient();
             const universeDomain = client.universeDomain;

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/compliance_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/compliance_client.ts.baseline
@@ -297,7 +297,7 @@ export class ComplianceClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -310,7 +310,7 @@ export class ComplianceClient {
   /**
    * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -322,14 +322,6 @@ export class ComplianceClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/echo_client.ts.baseline
@@ -353,7 +353,7 @@ export class EchoClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -366,7 +366,7 @@ export class EchoClient {
   /**
    * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -378,14 +378,6 @@ export class EchoClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/identity_client.ts.baseline
@@ -304,7 +304,7 @@ export class IdentityClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -317,7 +317,7 @@ export class IdentityClient {
   /**
    * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -329,14 +329,6 @@ export class IdentityClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/messaging_client.ts.baseline
@@ -352,7 +352,7 @@ export class MessagingClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -365,7 +365,7 @@ export class MessagingClient {
   /**
    * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -377,14 +377,6 @@ export class MessagingClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/sequence_service_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/sequence_service_client.ts.baseline
@@ -294,7 +294,7 @@ export class SequenceServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -307,7 +307,7 @@ export class SequenceServiceClient {
   /**
    * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -319,14 +319,6 @@ export class SequenceServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/testing_client.ts.baseline
@@ -307,7 +307,7 @@ export class TestingClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -320,7 +320,7 @@ export class TestingClient {
   /**
    * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -332,14 +332,6 @@ export class TestingClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/disable-packing-test-esm/esm/test/gapic_compliance_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/test/gapic_compliance_v1beta1.ts.baseline
@@ -63,18 +63,12 @@ function stubSimpleCallWithCallback<ResponseType>(response?: ResponseType, error
 
 describe('v1beta1.ComplianceClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new complianceModule.v1beta1.ComplianceClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost');
-        });
-
         it('has apiEndpoint', () => {
             const client = new complianceModule.v1beta1.ComplianceClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'localhost');
         });
-        
+
         it('has universeDomain', () => {
             const client = new complianceModule.v1beta1.ComplianceClient();
             const universeDomain = client.universeDomain;

--- a/baselines/disable-packing-test-esm/esm/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/test/gapic_echo_v1beta1.ts.baseline
@@ -159,18 +159,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v1beta1.EchoClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new echoModule.v1beta1.EchoClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost');
-        });
-
         it('has apiEndpoint', () => {
             const client = new echoModule.v1beta1.EchoClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'localhost');
         });
-        
+
         it('has universeDomain', () => {
             const client = new echoModule.v1beta1.EchoClient();
             const universeDomain = client.universeDomain;

--- a/baselines/disable-packing-test-esm/esm/test/gapic_identity_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/test/gapic_identity_v1beta1.ts.baseline
@@ -110,18 +110,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v1beta1.IdentityClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new identityModule.v1beta1.IdentityClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost');
-        });
-
         it('has apiEndpoint', () => {
             const client = new identityModule.v1beta1.IdentityClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'localhost');
         });
-        
+
         it('has universeDomain', () => {
             const client = new identityModule.v1beta1.IdentityClient();
             const universeDomain = client.universeDomain;

--- a/baselines/disable-packing-test-esm/esm/test/gapic_messaging_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/test/gapic_messaging_v1beta1.ts.baseline
@@ -159,18 +159,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v1beta1.MessagingClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new messagingModule.v1beta1.MessagingClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost');
-        });
-
         it('has apiEndpoint', () => {
             const client = new messagingModule.v1beta1.MessagingClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'localhost');
         });
-        
+
         it('has universeDomain', () => {
             const client = new messagingModule.v1beta1.MessagingClient();
             const universeDomain = client.universeDomain;

--- a/baselines/disable-packing-test-esm/esm/test/gapic_sequence_service_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/test/gapic_sequence_service_v1beta1.ts.baseline
@@ -63,18 +63,12 @@ function stubSimpleCallWithCallback<ResponseType>(response?: ResponseType, error
 
 describe('v1beta1.SequenceServiceClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new sequenceserviceModule.v1beta1.SequenceServiceClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost');
-        });
-
         it('has apiEndpoint', () => {
             const client = new sequenceserviceModule.v1beta1.SequenceServiceClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'localhost');
         });
-        
+
         it('has universeDomain', () => {
             const client = new sequenceserviceModule.v1beta1.SequenceServiceClient();
             const universeDomain = client.universeDomain;

--- a/baselines/disable-packing-test-esm/esm/test/gapic_testing_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/test/gapic_testing_v1beta1.ts.baseline
@@ -110,18 +110,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v1beta1.TestingClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new testingModule.v1beta1.TestingClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost');
-        });
-
         it('has apiEndpoint', () => {
             const client = new testingModule.v1beta1.TestingClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'localhost');
         });
-        
+
         it('has universeDomain', () => {
             const client = new testingModule.v1beta1.TestingClient();
             const universeDomain = client.universeDomain;

--- a/baselines/disable-packing-test/src/v1beta1/compliance_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/compliance_client.ts.baseline
@@ -281,7 +281,7 @@ export class ComplianceClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -292,9 +292,8 @@ export class ComplianceClient {
   }
 
   /**
-   * The DNS address for this API service - same as servicePath,
-   * exists for compatibility reasons.
-   * @deprecated
+   * The DNS address for this API service - same as servicePath.
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -306,14 +305,6 @@ export class ComplianceClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
@@ -337,7 +337,7 @@ export class EchoClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -348,9 +348,8 @@ export class EchoClient {
   }
 
   /**
-   * The DNS address for this API service - same as servicePath,
-   * exists for compatibility reasons.
-   * @deprecated
+   * The DNS address for this API service - same as servicePath.
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -362,14 +361,6 @@ export class EchoClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/disable-packing-test/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/identity_client.ts.baseline
@@ -288,7 +288,7 @@ export class IdentityClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -299,9 +299,8 @@ export class IdentityClient {
   }
 
   /**
-   * The DNS address for this API service - same as servicePath,
-   * exists for compatibility reasons.
-   * @deprecated
+   * The DNS address for this API service - same as servicePath.
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -313,14 +312,6 @@ export class IdentityClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
@@ -336,7 +336,7 @@ export class MessagingClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -347,9 +347,8 @@ export class MessagingClient {
   }
 
   /**
-   * The DNS address for this API service - same as servicePath,
-   * exists for compatibility reasons.
-   * @deprecated
+   * The DNS address for this API service - same as servicePath.
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -361,14 +360,6 @@ export class MessagingClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/disable-packing-test/src/v1beta1/sequence_service_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/sequence_service_client.ts.baseline
@@ -278,7 +278,7 @@ export class SequenceServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -289,9 +289,8 @@ export class SequenceServiceClient {
   }
 
   /**
-   * The DNS address for this API service - same as servicePath,
-   * exists for compatibility reasons.
-   * @deprecated
+   * The DNS address for this API service - same as servicePath.
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -303,14 +302,6 @@ export class SequenceServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/disable-packing-test/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/testing_client.ts.baseline
@@ -291,7 +291,7 @@ export class TestingClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -302,9 +302,8 @@ export class TestingClient {
   }
 
   /**
-   * The DNS address for this API service - same as servicePath,
-   * exists for compatibility reasons.
-   * @deprecated
+   * The DNS address for this API service - same as servicePath.
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -316,14 +315,6 @@ export class TestingClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/disable-packing-test/test/gapic_compliance_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_compliance_v1beta1.ts.baseline
@@ -54,18 +54,12 @@ function stubSimpleCallWithCallback<ResponseType>(response?: ResponseType, error
 
 describe('v1beta1.ComplianceClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new complianceModule.v1beta1.ComplianceClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost');
-        });
-
         it('has apiEndpoint', () => {
             const client = new complianceModule.v1beta1.ComplianceClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'localhost');
         });
-        
+
         it('has universeDomain', () => {
             const client = new complianceModule.v1beta1.ComplianceClient();
             const universeDomain = client.universeDomain;

--- a/baselines/disable-packing-test/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_echo_v1beta1.ts.baseline
@@ -150,18 +150,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v1beta1.EchoClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new echoModule.v1beta1.EchoClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost');
-        });
-
         it('has apiEndpoint', () => {
             const client = new echoModule.v1beta1.EchoClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'localhost');
         });
-        
+
         it('has universeDomain', () => {
             const client = new echoModule.v1beta1.EchoClient();
             const universeDomain = client.universeDomain;

--- a/baselines/disable-packing-test/test/gapic_identity_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_identity_v1beta1.ts.baseline
@@ -101,18 +101,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v1beta1.IdentityClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new identityModule.v1beta1.IdentityClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost');
-        });
-
         it('has apiEndpoint', () => {
             const client = new identityModule.v1beta1.IdentityClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'localhost');
         });
-        
+
         it('has universeDomain', () => {
             const client = new identityModule.v1beta1.IdentityClient();
             const universeDomain = client.universeDomain;

--- a/baselines/disable-packing-test/test/gapic_messaging_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_messaging_v1beta1.ts.baseline
@@ -150,18 +150,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v1beta1.MessagingClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new messagingModule.v1beta1.MessagingClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost');
-        });
-
         it('has apiEndpoint', () => {
             const client = new messagingModule.v1beta1.MessagingClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'localhost');
         });
-        
+
         it('has universeDomain', () => {
             const client = new messagingModule.v1beta1.MessagingClient();
             const universeDomain = client.universeDomain;

--- a/baselines/disable-packing-test/test/gapic_sequence_service_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_sequence_service_v1beta1.ts.baseline
@@ -54,18 +54,12 @@ function stubSimpleCallWithCallback<ResponseType>(response?: ResponseType, error
 
 describe('v1beta1.SequenceServiceClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new sequenceserviceModule.v1beta1.SequenceServiceClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost');
-        });
-
         it('has apiEndpoint', () => {
             const client = new sequenceserviceModule.v1beta1.SequenceServiceClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'localhost');
         });
-        
+
         it('has universeDomain', () => {
             const client = new sequenceserviceModule.v1beta1.SequenceServiceClient();
             const universeDomain = client.universeDomain;

--- a/baselines/disable-packing-test/test/gapic_testing_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_testing_v1beta1.ts.baseline
@@ -101,18 +101,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v1beta1.TestingClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new testingModule.v1beta1.TestingClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost');
-        });
-
         it('has apiEndpoint', () => {
             const client = new testingModule.v1beta1.TestingClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'localhost');
         });
-        
+
         it('has universeDomain', () => {
             const client = new testingModule.v1beta1.TestingClient();
             const universeDomain = client.universeDomain;

--- a/baselines/dlp-esm/esm/src/v2/dlp_service_client.ts.baseline
+++ b/baselines/dlp-esm/esm/src/v2/dlp_service_client.ts.baseline
@@ -317,7 +317,7 @@ export class DlpServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -330,7 +330,7 @@ export class DlpServiceClient {
   /**
    * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -342,14 +342,6 @@ export class DlpServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/dlp-esm/esm/test/gapic_dlp_service_v2.ts.baseline
+++ b/baselines/dlp-esm/esm/test/gapic_dlp_service_v2.ts.baseline
@@ -110,18 +110,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v2.DlpServiceClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new dlpserviceModule.v2.DlpServiceClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'dlp.googleapis.com');
-        });
-
         it('has apiEndpoint', () => {
             const client = new dlpserviceModule.v2.DlpServiceClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'dlp.googleapis.com');
         });
-        
+
         it('has universeDomain', () => {
             const client = new dlpserviceModule.v2.DlpServiceClient();
             const universeDomain = client.universeDomain;

--- a/baselines/dlp-esm/esm/test/gapic_dlp_service_v2.ts.baseline
+++ b/baselines/dlp-esm/esm/test/gapic_dlp_service_v2.ts.baseline
@@ -139,15 +139,15 @@ describe('v2.DlpServiceClient', () => {
                 stub.restore();
             });
         }
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new dlpserviceModule.v2.DlpServiceClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'dlp.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new dlpserviceModule.v2.DlpServiceClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'dlp.example.com');
         });
         it('does not allow setting both universeDomain and universe_domain', () => {

--- a/baselines/dlp/src/v2/dlp_service_client.ts.baseline
+++ b/baselines/dlp/src/v2/dlp_service_client.ts.baseline
@@ -301,7 +301,7 @@ export class DlpServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -312,9 +312,8 @@ export class DlpServiceClient {
   }
 
   /**
-   * The DNS address for this API service - same as servicePath,
-   * exists for compatibility reasons.
-   * @deprecated
+   * The DNS address for this API service - same as servicePath.
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -326,14 +325,6 @@ export class DlpServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/dlp/test/gapic_dlp_service_v2.ts.baseline
+++ b/baselines/dlp/test/gapic_dlp_service_v2.ts.baseline
@@ -130,15 +130,15 @@ describe('v2.DlpServiceClient', () => {
                 stub.restore();
             });
         }
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new dlpserviceModule.v2.DlpServiceClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'dlp.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new dlpserviceModule.v2.DlpServiceClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'dlp.example.com');
         });
         it('does not allow setting both universeDomain and universe_domain', () => {

--- a/baselines/dlp/test/gapic_dlp_service_v2.ts.baseline
+++ b/baselines/dlp/test/gapic_dlp_service_v2.ts.baseline
@@ -101,18 +101,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v2.DlpServiceClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new dlpserviceModule.v2.DlpServiceClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'dlp.googleapis.com');
-        });
-
         it('has apiEndpoint', () => {
             const client = new dlpserviceModule.v2.DlpServiceClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'dlp.googleapis.com');
         });
-        
+
         it('has universeDomain', () => {
             const client = new dlpserviceModule.v2.DlpServiceClient();
             const universeDomain = client.universeDomain;

--- a/baselines/kms-esm/esm/src/v1/key_management_service_client.ts.baseline
+++ b/baselines/kms-esm/esm/src/v1/key_management_service_client.ts.baseline
@@ -283,7 +283,7 @@ export class KeyManagementServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -296,7 +296,7 @@ export class KeyManagementServiceClient {
   /**
    * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -308,14 +308,6 @@ export class KeyManagementServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/kms-esm/esm/test/gapic_key_management_service_v1.ts.baseline
+++ b/baselines/kms-esm/esm/test/gapic_key_management_service_v1.ts.baseline
@@ -110,18 +110,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v1.KeyManagementServiceClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new keymanagementserviceModule.v1.KeyManagementServiceClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'cloudkms.googleapis.com');
-        });
-
         it('has apiEndpoint', () => {
             const client = new keymanagementserviceModule.v1.KeyManagementServiceClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'cloudkms.googleapis.com');
         });
-        
+
         it('has universeDomain', () => {
             const client = new keymanagementserviceModule.v1.KeyManagementServiceClient();
             const universeDomain = client.universeDomain;

--- a/baselines/kms-esm/esm/test/gapic_key_management_service_v1.ts.baseline
+++ b/baselines/kms-esm/esm/test/gapic_key_management_service_v1.ts.baseline
@@ -139,15 +139,15 @@ describe('v1.KeyManagementServiceClient', () => {
                 stub.restore();
             });
         }
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new keymanagementserviceModule.v1.KeyManagementServiceClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'cloudkms.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new keymanagementserviceModule.v1.KeyManagementServiceClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'cloudkms.example.com');
         });
         it('does not allow setting both universeDomain and universe_domain', () => {

--- a/baselines/kms/src/v1/key_management_service_client.ts.baseline
+++ b/baselines/kms/src/v1/key_management_service_client.ts.baseline
@@ -267,7 +267,7 @@ export class KeyManagementServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -278,9 +278,8 @@ export class KeyManagementServiceClient {
   }
 
   /**
-   * The DNS address for this API service - same as servicePath,
-   * exists for compatibility reasons.
-   * @deprecated
+   * The DNS address for this API service - same as servicePath.
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -292,14 +291,6 @@ export class KeyManagementServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/kms/test/gapic_key_management_service_v1.ts.baseline
+++ b/baselines/kms/test/gapic_key_management_service_v1.ts.baseline
@@ -101,18 +101,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v1.KeyManagementServiceClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new keymanagementserviceModule.v1.KeyManagementServiceClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'cloudkms.googleapis.com');
-        });
-
         it('has apiEndpoint', () => {
             const client = new keymanagementserviceModule.v1.KeyManagementServiceClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'cloudkms.googleapis.com');
         });
-        
+
         it('has universeDomain', () => {
             const client = new keymanagementserviceModule.v1.KeyManagementServiceClient();
             const universeDomain = client.universeDomain;

--- a/baselines/kms/test/gapic_key_management_service_v1.ts.baseline
+++ b/baselines/kms/test/gapic_key_management_service_v1.ts.baseline
@@ -130,15 +130,15 @@ describe('v1.KeyManagementServiceClient', () => {
                 stub.restore();
             });
         }
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new keymanagementserviceModule.v1.KeyManagementServiceClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'cloudkms.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new keymanagementserviceModule.v1.KeyManagementServiceClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'cloudkms.example.com');
         });
         it('does not allow setting both universeDomain and universe_domain', () => {

--- a/baselines/logging-esm/esm/src/v2/config_service_v2_client.ts.baseline
+++ b/baselines/logging-esm/esm/src/v2/config_service_v2_client.ts.baseline
@@ -397,7 +397,7 @@ export class ConfigServiceV2Client {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -410,7 +410,7 @@ export class ConfigServiceV2Client {
   /**
    * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -422,14 +422,6 @@ export class ConfigServiceV2Client {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/logging-esm/esm/src/v2/logging_service_v2_client.ts.baseline
+++ b/baselines/logging-esm/esm/src/v2/logging_service_v2_client.ts.baseline
@@ -396,7 +396,7 @@ export class LoggingServiceV2Client {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -409,7 +409,7 @@ export class LoggingServiceV2Client {
   /**
    * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -421,14 +421,6 @@ export class LoggingServiceV2Client {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/logging-esm/esm/src/v2/metrics_service_v2_client.ts.baseline
+++ b/baselines/logging-esm/esm/src/v2/metrics_service_v2_client.ts.baseline
@@ -361,7 +361,7 @@ export class MetricsServiceV2Client {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -374,7 +374,7 @@ export class MetricsServiceV2Client {
   /**
    * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -386,14 +386,6 @@ export class MetricsServiceV2Client {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/logging-esm/esm/test/gapic_config_service_v2_v2.ts.baseline
+++ b/baselines/logging-esm/esm/test/gapic_config_service_v2_v2.ts.baseline
@@ -126,18 +126,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v2.ConfigServiceV2Client', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new configservicev2Module.v2.ConfigServiceV2Client();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'logging.googleapis.com');
-        });
-
         it('has apiEndpoint', () => {
             const client = new configservicev2Module.v2.ConfigServiceV2Client();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'logging.googleapis.com');
         });
-        
+
         it('has universeDomain', () => {
             const client = new configservicev2Module.v2.ConfigServiceV2Client();
             const universeDomain = client.universeDomain;

--- a/baselines/logging-esm/esm/test/gapic_config_service_v2_v2.ts.baseline
+++ b/baselines/logging-esm/esm/test/gapic_config_service_v2_v2.ts.baseline
@@ -155,15 +155,15 @@ describe('v2.ConfigServiceV2Client', () => {
                 stub.restore();
             });
         }
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new configservicev2Module.v2.ConfigServiceV2Client({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'logging.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new configservicev2Module.v2.ConfigServiceV2Client({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'logging.example.com');
         });
         it('does not allow setting both universeDomain and universe_domain', () => {

--- a/baselines/logging-esm/esm/test/gapic_logging_service_v2_v2.ts.baseline
+++ b/baselines/logging-esm/esm/test/gapic_logging_service_v2_v2.ts.baseline
@@ -148,15 +148,15 @@ describe('v2.LoggingServiceV2Client', () => {
                 stub.restore();
             });
         }
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new loggingservicev2Module.v2.LoggingServiceV2Client({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'logging.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new loggingservicev2Module.v2.LoggingServiceV2Client({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'logging.example.com');
         });
         it('does not allow setting both universeDomain and universe_domain', () => {

--- a/baselines/logging-esm/esm/test/gapic_logging_service_v2_v2.ts.baseline
+++ b/baselines/logging-esm/esm/test/gapic_logging_service_v2_v2.ts.baseline
@@ -119,18 +119,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v2.LoggingServiceV2Client', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new loggingservicev2Module.v2.LoggingServiceV2Client();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'logging.googleapis.com');
-        });
-
         it('has apiEndpoint', () => {
             const client = new loggingservicev2Module.v2.LoggingServiceV2Client();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'logging.googleapis.com');
         });
-        
+
         it('has universeDomain', () => {
             const client = new loggingservicev2Module.v2.LoggingServiceV2Client();
             const universeDomain = client.universeDomain;

--- a/baselines/logging-esm/esm/test/gapic_metrics_service_v2_v2.ts.baseline
+++ b/baselines/logging-esm/esm/test/gapic_metrics_service_v2_v2.ts.baseline
@@ -139,15 +139,15 @@ describe('v2.MetricsServiceV2Client', () => {
                 stub.restore();
             });
         }
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new metricsservicev2Module.v2.MetricsServiceV2Client({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'logging.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new metricsservicev2Module.v2.MetricsServiceV2Client({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'logging.example.com');
         });
         it('does not allow setting both universeDomain and universe_domain', () => {

--- a/baselines/logging-esm/esm/test/gapic_metrics_service_v2_v2.ts.baseline
+++ b/baselines/logging-esm/esm/test/gapic_metrics_service_v2_v2.ts.baseline
@@ -110,18 +110,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v2.MetricsServiceV2Client', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new metricsservicev2Module.v2.MetricsServiceV2Client();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'logging.googleapis.com');
-        });
-
         it('has apiEndpoint', () => {
             const client = new metricsservicev2Module.v2.MetricsServiceV2Client();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'logging.googleapis.com');
         });
-        
+
         it('has universeDomain', () => {
             const client = new metricsservicev2Module.v2.MetricsServiceV2Client();
             const universeDomain = client.universeDomain;

--- a/baselines/logging/src/v2/config_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/config_service_v2_client.ts.baseline
@@ -381,7 +381,7 @@ export class ConfigServiceV2Client {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -392,9 +392,8 @@ export class ConfigServiceV2Client {
   }
 
   /**
-   * The DNS address for this API service - same as servicePath,
-   * exists for compatibility reasons.
-   * @deprecated
+   * The DNS address for this API service - same as servicePath.
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -406,14 +405,6 @@ export class ConfigServiceV2Client {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
@@ -380,7 +380,7 @@ export class LoggingServiceV2Client {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -391,9 +391,8 @@ export class LoggingServiceV2Client {
   }
 
   /**
-   * The DNS address for this API service - same as servicePath,
-   * exists for compatibility reasons.
-   * @deprecated
+   * The DNS address for this API service - same as servicePath.
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -405,14 +404,6 @@ export class LoggingServiceV2Client {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/logging/src/v2/metrics_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/metrics_service_v2_client.ts.baseline
@@ -345,7 +345,7 @@ export class MetricsServiceV2Client {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -356,9 +356,8 @@ export class MetricsServiceV2Client {
   }
 
   /**
-   * The DNS address for this API service - same as servicePath,
-   * exists for compatibility reasons.
-   * @deprecated
+   * The DNS address for this API service - same as servicePath.
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -370,14 +369,6 @@ export class MetricsServiceV2Client {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/logging/test/gapic_config_service_v2_v2.ts.baseline
+++ b/baselines/logging/test/gapic_config_service_v2_v2.ts.baseline
@@ -117,18 +117,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v2.ConfigServiceV2Client', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new configservicev2Module.v2.ConfigServiceV2Client();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'logging.googleapis.com');
-        });
-
         it('has apiEndpoint', () => {
             const client = new configservicev2Module.v2.ConfigServiceV2Client();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'logging.googleapis.com');
         });
-        
+
         it('has universeDomain', () => {
             const client = new configservicev2Module.v2.ConfigServiceV2Client();
             const universeDomain = client.universeDomain;

--- a/baselines/logging/test/gapic_config_service_v2_v2.ts.baseline
+++ b/baselines/logging/test/gapic_config_service_v2_v2.ts.baseline
@@ -146,15 +146,15 @@ describe('v2.ConfigServiceV2Client', () => {
                 stub.restore();
             });
         }
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new configservicev2Module.v2.ConfigServiceV2Client({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'logging.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new configservicev2Module.v2.ConfigServiceV2Client({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'logging.example.com');
         });
         it('does not allow setting both universeDomain and universe_domain', () => {

--- a/baselines/logging/test/gapic_logging_service_v2_v2.ts.baseline
+++ b/baselines/logging/test/gapic_logging_service_v2_v2.ts.baseline
@@ -110,18 +110,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v2.LoggingServiceV2Client', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new loggingservicev2Module.v2.LoggingServiceV2Client();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'logging.googleapis.com');
-        });
-
         it('has apiEndpoint', () => {
             const client = new loggingservicev2Module.v2.LoggingServiceV2Client();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'logging.googleapis.com');
         });
-        
+
         it('has universeDomain', () => {
             const client = new loggingservicev2Module.v2.LoggingServiceV2Client();
             const universeDomain = client.universeDomain;

--- a/baselines/logging/test/gapic_logging_service_v2_v2.ts.baseline
+++ b/baselines/logging/test/gapic_logging_service_v2_v2.ts.baseline
@@ -139,15 +139,15 @@ describe('v2.LoggingServiceV2Client', () => {
                 stub.restore();
             });
         }
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new loggingservicev2Module.v2.LoggingServiceV2Client({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'logging.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new loggingservicev2Module.v2.LoggingServiceV2Client({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'logging.example.com');
         });
         it('does not allow setting both universeDomain and universe_domain', () => {

--- a/baselines/logging/test/gapic_metrics_service_v2_v2.ts.baseline
+++ b/baselines/logging/test/gapic_metrics_service_v2_v2.ts.baseline
@@ -101,18 +101,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v2.MetricsServiceV2Client', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new metricsservicev2Module.v2.MetricsServiceV2Client();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'logging.googleapis.com');
-        });
-
         it('has apiEndpoint', () => {
             const client = new metricsservicev2Module.v2.MetricsServiceV2Client();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'logging.googleapis.com');
         });
-        
+
         it('has universeDomain', () => {
             const client = new metricsservicev2Module.v2.MetricsServiceV2Client();
             const universeDomain = client.universeDomain;

--- a/baselines/logging/test/gapic_metrics_service_v2_v2.ts.baseline
+++ b/baselines/logging/test/gapic_metrics_service_v2_v2.ts.baseline
@@ -130,15 +130,15 @@ describe('v2.MetricsServiceV2Client', () => {
                 stub.restore();
             });
         }
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new metricsservicev2Module.v2.MetricsServiceV2Client({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'logging.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new metricsservicev2Module.v2.MetricsServiceV2Client({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'logging.example.com');
         });
         it('does not allow setting both universeDomain and universe_domain', () => {

--- a/baselines/monitoring-esm/esm/src/v3/alert_policy_service_client.ts.baseline
+++ b/baselines/monitoring-esm/esm/src/v3/alert_policy_service_client.ts.baseline
@@ -351,7 +351,7 @@ export class AlertPolicyServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -364,7 +364,7 @@ export class AlertPolicyServiceClient {
   /**
    * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -376,14 +376,6 @@ export class AlertPolicyServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/monitoring-esm/esm/src/v3/group_service_client.ts.baseline
+++ b/baselines/monitoring-esm/esm/src/v3/group_service_client.ts.baseline
@@ -356,7 +356,7 @@ export class GroupServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -369,7 +369,7 @@ export class GroupServiceClient {
   /**
    * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -381,14 +381,6 @@ export class GroupServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/monitoring-esm/esm/src/v3/metric_service_client.ts.baseline
+++ b/baselines/monitoring-esm/esm/src/v3/metric_service_client.ts.baseline
@@ -366,7 +366,7 @@ export class MetricServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -379,7 +379,7 @@ export class MetricServiceClient {
   /**
    * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -391,14 +391,6 @@ export class MetricServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/monitoring-esm/esm/src/v3/notification_channel_service_client.ts.baseline
+++ b/baselines/monitoring-esm/esm/src/v3/notification_channel_service_client.ts.baseline
@@ -346,7 +346,7 @@ export class NotificationChannelServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -359,7 +359,7 @@ export class NotificationChannelServiceClient {
   /**
    * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -371,14 +371,6 @@ export class NotificationChannelServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/monitoring-esm/esm/src/v3/service_monitoring_service_client.ts.baseline
+++ b/baselines/monitoring-esm/esm/src/v3/service_monitoring_service_client.ts.baseline
@@ -348,7 +348,7 @@ export class ServiceMonitoringServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -361,7 +361,7 @@ export class ServiceMonitoringServiceClient {
   /**
    * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -373,14 +373,6 @@ export class ServiceMonitoringServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/monitoring-esm/esm/src/v3/uptime_check_service_client.ts.baseline
+++ b/baselines/monitoring-esm/esm/src/v3/uptime_check_service_client.ts.baseline
@@ -352,7 +352,7 @@ export class UptimeCheckServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -365,7 +365,7 @@ export class UptimeCheckServiceClient {
   /**
    * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -377,14 +377,6 @@ export class UptimeCheckServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/monitoring-esm/esm/test/gapic_alert_policy_service_v3.ts.baseline
+++ b/baselines/monitoring-esm/esm/test/gapic_alert_policy_service_v3.ts.baseline
@@ -139,15 +139,15 @@ describe('v3.AlertPolicyServiceClient', () => {
                 stub.restore();
             });
         }
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new alertpolicyserviceModule.v3.AlertPolicyServiceClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'monitoring.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new alertpolicyserviceModule.v3.AlertPolicyServiceClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'monitoring.example.com');
         });
         it('does not allow setting both universeDomain and universe_domain', () => {

--- a/baselines/monitoring-esm/esm/test/gapic_alert_policy_service_v3.ts.baseline
+++ b/baselines/monitoring-esm/esm/test/gapic_alert_policy_service_v3.ts.baseline
@@ -110,18 +110,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v3.AlertPolicyServiceClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new alertpolicyserviceModule.v3.AlertPolicyServiceClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'monitoring.googleapis.com');
-        });
-
         it('has apiEndpoint', () => {
             const client = new alertpolicyserviceModule.v3.AlertPolicyServiceClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'monitoring.googleapis.com');
         });
-        
+
         it('has universeDomain', () => {
             const client = new alertpolicyserviceModule.v3.AlertPolicyServiceClient();
             const universeDomain = client.universeDomain;

--- a/baselines/monitoring-esm/esm/test/gapic_group_service_v3.ts.baseline
+++ b/baselines/monitoring-esm/esm/test/gapic_group_service_v3.ts.baseline
@@ -110,18 +110,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v3.GroupServiceClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new groupserviceModule.v3.GroupServiceClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'monitoring.googleapis.com');
-        });
-
         it('has apiEndpoint', () => {
             const client = new groupserviceModule.v3.GroupServiceClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'monitoring.googleapis.com');
         });
-        
+
         it('has universeDomain', () => {
             const client = new groupserviceModule.v3.GroupServiceClient();
             const universeDomain = client.universeDomain;

--- a/baselines/monitoring-esm/esm/test/gapic_group_service_v3.ts.baseline
+++ b/baselines/monitoring-esm/esm/test/gapic_group_service_v3.ts.baseline
@@ -139,15 +139,15 @@ describe('v3.GroupServiceClient', () => {
                 stub.restore();
             });
         }
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new groupserviceModule.v3.GroupServiceClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'monitoring.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new groupserviceModule.v3.GroupServiceClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'monitoring.example.com');
         });
         it('does not allow setting both universeDomain and universe_domain', () => {

--- a/baselines/monitoring-esm/esm/test/gapic_metric_service_v3.ts.baseline
+++ b/baselines/monitoring-esm/esm/test/gapic_metric_service_v3.ts.baseline
@@ -110,18 +110,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v3.MetricServiceClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new metricserviceModule.v3.MetricServiceClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'monitoring.googleapis.com');
-        });
-
         it('has apiEndpoint', () => {
             const client = new metricserviceModule.v3.MetricServiceClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'monitoring.googleapis.com');
         });
-        
+
         it('has universeDomain', () => {
             const client = new metricserviceModule.v3.MetricServiceClient();
             const universeDomain = client.universeDomain;

--- a/baselines/monitoring-esm/esm/test/gapic_metric_service_v3.ts.baseline
+++ b/baselines/monitoring-esm/esm/test/gapic_metric_service_v3.ts.baseline
@@ -139,15 +139,15 @@ describe('v3.MetricServiceClient', () => {
                 stub.restore();
             });
         }
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new metricserviceModule.v3.MetricServiceClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'monitoring.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new metricserviceModule.v3.MetricServiceClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'monitoring.example.com');
         });
         it('does not allow setting both universeDomain and universe_domain', () => {

--- a/baselines/monitoring-esm/esm/test/gapic_notification_channel_service_v3.ts.baseline
+++ b/baselines/monitoring-esm/esm/test/gapic_notification_channel_service_v3.ts.baseline
@@ -110,18 +110,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v3.NotificationChannelServiceClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new notificationchannelserviceModule.v3.NotificationChannelServiceClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'monitoring.googleapis.com');
-        });
-
         it('has apiEndpoint', () => {
             const client = new notificationchannelserviceModule.v3.NotificationChannelServiceClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'monitoring.googleapis.com');
         });
-        
+
         it('has universeDomain', () => {
             const client = new notificationchannelserviceModule.v3.NotificationChannelServiceClient();
             const universeDomain = client.universeDomain;

--- a/baselines/monitoring-esm/esm/test/gapic_notification_channel_service_v3.ts.baseline
+++ b/baselines/monitoring-esm/esm/test/gapic_notification_channel_service_v3.ts.baseline
@@ -139,15 +139,15 @@ describe('v3.NotificationChannelServiceClient', () => {
                 stub.restore();
             });
         }
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new notificationchannelserviceModule.v3.NotificationChannelServiceClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'monitoring.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new notificationchannelserviceModule.v3.NotificationChannelServiceClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'monitoring.example.com');
         });
         it('does not allow setting both universeDomain and universe_domain', () => {

--- a/baselines/monitoring-esm/esm/test/gapic_service_monitoring_service_v3.ts.baseline
+++ b/baselines/monitoring-esm/esm/test/gapic_service_monitoring_service_v3.ts.baseline
@@ -139,15 +139,15 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 stub.restore();
             });
         }
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new servicemonitoringserviceModule.v3.ServiceMonitoringServiceClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'monitoring.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new servicemonitoringserviceModule.v3.ServiceMonitoringServiceClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'monitoring.example.com');
         });
         it('does not allow setting both universeDomain and universe_domain', () => {

--- a/baselines/monitoring-esm/esm/test/gapic_service_monitoring_service_v3.ts.baseline
+++ b/baselines/monitoring-esm/esm/test/gapic_service_monitoring_service_v3.ts.baseline
@@ -110,18 +110,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v3.ServiceMonitoringServiceClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new servicemonitoringserviceModule.v3.ServiceMonitoringServiceClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'monitoring.googleapis.com');
-        });
-
         it('has apiEndpoint', () => {
             const client = new servicemonitoringserviceModule.v3.ServiceMonitoringServiceClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'monitoring.googleapis.com');
         });
-        
+
         it('has universeDomain', () => {
             const client = new servicemonitoringserviceModule.v3.ServiceMonitoringServiceClient();
             const universeDomain = client.universeDomain;

--- a/baselines/monitoring-esm/esm/test/gapic_uptime_check_service_v3.ts.baseline
+++ b/baselines/monitoring-esm/esm/test/gapic_uptime_check_service_v3.ts.baseline
@@ -110,18 +110,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v3.UptimeCheckServiceClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new uptimecheckserviceModule.v3.UptimeCheckServiceClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'monitoring.googleapis.com');
-        });
-
         it('has apiEndpoint', () => {
             const client = new uptimecheckserviceModule.v3.UptimeCheckServiceClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'monitoring.googleapis.com');
         });
-        
+
         it('has universeDomain', () => {
             const client = new uptimecheckserviceModule.v3.UptimeCheckServiceClient();
             const universeDomain = client.universeDomain;

--- a/baselines/monitoring-esm/esm/test/gapic_uptime_check_service_v3.ts.baseline
+++ b/baselines/monitoring-esm/esm/test/gapic_uptime_check_service_v3.ts.baseline
@@ -139,15 +139,15 @@ describe('v3.UptimeCheckServiceClient', () => {
                 stub.restore();
             });
         }
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new uptimecheckserviceModule.v3.UptimeCheckServiceClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'monitoring.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new uptimecheckserviceModule.v3.UptimeCheckServiceClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'monitoring.example.com');
         });
         it('does not allow setting both universeDomain and universe_domain', () => {

--- a/baselines/monitoring/src/v3/alert_policy_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/alert_policy_service_client.ts.baseline
@@ -335,7 +335,7 @@ export class AlertPolicyServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -346,9 +346,8 @@ export class AlertPolicyServiceClient {
   }
 
   /**
-   * The DNS address for this API service - same as servicePath,
-   * exists for compatibility reasons.
-   * @deprecated
+   * The DNS address for this API service - same as servicePath.
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -360,14 +359,6 @@ export class AlertPolicyServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/monitoring/src/v3/group_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/group_service_client.ts.baseline
@@ -340,7 +340,7 @@ export class GroupServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -351,9 +351,8 @@ export class GroupServiceClient {
   }
 
   /**
-   * The DNS address for this API service - same as servicePath,
-   * exists for compatibility reasons.
-   * @deprecated
+   * The DNS address for this API service - same as servicePath.
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -365,14 +364,6 @@ export class GroupServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/monitoring/src/v3/metric_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/metric_service_client.ts.baseline
@@ -350,7 +350,7 @@ export class MetricServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -361,9 +361,8 @@ export class MetricServiceClient {
   }
 
   /**
-   * The DNS address for this API service - same as servicePath,
-   * exists for compatibility reasons.
-   * @deprecated
+   * The DNS address for this API service - same as servicePath.
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -375,14 +374,6 @@ export class MetricServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/monitoring/src/v3/notification_channel_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/notification_channel_service_client.ts.baseline
@@ -330,7 +330,7 @@ export class NotificationChannelServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -341,9 +341,8 @@ export class NotificationChannelServiceClient {
   }
 
   /**
-   * The DNS address for this API service - same as servicePath,
-   * exists for compatibility reasons.
-   * @deprecated
+   * The DNS address for this API service - same as servicePath.
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -355,14 +354,6 @@ export class NotificationChannelServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/monitoring/src/v3/service_monitoring_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/service_monitoring_service_client.ts.baseline
@@ -332,7 +332,7 @@ export class ServiceMonitoringServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -343,9 +343,8 @@ export class ServiceMonitoringServiceClient {
   }
 
   /**
-   * The DNS address for this API service - same as servicePath,
-   * exists for compatibility reasons.
-   * @deprecated
+   * The DNS address for this API service - same as servicePath.
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -357,14 +356,6 @@ export class ServiceMonitoringServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/monitoring/src/v3/uptime_check_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/uptime_check_service_client.ts.baseline
@@ -336,7 +336,7 @@ export class UptimeCheckServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -347,9 +347,8 @@ export class UptimeCheckServiceClient {
   }
 
   /**
-   * The DNS address for this API service - same as servicePath,
-   * exists for compatibility reasons.
-   * @deprecated
+   * The DNS address for this API service - same as servicePath.
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -361,14 +360,6 @@ export class UptimeCheckServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/monitoring/test/gapic_alert_policy_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_alert_policy_service_v3.ts.baseline
@@ -101,18 +101,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v3.AlertPolicyServiceClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new alertpolicyserviceModule.v3.AlertPolicyServiceClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'monitoring.googleapis.com');
-        });
-
         it('has apiEndpoint', () => {
             const client = new alertpolicyserviceModule.v3.AlertPolicyServiceClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'monitoring.googleapis.com');
         });
-        
+
         it('has universeDomain', () => {
             const client = new alertpolicyserviceModule.v3.AlertPolicyServiceClient();
             const universeDomain = client.universeDomain;

--- a/baselines/monitoring/test/gapic_alert_policy_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_alert_policy_service_v3.ts.baseline
@@ -130,15 +130,15 @@ describe('v3.AlertPolicyServiceClient', () => {
                 stub.restore();
             });
         }
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new alertpolicyserviceModule.v3.AlertPolicyServiceClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'monitoring.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new alertpolicyserviceModule.v3.AlertPolicyServiceClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'monitoring.example.com');
         });
         it('does not allow setting both universeDomain and universe_domain', () => {

--- a/baselines/monitoring/test/gapic_group_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_group_service_v3.ts.baseline
@@ -101,18 +101,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v3.GroupServiceClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new groupserviceModule.v3.GroupServiceClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'monitoring.googleapis.com');
-        });
-
         it('has apiEndpoint', () => {
             const client = new groupserviceModule.v3.GroupServiceClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'monitoring.googleapis.com');
         });
-        
+
         it('has universeDomain', () => {
             const client = new groupserviceModule.v3.GroupServiceClient();
             const universeDomain = client.universeDomain;

--- a/baselines/monitoring/test/gapic_group_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_group_service_v3.ts.baseline
@@ -130,15 +130,15 @@ describe('v3.GroupServiceClient', () => {
                 stub.restore();
             });
         }
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new groupserviceModule.v3.GroupServiceClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'monitoring.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new groupserviceModule.v3.GroupServiceClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'monitoring.example.com');
         });
         it('does not allow setting both universeDomain and universe_domain', () => {

--- a/baselines/monitoring/test/gapic_metric_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_metric_service_v3.ts.baseline
@@ -130,15 +130,15 @@ describe('v3.MetricServiceClient', () => {
                 stub.restore();
             });
         }
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new metricserviceModule.v3.MetricServiceClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'monitoring.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new metricserviceModule.v3.MetricServiceClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'monitoring.example.com');
         });
         it('does not allow setting both universeDomain and universe_domain', () => {

--- a/baselines/monitoring/test/gapic_metric_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_metric_service_v3.ts.baseline
@@ -101,18 +101,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v3.MetricServiceClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new metricserviceModule.v3.MetricServiceClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'monitoring.googleapis.com');
-        });
-
         it('has apiEndpoint', () => {
             const client = new metricserviceModule.v3.MetricServiceClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'monitoring.googleapis.com');
         });
-        
+
         it('has universeDomain', () => {
             const client = new metricserviceModule.v3.MetricServiceClient();
             const universeDomain = client.universeDomain;

--- a/baselines/monitoring/test/gapic_notification_channel_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_notification_channel_service_v3.ts.baseline
@@ -130,15 +130,15 @@ describe('v3.NotificationChannelServiceClient', () => {
                 stub.restore();
             });
         }
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new notificationchannelserviceModule.v3.NotificationChannelServiceClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'monitoring.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new notificationchannelserviceModule.v3.NotificationChannelServiceClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'monitoring.example.com');
         });
         it('does not allow setting both universeDomain and universe_domain', () => {

--- a/baselines/monitoring/test/gapic_notification_channel_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_notification_channel_service_v3.ts.baseline
@@ -101,18 +101,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v3.NotificationChannelServiceClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new notificationchannelserviceModule.v3.NotificationChannelServiceClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'monitoring.googleapis.com');
-        });
-
         it('has apiEndpoint', () => {
             const client = new notificationchannelserviceModule.v3.NotificationChannelServiceClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'monitoring.googleapis.com');
         });
-        
+
         it('has universeDomain', () => {
             const client = new notificationchannelserviceModule.v3.NotificationChannelServiceClient();
             const universeDomain = client.universeDomain;

--- a/baselines/monitoring/test/gapic_service_monitoring_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_service_monitoring_service_v3.ts.baseline
@@ -101,18 +101,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v3.ServiceMonitoringServiceClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new servicemonitoringserviceModule.v3.ServiceMonitoringServiceClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'monitoring.googleapis.com');
-        });
-
         it('has apiEndpoint', () => {
             const client = new servicemonitoringserviceModule.v3.ServiceMonitoringServiceClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'monitoring.googleapis.com');
         });
-        
+
         it('has universeDomain', () => {
             const client = new servicemonitoringserviceModule.v3.ServiceMonitoringServiceClient();
             const universeDomain = client.universeDomain;

--- a/baselines/monitoring/test/gapic_service_monitoring_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_service_monitoring_service_v3.ts.baseline
@@ -130,15 +130,15 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 stub.restore();
             });
         }
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new servicemonitoringserviceModule.v3.ServiceMonitoringServiceClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'monitoring.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new servicemonitoringserviceModule.v3.ServiceMonitoringServiceClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'monitoring.example.com');
         });
         it('does not allow setting both universeDomain and universe_domain', () => {

--- a/baselines/monitoring/test/gapic_uptime_check_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_uptime_check_service_v3.ts.baseline
@@ -101,18 +101,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v3.UptimeCheckServiceClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new uptimecheckserviceModule.v3.UptimeCheckServiceClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'monitoring.googleapis.com');
-        });
-
         it('has apiEndpoint', () => {
             const client = new uptimecheckserviceModule.v3.UptimeCheckServiceClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'monitoring.googleapis.com');
         });
-        
+
         it('has universeDomain', () => {
             const client = new uptimecheckserviceModule.v3.UptimeCheckServiceClient();
             const universeDomain = client.universeDomain;

--- a/baselines/monitoring/test/gapic_uptime_check_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_uptime_check_service_v3.ts.baseline
@@ -130,15 +130,15 @@ describe('v3.UptimeCheckServiceClient', () => {
                 stub.restore();
             });
         }
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new uptimecheckserviceModule.v3.UptimeCheckServiceClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'monitoring.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new uptimecheckserviceModule.v3.UptimeCheckServiceClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'monitoring.example.com');
         });
         it('does not allow setting both universeDomain and universe_domain', () => {

--- a/baselines/naming-esm/esm/src/v1beta1/naming_client.ts.baseline
+++ b/baselines/naming-esm/esm/src/v1beta1/naming_client.ts.baseline
@@ -304,7 +304,7 @@ export class NamingClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint1 method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath1() {
@@ -317,7 +317,7 @@ export class NamingClient {
   /**
    * The DNS address for this API service - same as servicePath1,
    * exists for compatibility reasons.
-   * @deprecated
+   * @deprecated Use the apiEndpoint1 method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint1() {
@@ -329,14 +329,6 @@ export class NamingClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath1() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath1().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint1() {

--- a/baselines/naming-esm/esm/test/gapic_naming_v1beta1.ts.baseline
+++ b/baselines/naming-esm/esm/test/gapic_naming_v1beta1.ts.baseline
@@ -126,18 +126,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v1beta1.NamingClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new namingModule.v1beta1.NamingClient();
-            const servicePath = client.servicePath1;
-            assert.strictEqual(servicePath, 'localhost');
-        });
-
         it('has apiEndpoint', () => {
             const client = new namingModule.v1beta1.NamingClient();
             const apiEndpoint = client.apiEndpoint1;
             assert.strictEqual(apiEndpoint, 'localhost');
         });
-        
+
         it('has universeDomain', () => {
             const client = new namingModule.v1beta1.NamingClient();
             const universeDomain = client.universeDomain;

--- a/baselines/naming/src/v1beta1/naming_client.ts.baseline
+++ b/baselines/naming/src/v1beta1/naming_client.ts.baseline
@@ -288,7 +288,7 @@ export class NamingClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint1 method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath1() {
@@ -299,9 +299,8 @@ export class NamingClient {
   }
 
   /**
-   * The DNS address for this API service - same as servicePath1,
-   * exists for compatibility reasons.
-   * @deprecated
+   * The DNS address for this API service - same as servicePath1.
+   * @deprecated Use the apiEndpoint1 method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint1() {
@@ -313,14 +312,6 @@ export class NamingClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath1() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath1().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint1() {

--- a/baselines/naming/test/gapic_naming_v1beta1.ts.baseline
+++ b/baselines/naming/test/gapic_naming_v1beta1.ts.baseline
@@ -117,18 +117,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v1beta1.NamingClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new namingModule.v1beta1.NamingClient();
-            const servicePath = client.servicePath1;
-            assert.strictEqual(servicePath, 'localhost');
-        });
-
         it('has apiEndpoint', () => {
             const client = new namingModule.v1beta1.NamingClient();
             const apiEndpoint = client.apiEndpoint1;
             assert.strictEqual(apiEndpoint, 'localhost');
         });
-        
+
         it('has universeDomain', () => {
             const client = new namingModule.v1beta1.NamingClient();
             const universeDomain = client.universeDomain;

--- a/baselines/redis-esm/esm/src/v1beta1/cloud_redis_client.ts.baseline
+++ b/baselines/redis-esm/esm/src/v1beta1/cloud_redis_client.ts.baseline
@@ -358,7 +358,7 @@ export class CloudRedisClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -371,7 +371,7 @@ export class CloudRedisClient {
   /**
    * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -383,14 +383,6 @@ export class CloudRedisClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/redis-esm/esm/test/gapic_cloud_redis_v1beta1.ts.baseline
+++ b/baselines/redis-esm/esm/test/gapic_cloud_redis_v1beta1.ts.baseline
@@ -155,15 +155,15 @@ describe('v1beta1.CloudRedisClient', () => {
                 stub.restore();
             });
         }
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new cloudredisModule.v1beta1.CloudRedisClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'redis.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new cloudredisModule.v1beta1.CloudRedisClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'redis.example.com');
         });
         it('does not allow setting both universeDomain and universe_domain', () => {

--- a/baselines/redis-esm/esm/test/gapic_cloud_redis_v1beta1.ts.baseline
+++ b/baselines/redis-esm/esm/test/gapic_cloud_redis_v1beta1.ts.baseline
@@ -126,18 +126,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v1beta1.CloudRedisClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new cloudredisModule.v1beta1.CloudRedisClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'redis.googleapis.com');
-        });
-
         it('has apiEndpoint', () => {
             const client = new cloudredisModule.v1beta1.CloudRedisClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'redis.googleapis.com');
         });
-        
+
         it('has universeDomain', () => {
             const client = new cloudredisModule.v1beta1.CloudRedisClient();
             const universeDomain = client.universeDomain;

--- a/baselines/redis/src/v1beta1/cloud_redis_client.ts.baseline
+++ b/baselines/redis/src/v1beta1/cloud_redis_client.ts.baseline
@@ -342,7 +342,7 @@ export class CloudRedisClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -353,9 +353,8 @@ export class CloudRedisClient {
   }
 
   /**
-   * The DNS address for this API service - same as servicePath,
-   * exists for compatibility reasons.
-   * @deprecated
+   * The DNS address for this API service - same as servicePath.
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -367,14 +366,6 @@ export class CloudRedisClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/redis/test/gapic_cloud_redis_v1beta1.ts.baseline
+++ b/baselines/redis/test/gapic_cloud_redis_v1beta1.ts.baseline
@@ -146,15 +146,15 @@ describe('v1beta1.CloudRedisClient', () => {
                 stub.restore();
             });
         }
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new cloudredisModule.v1beta1.CloudRedisClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'redis.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new cloudredisModule.v1beta1.CloudRedisClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'redis.example.com');
         });
         it('does not allow setting both universeDomain and universe_domain', () => {

--- a/baselines/redis/test/gapic_cloud_redis_v1beta1.ts.baseline
+++ b/baselines/redis/test/gapic_cloud_redis_v1beta1.ts.baseline
@@ -117,18 +117,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v1beta1.CloudRedisClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new cloudredisModule.v1beta1.CloudRedisClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'redis.googleapis.com');
-        });
-
         it('has apiEndpoint', () => {
             const client = new cloudredisModule.v1beta1.CloudRedisClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'redis.googleapis.com');
         });
-        
+
         it('has universeDomain', () => {
             const client = new cloudredisModule.v1beta1.CloudRedisClient();
             const universeDomain = client.universeDomain;

--- a/baselines/routingtest-esm/esm/src/v1/test_service_client.ts.baseline
+++ b/baselines/routingtest-esm/esm/src/v1/test_service_client.ts.baseline
@@ -256,7 +256,7 @@ export class TestServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -269,7 +269,7 @@ export class TestServiceClient {
   /**
    * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -281,14 +281,6 @@ export class TestServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/routingtest-esm/esm/test/gapic_test_service_v1.ts.baseline
+++ b/baselines/routingtest-esm/esm/test/gapic_test_service_v1.ts.baseline
@@ -63,18 +63,12 @@ function stubSimpleCallWithCallback<ResponseType>(response?: ResponseType, error
 
 describe('v1.TestServiceClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new testserviceModule.v1.TestServiceClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost');
-        });
-
         it('has apiEndpoint', () => {
             const client = new testserviceModule.v1.TestServiceClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'localhost');
         });
-        
+
         it('has universeDomain', () => {
             const client = new testserviceModule.v1.TestServiceClient();
             const universeDomain = client.universeDomain;

--- a/baselines/routingtest/src/v1/test_service_client.ts.baseline
+++ b/baselines/routingtest/src/v1/test_service_client.ts.baseline
@@ -240,7 +240,7 @@ export class TestServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -251,9 +251,8 @@ export class TestServiceClient {
   }
 
   /**
-   * The DNS address for this API service - same as servicePath,
-   * exists for compatibility reasons.
-   * @deprecated
+   * The DNS address for this API service - same as servicePath.
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -265,14 +264,6 @@ export class TestServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/routingtest/test/gapic_test_service_v1.ts.baseline
+++ b/baselines/routingtest/test/gapic_test_service_v1.ts.baseline
@@ -54,18 +54,12 @@ function stubSimpleCallWithCallback<ResponseType>(response?: ResponseType, error
 
 describe('v1.TestServiceClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new testserviceModule.v1.TestServiceClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost');
-        });
-
         it('has apiEndpoint', () => {
             const client = new testserviceModule.v1.TestServiceClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'localhost');
         });
-        
+
         it('has universeDomain', () => {
             const client = new testserviceModule.v1.TestServiceClient();
             const universeDomain = client.universeDomain;

--- a/baselines/showcase-esm/esm/src/v1beta1/compliance_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/compliance_client.ts.baseline
@@ -300,7 +300,7 @@ export class ComplianceClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -313,7 +313,7 @@ export class ComplianceClient {
   /**
    * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -325,14 +325,6 @@ export class ComplianceClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/showcase-esm/esm/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/echo_client.ts.baseline
@@ -359,7 +359,7 @@ export class EchoClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -372,7 +372,7 @@ export class EchoClient {
   /**
    * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -384,14 +384,6 @@ export class EchoClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/showcase-esm/esm/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/identity_client.ts.baseline
@@ -307,7 +307,7 @@ export class IdentityClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -320,7 +320,7 @@ export class IdentityClient {
   /**
    * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -332,14 +332,6 @@ export class IdentityClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/showcase-esm/esm/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/messaging_client.ts.baseline
@@ -358,7 +358,7 @@ export class MessagingClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -371,7 +371,7 @@ export class MessagingClient {
   /**
    * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -383,14 +383,6 @@ export class MessagingClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/showcase-esm/esm/src/v1beta1/sequence_service_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/sequence_service_client.ts.baseline
@@ -297,7 +297,7 @@ export class SequenceServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -310,7 +310,7 @@ export class SequenceServiceClient {
   /**
    * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -322,14 +322,6 @@ export class SequenceServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/showcase-esm/esm/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/testing_client.ts.baseline
@@ -310,7 +310,7 @@ export class TestingClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -323,7 +323,7 @@ export class TestingClient {
   /**
    * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -335,14 +335,6 @@ export class TestingClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/showcase-esm/esm/test/gapic_compliance_v1beta1.ts.baseline
+++ b/baselines/showcase-esm/esm/test/gapic_compliance_v1beta1.ts.baseline
@@ -63,18 +63,12 @@ function stubSimpleCallWithCallback<ResponseType>(response?: ResponseType, error
 
 describe('v1beta1.ComplianceClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new complianceModule.v1beta1.ComplianceClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost');
-        });
-
         it('has apiEndpoint', () => {
             const client = new complianceModule.v1beta1.ComplianceClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'localhost');
         });
-        
+
         it('has universeDomain', () => {
             const client = new complianceModule.v1beta1.ComplianceClient();
             const universeDomain = client.universeDomain;

--- a/baselines/showcase-esm/esm/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase-esm/esm/test/gapic_echo_v1beta1.ts.baseline
@@ -159,18 +159,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v1beta1.EchoClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new echoModule.v1beta1.EchoClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost');
-        });
-
         it('has apiEndpoint', () => {
             const client = new echoModule.v1beta1.EchoClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'localhost');
         });
-        
+
         it('has universeDomain', () => {
             const client = new echoModule.v1beta1.EchoClient();
             const universeDomain = client.universeDomain;

--- a/baselines/showcase-esm/esm/test/gapic_identity_v1beta1.ts.baseline
+++ b/baselines/showcase-esm/esm/test/gapic_identity_v1beta1.ts.baseline
@@ -110,18 +110,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v1beta1.IdentityClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new identityModule.v1beta1.IdentityClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost');
-        });
-
         it('has apiEndpoint', () => {
             const client = new identityModule.v1beta1.IdentityClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'localhost');
         });
-        
+
         it('has universeDomain', () => {
             const client = new identityModule.v1beta1.IdentityClient();
             const universeDomain = client.universeDomain;

--- a/baselines/showcase-esm/esm/test/gapic_messaging_v1beta1.ts.baseline
+++ b/baselines/showcase-esm/esm/test/gapic_messaging_v1beta1.ts.baseline
@@ -159,18 +159,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v1beta1.MessagingClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new messagingModule.v1beta1.MessagingClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost');
-        });
-
         it('has apiEndpoint', () => {
             const client = new messagingModule.v1beta1.MessagingClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'localhost');
         });
-        
+
         it('has universeDomain', () => {
             const client = new messagingModule.v1beta1.MessagingClient();
             const universeDomain = client.universeDomain;

--- a/baselines/showcase-esm/esm/test/gapic_sequence_service_v1beta1.ts.baseline
+++ b/baselines/showcase-esm/esm/test/gapic_sequence_service_v1beta1.ts.baseline
@@ -63,18 +63,12 @@ function stubSimpleCallWithCallback<ResponseType>(response?: ResponseType, error
 
 describe('v1beta1.SequenceServiceClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new sequenceserviceModule.v1beta1.SequenceServiceClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost');
-        });
-
         it('has apiEndpoint', () => {
             const client = new sequenceserviceModule.v1beta1.SequenceServiceClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'localhost');
         });
-        
+
         it('has universeDomain', () => {
             const client = new sequenceserviceModule.v1beta1.SequenceServiceClient();
             const universeDomain = client.universeDomain;

--- a/baselines/showcase-esm/esm/test/gapic_testing_v1beta1.ts.baseline
+++ b/baselines/showcase-esm/esm/test/gapic_testing_v1beta1.ts.baseline
@@ -110,18 +110,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v1beta1.TestingClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new testingModule.v1beta1.TestingClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost');
-        });
-
         it('has apiEndpoint', () => {
             const client = new testingModule.v1beta1.TestingClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'localhost');
         });
-        
+
         it('has universeDomain', () => {
             const client = new testingModule.v1beta1.TestingClient();
             const universeDomain = client.universeDomain;

--- a/baselines/showcase-legacy-esm/esm/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase-legacy-esm/esm/src/v1beta1/echo_client.ts.baseline
@@ -290,7 +290,7 @@ export class EchoClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -303,7 +303,7 @@ export class EchoClient {
   /**
    * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -315,14 +315,6 @@ export class EchoClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/showcase-legacy-esm/esm/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase-legacy-esm/esm/test/gapic_echo_v1beta1.ts.baseline
@@ -145,18 +145,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v1beta1.EchoClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new echoModule.v1beta1.EchoClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost');
-        });
-
         it('has apiEndpoint', () => {
             const client = new echoModule.v1beta1.EchoClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'localhost');
         });
-        
+
         it('has universeDomain', () => {
             const client = new echoModule.v1beta1.EchoClient();
             const universeDomain = client.universeDomain;

--- a/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
@@ -276,7 +276,7 @@ export class EchoClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -287,9 +287,8 @@ export class EchoClient {
   }
 
   /**
-   * The DNS address for this API service - same as servicePath,
-   * exists for compatibility reasons.
-   * @deprecated
+   * The DNS address for this API service - same as servicePath.
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -301,14 +300,6 @@ export class EchoClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/showcase-legacy/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase-legacy/test/gapic_echo_v1beta1.ts.baseline
@@ -144,18 +144,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v1beta1.EchoClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new echoModule.v1beta1.EchoClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost');
-        });
-
         it('has apiEndpoint', () => {
             const client = new echoModule.v1beta1.EchoClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'localhost');
         });
-        
+
         it('has universeDomain', () => {
             const client = new echoModule.v1beta1.EchoClient();
             const universeDomain = client.universeDomain;

--- a/baselines/showcase/src/v1beta1/compliance_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/compliance_client.ts.baseline
@@ -284,7 +284,7 @@ export class ComplianceClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -295,9 +295,8 @@ export class ComplianceClient {
   }
 
   /**
-   * The DNS address for this API service - same as servicePath,
-   * exists for compatibility reasons.
-   * @deprecated
+   * The DNS address for this API service - same as servicePath.
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -309,14 +308,6 @@ export class ComplianceClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/showcase/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/echo_client.ts.baseline
@@ -343,7 +343,7 @@ export class EchoClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -354,9 +354,8 @@ export class EchoClient {
   }
 
   /**
-   * The DNS address for this API service - same as servicePath,
-   * exists for compatibility reasons.
-   * @deprecated
+   * The DNS address for this API service - same as servicePath.
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -368,14 +367,6 @@ export class EchoClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/showcase/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/identity_client.ts.baseline
@@ -291,7 +291,7 @@ export class IdentityClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -302,9 +302,8 @@ export class IdentityClient {
   }
 
   /**
-   * The DNS address for this API service - same as servicePath,
-   * exists for compatibility reasons.
-   * @deprecated
+   * The DNS address for this API service - same as servicePath.
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -316,14 +315,6 @@ export class IdentityClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
@@ -342,7 +342,7 @@ export class MessagingClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -353,9 +353,8 @@ export class MessagingClient {
   }
 
   /**
-   * The DNS address for this API service - same as servicePath,
-   * exists for compatibility reasons.
-   * @deprecated
+   * The DNS address for this API service - same as servicePath.
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -367,14 +366,6 @@ export class MessagingClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/showcase/src/v1beta1/sequence_service_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/sequence_service_client.ts.baseline
@@ -281,7 +281,7 @@ export class SequenceServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -292,9 +292,8 @@ export class SequenceServiceClient {
   }
 
   /**
-   * The DNS address for this API service - same as servicePath,
-   * exists for compatibility reasons.
-   * @deprecated
+   * The DNS address for this API service - same as servicePath.
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -306,14 +305,6 @@ export class SequenceServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/showcase/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/testing_client.ts.baseline
@@ -294,7 +294,7 @@ export class TestingClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -305,9 +305,8 @@ export class TestingClient {
   }
 
   /**
-   * The DNS address for this API service - same as servicePath,
-   * exists for compatibility reasons.
-   * @deprecated
+   * The DNS address for this API service - same as servicePath.
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -319,14 +318,6 @@ export class TestingClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/showcase/test/gapic_compliance_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_compliance_v1beta1.ts.baseline
@@ -54,18 +54,12 @@ function stubSimpleCallWithCallback<ResponseType>(response?: ResponseType, error
 
 describe('v1beta1.ComplianceClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new complianceModule.v1beta1.ComplianceClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost');
-        });
-
         it('has apiEndpoint', () => {
             const client = new complianceModule.v1beta1.ComplianceClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'localhost');
         });
-        
+
         it('has universeDomain', () => {
             const client = new complianceModule.v1beta1.ComplianceClient();
             const universeDomain = client.universeDomain;

--- a/baselines/showcase/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_echo_v1beta1.ts.baseline
@@ -150,18 +150,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v1beta1.EchoClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new echoModule.v1beta1.EchoClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost');
-        });
-
         it('has apiEndpoint', () => {
             const client = new echoModule.v1beta1.EchoClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'localhost');
         });
-        
+
         it('has universeDomain', () => {
             const client = new echoModule.v1beta1.EchoClient();
             const universeDomain = client.universeDomain;

--- a/baselines/showcase/test/gapic_identity_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_identity_v1beta1.ts.baseline
@@ -101,18 +101,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v1beta1.IdentityClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new identityModule.v1beta1.IdentityClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost');
-        });
-
         it('has apiEndpoint', () => {
             const client = new identityModule.v1beta1.IdentityClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'localhost');
         });
-        
+
         it('has universeDomain', () => {
             const client = new identityModule.v1beta1.IdentityClient();
             const universeDomain = client.universeDomain;

--- a/baselines/showcase/test/gapic_messaging_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_messaging_v1beta1.ts.baseline
@@ -150,18 +150,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v1beta1.MessagingClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new messagingModule.v1beta1.MessagingClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost');
-        });
-
         it('has apiEndpoint', () => {
             const client = new messagingModule.v1beta1.MessagingClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'localhost');
         });
-        
+
         it('has universeDomain', () => {
             const client = new messagingModule.v1beta1.MessagingClient();
             const universeDomain = client.universeDomain;

--- a/baselines/showcase/test/gapic_sequence_service_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_sequence_service_v1beta1.ts.baseline
@@ -54,18 +54,12 @@ function stubSimpleCallWithCallback<ResponseType>(response?: ResponseType, error
 
 describe('v1beta1.SequenceServiceClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new sequenceserviceModule.v1beta1.SequenceServiceClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost');
-        });
-
         it('has apiEndpoint', () => {
             const client = new sequenceserviceModule.v1beta1.SequenceServiceClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'localhost');
         });
-        
+
         it('has universeDomain', () => {
             const client = new sequenceserviceModule.v1beta1.SequenceServiceClient();
             const universeDomain = client.universeDomain;

--- a/baselines/showcase/test/gapic_testing_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_testing_v1beta1.ts.baseline
@@ -101,18 +101,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v1beta1.TestingClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new testingModule.v1beta1.TestingClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'localhost');
-        });
-
         it('has apiEndpoint', () => {
             const client = new testingModule.v1beta1.TestingClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'localhost');
         });
-        
+
         it('has universeDomain', () => {
             const client = new testingModule.v1beta1.TestingClient();
             const universeDomain = client.universeDomain;

--- a/baselines/tasks-esm/esm/src/v2/cloud_tasks_client.ts.baseline
+++ b/baselines/tasks-esm/esm/src/v2/cloud_tasks_client.ts.baseline
@@ -280,7 +280,7 @@ export class CloudTasksClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -293,7 +293,7 @@ export class CloudTasksClient {
   /**
    * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -305,14 +305,6 @@ export class CloudTasksClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/tasks-esm/esm/test/gapic_cloud_tasks_v2.ts.baseline
+++ b/baselines/tasks-esm/esm/test/gapic_cloud_tasks_v2.ts.baseline
@@ -110,18 +110,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v2.CloudTasksClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new cloudtasksModule.v2.CloudTasksClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'cloudtasks.googleapis.com');
-        });
-
         it('has apiEndpoint', () => {
             const client = new cloudtasksModule.v2.CloudTasksClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'cloudtasks.googleapis.com');
         });
-        
+
         it('has universeDomain', () => {
             const client = new cloudtasksModule.v2.CloudTasksClient();
             const universeDomain = client.universeDomain;

--- a/baselines/tasks-esm/esm/test/gapic_cloud_tasks_v2.ts.baseline
+++ b/baselines/tasks-esm/esm/test/gapic_cloud_tasks_v2.ts.baseline
@@ -139,15 +139,15 @@ describe('v2.CloudTasksClient', () => {
                 stub.restore();
             });
         }
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new cloudtasksModule.v2.CloudTasksClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'cloudtasks.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new cloudtasksModule.v2.CloudTasksClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'cloudtasks.example.com');
         });
         it('does not allow setting both universeDomain and universe_domain', () => {

--- a/baselines/tasks/src/v2/cloud_tasks_client.ts.baseline
+++ b/baselines/tasks/src/v2/cloud_tasks_client.ts.baseline
@@ -264,7 +264,7 @@ export class CloudTasksClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -275,9 +275,8 @@ export class CloudTasksClient {
   }
 
   /**
-   * The DNS address for this API service - same as servicePath,
-   * exists for compatibility reasons.
-   * @deprecated
+   * The DNS address for this API service - same as servicePath.
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -289,14 +288,6 @@ export class CloudTasksClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/tasks/test/gapic_cloud_tasks_v2.ts.baseline
+++ b/baselines/tasks/test/gapic_cloud_tasks_v2.ts.baseline
@@ -101,18 +101,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v2.CloudTasksClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new cloudtasksModule.v2.CloudTasksClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'cloudtasks.googleapis.com');
-        });
-
         it('has apiEndpoint', () => {
             const client = new cloudtasksModule.v2.CloudTasksClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'cloudtasks.googleapis.com');
         });
-        
+
         it('has universeDomain', () => {
             const client = new cloudtasksModule.v2.CloudTasksClient();
             const universeDomain = client.universeDomain;

--- a/baselines/tasks/test/gapic_cloud_tasks_v2.ts.baseline
+++ b/baselines/tasks/test/gapic_cloud_tasks_v2.ts.baseline
@@ -130,15 +130,15 @@ describe('v2.CloudTasksClient', () => {
                 stub.restore();
             });
         }
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new cloudtasksModule.v2.CloudTasksClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'cloudtasks.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new cloudtasksModule.v2.CloudTasksClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'cloudtasks.example.com');
         });
         it('does not allow setting both universeDomain and universe_domain', () => {

--- a/baselines/texttospeech-esm/esm/src/v1/text_to_speech_client.ts.baseline
+++ b/baselines/texttospeech-esm/esm/src/v1/text_to_speech_client.ts.baseline
@@ -255,7 +255,7 @@ export class TextToSpeechClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -268,7 +268,7 @@ export class TextToSpeechClient {
   /**
    * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -280,14 +280,6 @@ export class TextToSpeechClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/texttospeech-esm/esm/test/gapic_text_to_speech_v1.ts.baseline
+++ b/baselines/texttospeech-esm/esm/test/gapic_text_to_speech_v1.ts.baseline
@@ -63,18 +63,12 @@ function stubSimpleCallWithCallback<ResponseType>(response?: ResponseType, error
 
 describe('v1.TextToSpeechClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new texttospeechModule.v1.TextToSpeechClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'texttospeech.googleapis.com');
-        });
-
         it('has apiEndpoint', () => {
             const client = new texttospeechModule.v1.TextToSpeechClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'texttospeech.googleapis.com');
         });
-        
+
         it('has universeDomain', () => {
             const client = new texttospeechModule.v1.TextToSpeechClient();
             const universeDomain = client.universeDomain;

--- a/baselines/texttospeech-esm/esm/test/gapic_text_to_speech_v1.ts.baseline
+++ b/baselines/texttospeech-esm/esm/test/gapic_text_to_speech_v1.ts.baseline
@@ -92,15 +92,15 @@ describe('v1.TextToSpeechClient', () => {
                 stub.restore();
             });
         }
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new texttospeechModule.v1.TextToSpeechClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'texttospeech.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new texttospeechModule.v1.TextToSpeechClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'texttospeech.example.com');
         });
         it('does not allow setting both universeDomain and universe_domain', () => {

--- a/baselines/texttospeech/src/v1/text_to_speech_client.ts.baseline
+++ b/baselines/texttospeech/src/v1/text_to_speech_client.ts.baseline
@@ -239,7 +239,7 @@ export class TextToSpeechClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -250,9 +250,8 @@ export class TextToSpeechClient {
   }
 
   /**
-   * The DNS address for this API service - same as servicePath,
-   * exists for compatibility reasons.
-   * @deprecated
+   * The DNS address for this API service - same as servicePath.
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -264,14 +263,6 @@ export class TextToSpeechClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/texttospeech/test/gapic_text_to_speech_v1.ts.baseline
+++ b/baselines/texttospeech/test/gapic_text_to_speech_v1.ts.baseline
@@ -54,18 +54,12 @@ function stubSimpleCallWithCallback<ResponseType>(response?: ResponseType, error
 
 describe('v1.TextToSpeechClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new texttospeechModule.v1.TextToSpeechClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'texttospeech.googleapis.com');
-        });
-
         it('has apiEndpoint', () => {
             const client = new texttospeechModule.v1.TextToSpeechClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'texttospeech.googleapis.com');
         });
-        
+
         it('has universeDomain', () => {
             const client = new texttospeechModule.v1.TextToSpeechClient();
             const universeDomain = client.universeDomain;

--- a/baselines/texttospeech/test/gapic_text_to_speech_v1.ts.baseline
+++ b/baselines/texttospeech/test/gapic_text_to_speech_v1.ts.baseline
@@ -83,15 +83,15 @@ describe('v1.TextToSpeechClient', () => {
                 stub.restore();
             });
         }
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new texttospeechModule.v1.TextToSpeechClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'texttospeech.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new texttospeechModule.v1.TextToSpeechClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'texttospeech.example.com');
         });
         it('does not allow setting both universeDomain and universe_domain', () => {

--- a/baselines/translate-esm/esm/src/v3beta1/translation_service_client.ts.baseline
+++ b/baselines/translate-esm/esm/src/v3beta1/translation_service_client.ts.baseline
@@ -320,7 +320,7 @@ export class TranslationServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -333,7 +333,7 @@ export class TranslationServiceClient {
   /**
    * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -345,14 +345,6 @@ export class TranslationServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/translate-esm/esm/test/gapic_translation_service_v3beta1.ts.baseline
+++ b/baselines/translate-esm/esm/test/gapic_translation_service_v3beta1.ts.baseline
@@ -155,15 +155,15 @@ describe('v3beta1.TranslationServiceClient', () => {
                 stub.restore();
             });
         }
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new translationserviceModule.v3beta1.TranslationServiceClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'translate.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new translationserviceModule.v3beta1.TranslationServiceClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'translate.example.com');
         });
         it('does not allow setting both universeDomain and universe_domain', () => {

--- a/baselines/translate-esm/esm/test/gapic_translation_service_v3beta1.ts.baseline
+++ b/baselines/translate-esm/esm/test/gapic_translation_service_v3beta1.ts.baseline
@@ -126,18 +126,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v3beta1.TranslationServiceClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new translationserviceModule.v3beta1.TranslationServiceClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'translate.googleapis.com');
-        });
-
         it('has apiEndpoint', () => {
             const client = new translationserviceModule.v3beta1.TranslationServiceClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'translate.googleapis.com');
         });
-        
+
         it('has universeDomain', () => {
             const client = new translationserviceModule.v3beta1.TranslationServiceClient();
             const universeDomain = client.universeDomain;

--- a/baselines/translate/src/v3beta1/translation_service_client.ts.baseline
+++ b/baselines/translate/src/v3beta1/translation_service_client.ts.baseline
@@ -304,7 +304,7 @@ export class TranslationServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -315,9 +315,8 @@ export class TranslationServiceClient {
   }
 
   /**
-   * The DNS address for this API service - same as servicePath,
-   * exists for compatibility reasons.
-   * @deprecated
+   * The DNS address for this API service - same as servicePath.
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -329,14 +328,6 @@ export class TranslationServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/translate/test/gapic_translation_service_v3beta1.ts.baseline
+++ b/baselines/translate/test/gapic_translation_service_v3beta1.ts.baseline
@@ -117,18 +117,12 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v3beta1.TranslationServiceClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new translationserviceModule.v3beta1.TranslationServiceClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'translate.googleapis.com');
-        });
-
         it('has apiEndpoint', () => {
             const client = new translationserviceModule.v3beta1.TranslationServiceClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'translate.googleapis.com');
         });
-        
+
         it('has universeDomain', () => {
             const client = new translationserviceModule.v3beta1.TranslationServiceClient();
             const universeDomain = client.universeDomain;

--- a/baselines/translate/test/gapic_translation_service_v3beta1.ts.baseline
+++ b/baselines/translate/test/gapic_translation_service_v3beta1.ts.baseline
@@ -146,15 +146,15 @@ describe('v3beta1.TranslationServiceClient', () => {
                 stub.restore();
             });
         }
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new translationserviceModule.v3beta1.TranslationServiceClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'translate.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new translationserviceModule.v3beta1.TranslationServiceClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'translate.example.com');
         });
         it('does not allow setting both universeDomain and universe_domain', () => {

--- a/baselines/videointelligence-esm/esm/src/v1/video_intelligence_service_client.ts.baseline
+++ b/baselines/videointelligence-esm/esm/src/v1/video_intelligence_service_client.ts.baseline
@@ -282,7 +282,7 @@ export class VideoIntelligenceServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -295,7 +295,7 @@ export class VideoIntelligenceServiceClient {
   /**
    * The DNS address for this API service - same as servicePath,
    * exists for compatibility reasons.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -307,14 +307,6 @@ export class VideoIntelligenceServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/videointelligence-esm/esm/test/gapic_video_intelligence_service_v1.ts.baseline
+++ b/baselines/videointelligence-esm/esm/test/gapic_video_intelligence_service_v1.ts.baseline
@@ -75,18 +75,12 @@ function stubLongRunningCallWithCallback<ResponseType>(response?: ResponseType, 
 
 describe('v1.VideoIntelligenceServiceClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new videointelligenceserviceModule.v1.VideoIntelligenceServiceClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'videointelligence.googleapis.com');
-        });
-
         it('has apiEndpoint', () => {
             const client = new videointelligenceserviceModule.v1.VideoIntelligenceServiceClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'videointelligence.googleapis.com');
         });
-        
+
         it('has universeDomain', () => {
             const client = new videointelligenceserviceModule.v1.VideoIntelligenceServiceClient();
             const universeDomain = client.universeDomain;

--- a/baselines/videointelligence-esm/esm/test/gapic_video_intelligence_service_v1.ts.baseline
+++ b/baselines/videointelligence-esm/esm/test/gapic_video_intelligence_service_v1.ts.baseline
@@ -104,15 +104,15 @@ describe('v1.VideoIntelligenceServiceClient', () => {
                 stub.restore();
             });
         }
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new videointelligenceserviceModule.v1.VideoIntelligenceServiceClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'videointelligence.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new videointelligenceserviceModule.v1.VideoIntelligenceServiceClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'videointelligence.example.com');
         });
         it('does not allow setting both universeDomain and universe_domain', () => {

--- a/baselines/videointelligence/src/v1/video_intelligence_service_client.ts.baseline
+++ b/baselines/videointelligence/src/v1/video_intelligence_service_client.ts.baseline
@@ -266,7 +266,7 @@ export class VideoIntelligenceServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
@@ -277,9 +277,8 @@ export class VideoIntelligenceServiceClient {
   }
 
   /**
-   * The DNS address for this API service - same as servicePath,
-   * exists for compatibility reasons.
-   * @deprecated
+   * The DNS address for this API service - same as servicePath.
+   * @deprecated Use the apiEndpoint method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
@@ -291,14 +290,6 @@ export class VideoIntelligenceServiceClient {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get servicePath() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as servicePath().
    * @returns {string} The DNS address for this service.
    */
   get apiEndpoint() {

--- a/baselines/videointelligence/test/gapic_video_intelligence_service_v1.ts.baseline
+++ b/baselines/videointelligence/test/gapic_video_intelligence_service_v1.ts.baseline
@@ -66,18 +66,12 @@ function stubLongRunningCallWithCallback<ResponseType>(response?: ResponseType, 
 
 describe('v1.VideoIntelligenceServiceClient', () => {
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new videointelligenceserviceModule.v1.VideoIntelligenceServiceClient();
-            const servicePath = client.servicePath;
-            assert.strictEqual(servicePath, 'videointelligence.googleapis.com');
-        });
-
         it('has apiEndpoint', () => {
             const client = new videointelligenceserviceModule.v1.VideoIntelligenceServiceClient();
             const apiEndpoint = client.apiEndpoint;
             assert.strictEqual(apiEndpoint, 'videointelligence.googleapis.com');
         });
-        
+
         it('has universeDomain', () => {
             const client = new videointelligenceserviceModule.v1.VideoIntelligenceServiceClient();
             const universeDomain = client.universeDomain;

--- a/baselines/videointelligence/test/gapic_video_intelligence_service_v1.ts.baseline
+++ b/baselines/videointelligence/test/gapic_video_intelligence_service_v1.ts.baseline
@@ -95,15 +95,15 @@ describe('v1.VideoIntelligenceServiceClient', () => {
                 stub.restore();
             });
         }
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new videointelligenceserviceModule.v1.VideoIntelligenceServiceClient({universeDomain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'videointelligence.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new videointelligenceserviceModule.v1.VideoIntelligenceServiceClient({universe_domain: 'example.com'});
-            const servicePath = client.servicePath;
+            const servicePath = client.apiEndpoint;
             assert.strictEqual(servicePath, 'videointelligence.example.com');
         });
         it('does not allow setting both universeDomain and universe_domain', () => {

--- a/templates/cjs/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/cjs/typescript_gapic/src/$version/$service_client.ts.njk
@@ -490,7 +490,7 @@ export class {{ service.name }}Client {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the {{ id.get("apiEndpoint") }} method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get {{ id.get("servicePath") }}() {
@@ -501,9 +501,8 @@ export class {{ service.name }}Client {
   }
 
   /**
-   * The DNS address for this API service - same as {{ id.get("servicePath") }},
-   * exists for compatibility reasons.
-   * @deprecated
+   * The DNS address for this API service - same as {{ id.get("servicePath") }}.
+   * @deprecated Use the {{ id.get("apiEndpoint") }} method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get {{ id.get("apiEndpoint") }}() {
@@ -515,14 +514,6 @@ export class {{ service.name }}Client {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get {{ id.get("servicePath") }}() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as {{ id.get("servicePath") }}().
    * @returns {string} The DNS address for this service.
    */
   get {{ id.get("apiEndpoint") }}() {

--- a/templates/cjs/typescript_gapic/test/gapic_$service_$version.ts.njk
+++ b/templates/cjs/typescript_gapic/test/gapic_$service_$version.ts.njk
@@ -214,18 +214,12 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
   });
 {%- endif %}
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client();
-            const servicePath = client.{{ id.get("servicePath") }};
-            assert.strictEqual(servicePath, '{{ api.hostName }}');
-        });
-
         it('has apiEndpoint', () => {
             const client = new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client();
             const apiEndpoint = client.{{ id.get("apiEndpoint") }};
             assert.strictEqual(apiEndpoint, '{{ api.hostName }}');
         });
-        
+
         it('has universeDomain', () => {
             const client = new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client();
             const universeDomain = client.{{ id.get("universeDomain") }};

--- a/templates/cjs/typescript_gapic/test/gapic_$service_$version.ts.njk
+++ b/templates/cjs/typescript_gapic/test/gapic_$service_$version.ts.njk
@@ -245,15 +245,15 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
         }
 
         {%- if api.hostName.endsWith("googleapis.com") %}
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client({universeDomain: 'example.com'});
-            const servicePath = client.{{ id.get("servicePath") }};
+            const servicePath = client.{{ id.get("apiEndpoint") }};
             assert.strictEqual(servicePath, '{{ api.shortName }}.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client({universe_domain: 'example.com'});
-            const servicePath = client.{{ id.get("servicePath") }};
+            const servicePath = client.{{ id.get("apiEndpoint") }};
             assert.strictEqual(servicePath, '{{ api.shortName }}.example.com');
         });
 

--- a/templates/esm/typescript_gapic/esm/src/$version/$service_client.ts.njk
+++ b/templates/esm/typescript_gapic/esm/src/$version/$service_client.ts.njk
@@ -498,7 +498,7 @@ export class {{ service.name }}Client {
 
   /**
    * The DNS address for this API service.
-   * @deprecated
+   * @deprecated Use the {{ id.get("apiEndpoint") }} method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get {{ id.get("servicePath") }}() {
@@ -511,7 +511,7 @@ export class {{ service.name }}Client {
   /**
    * The DNS address for this API service - same as {{ id.get("servicePath") }},
    * exists for compatibility reasons.
-   * @deprecated
+   * @deprecated Use the {{ id.get("apiEndpoint") }} method of the client instance.
    * @returns {string} The DNS address for this service.
    */
   static get {{ id.get("apiEndpoint") }}() {
@@ -523,14 +523,6 @@ export class {{ service.name }}Client {
 
   /**
    * The DNS address for this API service.
-   * @returns {string} The DNS address for this service.
-   */
-  get {{ id.get("servicePath") }}() {
-    return this._servicePath;
-  }
-
-  /**
-   * The DNS address for this API service - same as {{ id.get("servicePath") }}().
    * @returns {string} The DNS address for this service.
    */
   get {{ id.get("apiEndpoint") }}() {

--- a/templates/esm/typescript_gapic/esm/test/gapic_$service_$version.ts.njk
+++ b/templates/esm/typescript_gapic/esm/test/gapic_$service_$version.ts.njk
@@ -253,15 +253,15 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
         }
 
         {%- if api.hostName.endsWith("googleapis.com") %}
-        it('sets servicePath according to universe domain camelCase', () => {
+        it('sets apiEndpoint according to universe domain camelCase', () => {
             const client = new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client({universeDomain: 'example.com'});
-            const servicePath = client.{{ id.get("servicePath") }};
+            const servicePath = client.{{ id.get("apiEndpoint") }};
             assert.strictEqual(servicePath, '{{ api.shortName }}.example.com');
         });
 
-        it('sets servicePath according to universe domain snakeCase', () => {
+        it('sets apiEndpoint according to universe domain snakeCase', () => {
             const client = new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client({universe_domain: 'example.com'});
-            const servicePath = client.{{ id.get("servicePath") }};
+            const servicePath = client.{{ id.get("apiEndpoint") }};
             assert.strictEqual(servicePath, '{{ api.shortName }}.example.com');
         });
 

--- a/templates/esm/typescript_gapic/esm/test/gapic_$service_$version.ts.njk
+++ b/templates/esm/typescript_gapic/esm/test/gapic_$service_$version.ts.njk
@@ -222,18 +222,12 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
   });
 {%- endif %}
     describe('Common methods', () => {
-        it('has servicePath', () => {
-            const client = new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client();
-            const servicePath = client.{{ id.get("servicePath") }};
-            assert.strictEqual(servicePath, '{{ api.hostName }}');
-        });
-
         it('has apiEndpoint', () => {
             const client = new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client();
             const apiEndpoint = client.{{ id.get("apiEndpoint") }};
             assert.strictEqual(apiEndpoint, '{{ api.hostName }}');
         });
-        
+
         it('has universeDomain', () => {
             const client = new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client();
             const universeDomain = client.{{ id.get("universeDomain") }};


### PR DESCRIPTION
Some APIs actually have a "service" path template so we generate `servicePath` method for them. Remove the new `servicePath` property before it's too late.