### PR TITLE
fix: allow bundlers to bundle JSON files correctly

### DIFF
--- a/baselines/asset-esm/esm/src/json-helper.cjs.baseline
+++ b/baselines/asset-esm/esm/src/json-helper.cjs.baseline
@@ -1,0 +1,20 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* eslint-disable node/no-missing-require */
+function getJSON(path) {
+  return require(path);
+}
+
+exports.getJSON = getJSON;

--- a/baselines/asset-esm/esm/src/v1/asset_service_client.ts.baseline
+++ b/baselines/asset-esm/esm/src/v1/asset_service_client.ts.baseline
@@ -26,6 +26,7 @@ import * as asset_service_client_config from './asset_service_client_config.json
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {getJSON} from '../json-helper.cjs';
 // @ts-ignore
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -34,9 +35,17 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * `src/v1/asset_service_client_config.json`.
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
-const gapicConfig = JSON.parse(fs.readFileSync(path.join(dirname, 'asset_service_client_config.json'),'utf8'));
-const jsonProtos = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', 'protos/protos.json'), 'utf8'));
-const version = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', '..', 'package.json'), 'utf8')).version;
+const gapicConfig = getJSON(
+  path.join(dirname, 'cloud_tasks_client_config.json')
+);
+
+const jsonProtos = getJSON(
+  path.join(dirname, '..', '..', '..', 'protos/protos.json')
+);
+
+const version = getJSON(
+  path.join(dirname, '..', '..', '..', '..', 'package.json')
+).version;
 
 /**
  *  Asset service definition.

--- a/baselines/asset-esm/esm/src/v1/asset_service_client.ts.baseline
+++ b/baselines/asset-esm/esm/src/v1/asset_service_client.ts.baseline
@@ -36,7 +36,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 const gapicConfig = getJSON(
-  path.join(dirname, 'cloud_tasks_client_config.json')
+  path.join(dirname, 'asset_service_client_config.json')
 );
 
 const jsonProtos = getJSON(

--- a/baselines/asset-esm/package.json
+++ b/baselines/asset-esm/package.json
@@ -66,7 +66,7 @@
     "test:cjs": "c8 mocha build/cjs/test",
     "test:esm": "c8 mocha build/esm/test",
     "test": "npm run test:cjs && npm run test:esm",
-    "compile:esm": "tsc -p ./tsconfig.esm.json",
+    "compile:esm": "tsc -p ./tsconfig.esm.json && cp -r esm/src/json-helper.cjs build/esm/src/json-helper.cjs",
     "babel": "babel esm --out-dir build/cjs --ignore \"esm/**/*.d.ts\" --extensions \".ts\" --out-file-extension .cjs --copy-files",
     "compile:cjs": "tsc -p ./tsconfig.json && npm run babel",
     "compile": "npm run compile:esm && npm run compile:cjs && cp -r protos build/protos",

--- a/baselines/asset-esm/package.json
+++ b/baselines/asset-esm/package.json
@@ -18,6 +18,16 @@
         "types": "./build/cjs/src/index.d.ts",
         "default": "./build/cjs/src/index.cjs"
       }
+    },
+    "./build/protos/protos": {
+      "import": {
+        "types": "./build/protos/protos/protos.d.ts",
+        "default": "./build/protos/protos/protos.js"
+      },
+      "require": {
+        "types": "./build/protos/protos/protos.d.ts",
+        "default": "./build/protos/protos/protos.cjs"
+      }
     }
   },
   "files": [

--- a/baselines/asset-esm/tsconfig.esm.json.baseline
+++ b/baselines/asset-esm/tsconfig.esm.json.baseline
@@ -20,5 +20,8 @@
     "esm/test/*.ts",
     "esm/test/**/*.ts",
     "esm/system-test/*.ts"
+  ],
+  "exclude": [
+    "esm/src/json-heper.cjs"
   ]
 }

--- a/baselines/asset-esm/tsconfig.esm.json.baseline
+++ b/baselines/asset-esm/tsconfig.esm.json.baseline
@@ -22,6 +22,6 @@
     "esm/system-test/*.ts"
   ],
   "exclude": [
-    "esm/src/json-heper.cjs"
+    "esm/src/json-helper.cjs"
   ]
 }

--- a/baselines/bigquery-storage-esm/esm/src/json-helper.cjs.baseline
+++ b/baselines/bigquery-storage-esm/esm/src/json-helper.cjs.baseline
@@ -1,0 +1,20 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* eslint-disable node/no-missing-require */
+function getJSON(path) {
+  return require(path);
+}
+
+exports.getJSON = getJSON;

--- a/baselines/bigquery-storage-esm/esm/src/v1beta1/big_query_storage_client.ts.baseline
+++ b/baselines/bigquery-storage-esm/esm/src/v1beta1/big_query_storage_client.ts.baseline
@@ -26,6 +26,7 @@ import * as big_query_storage_client_config from './big_query_storage_client_con
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {getJSON} from '../json-helper.cjs';
 // @ts-ignore
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -34,9 +35,17 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * `src/v1beta1/big_query_storage_client_config.json`.
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
-const gapicConfig = JSON.parse(fs.readFileSync(path.join(dirname, 'big_query_storage_client_config.json'),'utf8'));
-const jsonProtos = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', 'protos/protos.json'), 'utf8'));
-const version = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', '..', 'package.json'), 'utf8')).version;
+const gapicConfig = getJSON(
+  path.join(dirname, 'cloud_tasks_client_config.json')
+);
+
+const jsonProtos = getJSON(
+  path.join(dirname, '..', '..', '..', 'protos/protos.json')
+);
+
+const version = getJSON(
+  path.join(dirname, '..', '..', '..', '..', 'package.json')
+).version;
 
 /**
  *  BigQuery storage API.

--- a/baselines/bigquery-storage-esm/esm/src/v1beta1/big_query_storage_client.ts.baseline
+++ b/baselines/bigquery-storage-esm/esm/src/v1beta1/big_query_storage_client.ts.baseline
@@ -36,7 +36,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 const gapicConfig = getJSON(
-  path.join(dirname, 'cloud_tasks_client_config.json')
+  path.join(dirname, 'big_query_storage_client_config.json')
 );
 
 const jsonProtos = getJSON(

--- a/baselines/bigquery-storage-esm/package.json
+++ b/baselines/bigquery-storage-esm/package.json
@@ -66,7 +66,7 @@
     "test:cjs": "c8 mocha build/cjs/test",
     "test:esm": "c8 mocha build/esm/test",
     "test": "npm run test:cjs && npm run test:esm",
-    "compile:esm": "tsc -p ./tsconfig.esm.json",
+    "compile:esm": "tsc -p ./tsconfig.esm.json && cp -r esm/src/json-helper.cjs build/esm/src/json-helper.cjs",
     "babel": "babel esm --out-dir build/cjs --ignore \"esm/**/*.d.ts\" --extensions \".ts\" --out-file-extension .cjs --copy-files",
     "compile:cjs": "tsc -p ./tsconfig.json && npm run babel",
     "compile": "npm run compile:esm && npm run compile:cjs && cp -r protos build/protos",

--- a/baselines/bigquery-storage-esm/package.json
+++ b/baselines/bigquery-storage-esm/package.json
@@ -18,6 +18,16 @@
         "types": "./build/cjs/src/index.d.ts",
         "default": "./build/cjs/src/index.cjs"
       }
+    },
+    "./build/protos/protos": {
+      "import": {
+        "types": "./build/protos/protos/protos.d.ts",
+        "default": "./build/protos/protos/protos.js"
+      },
+      "require": {
+        "types": "./build/protos/protos/protos.d.ts",
+        "default": "./build/protos/protos/protos.cjs"
+      }
     }
   },
   "files": [

--- a/baselines/bigquery-storage-esm/tsconfig.esm.json.baseline
+++ b/baselines/bigquery-storage-esm/tsconfig.esm.json.baseline
@@ -20,5 +20,8 @@
     "esm/test/*.ts",
     "esm/test/**/*.ts",
     "esm/system-test/*.ts"
+  ],
+  "exclude": [
+    "esm/src/json-heper.cjs"
   ]
 }

--- a/baselines/bigquery-storage-esm/tsconfig.esm.json.baseline
+++ b/baselines/bigquery-storage-esm/tsconfig.esm.json.baseline
@@ -22,6 +22,6 @@
     "esm/system-test/*.ts"
   ],
   "exclude": [
-    "esm/src/json-heper.cjs"
+    "esm/src/json-helper.cjs"
   ]
 }

--- a/baselines/compute-esm/esm/src/json-helper.cjs.baseline
+++ b/baselines/compute-esm/esm/src/json-helper.cjs.baseline
@@ -1,0 +1,20 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* eslint-disable node/no-missing-require */
+function getJSON(path) {
+  return require(path);
+}
+
+exports.getJSON = getJSON;

--- a/baselines/compute-esm/esm/src/v1/addresses_client.ts.baseline
+++ b/baselines/compute-esm/esm/src/v1/addresses_client.ts.baseline
@@ -36,7 +36,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 const gapicConfig = getJSON(
-  path.join(dirname, 'cloud_tasks_client_config.json')
+  path.join(dirname, 'addresses_client_config.json')
 );
 
 const jsonProtos = getJSON(

--- a/baselines/compute-esm/esm/src/v1/addresses_client.ts.baseline
+++ b/baselines/compute-esm/esm/src/v1/addresses_client.ts.baseline
@@ -26,6 +26,7 @@ import * as addresses_client_config from './addresses_client_config.json';
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {getJSON} from '../json-helper.cjs';
 // @ts-ignore
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -34,9 +35,17 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * `src/v1/addresses_client_config.json`.
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
-const gapicConfig = JSON.parse(fs.readFileSync(path.join(dirname, 'addresses_client_config.json'),'utf8'));
-const jsonProtos = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', 'protos/protos.json'), 'utf8'));
-const version = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', '..', 'package.json'), 'utf8')).version;
+const gapicConfig = getJSON(
+  path.join(dirname, 'cloud_tasks_client_config.json')
+);
+
+const jsonProtos = getJSON(
+  path.join(dirname, '..', '..', '..', 'protos/protos.json')
+);
+
+const version = getJSON(
+  path.join(dirname, '..', '..', '..', '..', 'package.json')
+).version;
 
 /**
  *

--- a/baselines/compute-esm/esm/src/v1/region_operations_client.ts.baseline
+++ b/baselines/compute-esm/esm/src/v1/region_operations_client.ts.baseline
@@ -36,7 +36,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 const gapicConfig = getJSON(
-  path.join(dirname, 'cloud_tasks_client_config.json')
+  path.join(dirname, 'region_operations_client_config.json')
 );
 
 const jsonProtos = getJSON(

--- a/baselines/compute-esm/esm/src/v1/region_operations_client.ts.baseline
+++ b/baselines/compute-esm/esm/src/v1/region_operations_client.ts.baseline
@@ -26,6 +26,7 @@ import * as region_operations_client_config from './region_operations_client_con
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {getJSON} from '../json-helper.cjs';
 // @ts-ignore
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -34,9 +35,17 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * `src/v1/region_operations_client_config.json`.
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
-const gapicConfig = JSON.parse(fs.readFileSync(path.join(dirname, 'region_operations_client_config.json'),'utf8'));
-const jsonProtos = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', 'protos/protos.json'), 'utf8'));
-const version = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', '..', 'package.json'), 'utf8')).version;
+const gapicConfig = getJSON(
+  path.join(dirname, 'cloud_tasks_client_config.json')
+);
+
+const jsonProtos = getJSON(
+  path.join(dirname, '..', '..', '..', 'protos/protos.json')
+);
+
+const version = getJSON(
+  path.join(dirname, '..', '..', '..', '..', 'package.json')
+).version;
 
 /**
  *  The RegionOperations API.

--- a/baselines/compute-esm/package.json
+++ b/baselines/compute-esm/package.json
@@ -67,7 +67,7 @@
     "test:cjs": "c8 mocha build/cjs/test",
     "test:esm": "c8 mocha build/esm/test",
     "test": "npm run test:cjs && npm run test:esm",
-    "compile:esm": "tsc -p ./tsconfig.esm.json",
+    "compile:esm": "tsc -p ./tsconfig.esm.json && cp -r esm/src/json-helper.cjs build/esm/src/json-helper.cjs",
     "babel": "babel esm --out-dir build/cjs --ignore \"esm/**/*.d.ts\" --extensions \".ts\" --out-file-extension .cjs --copy-files",
     "compile:cjs": "tsc -p ./tsconfig.json && npm run babel",
     "compile": "npm run compile:esm && npm run compile:cjs && cp -r protos build/protos",

--- a/baselines/compute-esm/package.json
+++ b/baselines/compute-esm/package.json
@@ -18,6 +18,16 @@
         "types": "./build/cjs/src/index.d.ts",
         "default": "./build/cjs/src/index.cjs"
       }
+    },
+    "./build/protos/protos": {
+      "import": {
+        "types": "./build/protos/protos/protos.d.ts",
+        "default": "./build/protos/protos/protos.js"
+      },
+      "require": {
+        "types": "./build/protos/protos/protos.d.ts",
+        "default": "./build/protos/protos/protos.cjs"
+      }
     }
   },
   "files": [

--- a/baselines/compute-esm/tsconfig.esm.json.baseline
+++ b/baselines/compute-esm/tsconfig.esm.json.baseline
@@ -20,5 +20,8 @@
     "esm/test/*.ts",
     "esm/test/**/*.ts",
     "esm/system-test/*.ts"
+  ],
+  "exclude": [
+    "esm/src/json-heper.cjs"
   ]
 }

--- a/baselines/compute-esm/tsconfig.esm.json.baseline
+++ b/baselines/compute-esm/tsconfig.esm.json.baseline
@@ -22,6 +22,6 @@
     "esm/system-test/*.ts"
   ],
   "exclude": [
-    "esm/src/json-heper.cjs"
+    "esm/src/json-helper.cjs"
   ]
 }

--- a/baselines/deprecatedtest-esm/esm/src/json-helper.cjs.baseline
+++ b/baselines/deprecatedtest-esm/esm/src/json-helper.cjs.baseline
@@ -1,0 +1,20 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* eslint-disable node/no-missing-require */
+function getJSON(path) {
+  return require(path);
+}
+
+exports.getJSON = getJSON;

--- a/baselines/deprecatedtest-esm/esm/src/v1/deprecated_service_client.ts.baseline
+++ b/baselines/deprecatedtest-esm/esm/src/v1/deprecated_service_client.ts.baseline
@@ -26,6 +26,7 @@ import * as deprecated_service_client_config from './deprecated_service_client_c
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {getJSON} from '../json-helper.cjs';
 // @ts-ignore
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -34,9 +35,17 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * `src/v1/deprecated_service_client_config.json`.
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
-const gapicConfig = JSON.parse(fs.readFileSync(path.join(dirname, 'deprecated_service_client_config.json'),'utf8'));
-const jsonProtos = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', 'protos/protos.json'), 'utf8'));
-const version = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', '..', 'package.json'), 'utf8')).version;
+const gapicConfig = getJSON(
+  path.join(dirname, 'cloud_tasks_client_config.json')
+);
+
+const jsonProtos = getJSON(
+  path.join(dirname, '..', '..', '..', 'protos/protos.json')
+);
+
+const version = getJSON(
+  path.join(dirname, '..', '..', '..', '..', 'package.json')
+).version;
 
 /**
  *  This is a service description.

--- a/baselines/deprecatedtest-esm/esm/src/v1/deprecated_service_client.ts.baseline
+++ b/baselines/deprecatedtest-esm/esm/src/v1/deprecated_service_client.ts.baseline
@@ -36,7 +36,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 const gapicConfig = getJSON(
-  path.join(dirname, 'cloud_tasks_client_config.json')
+  path.join(dirname, 'deprecated_service_client_config.json')
 );
 
 const jsonProtos = getJSON(

--- a/baselines/deprecatedtest-esm/package.json
+++ b/baselines/deprecatedtest-esm/package.json
@@ -66,7 +66,7 @@
     "test:cjs": "c8 mocha build/cjs/test",
     "test:esm": "c8 mocha build/esm/test",
     "test": "npm run test:cjs && npm run test:esm",
-    "compile:esm": "tsc -p ./tsconfig.esm.json",
+    "compile:esm": "tsc -p ./tsconfig.esm.json && cp -r esm/src/json-helper.cjs build/esm/src/json-helper.cjs",
     "babel": "babel esm --out-dir build/cjs --ignore \"esm/**/*.d.ts\" --extensions \".ts\" --out-file-extension .cjs --copy-files",
     "compile:cjs": "tsc -p ./tsconfig.json && npm run babel",
     "compile": "npm run compile:esm && npm run compile:cjs && cp -r protos build/protos",

--- a/baselines/deprecatedtest-esm/package.json
+++ b/baselines/deprecatedtest-esm/package.json
@@ -18,6 +18,16 @@
         "types": "./build/cjs/src/index.d.ts",
         "default": "./build/cjs/src/index.cjs"
       }
+    },
+    "./build/protos/protos": {
+      "import": {
+        "types": "./build/protos/protos/protos.d.ts",
+        "default": "./build/protos/protos/protos.js"
+      },
+      "require": {
+        "types": "./build/protos/protos/protos.d.ts",
+        "default": "./build/protos/protos/protos.cjs"
+      }
     }
   },
   "files": [

--- a/baselines/deprecatedtest-esm/tsconfig.esm.json.baseline
+++ b/baselines/deprecatedtest-esm/tsconfig.esm.json.baseline
@@ -20,5 +20,8 @@
     "esm/test/*.ts",
     "esm/test/**/*.ts",
     "esm/system-test/*.ts"
+  ],
+  "exclude": [
+    "esm/src/json-heper.cjs"
   ]
 }

--- a/baselines/deprecatedtest-esm/tsconfig.esm.json.baseline
+++ b/baselines/deprecatedtest-esm/tsconfig.esm.json.baseline
@@ -22,6 +22,6 @@
     "esm/system-test/*.ts"
   ],
   "exclude": [
-    "esm/src/json-heper.cjs"
+    "esm/src/json-helper.cjs"
   ]
 }

--- a/baselines/disable-packing-test-esm/esm/src/json-helper.cjs.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/json-helper.cjs.baseline
@@ -1,0 +1,20 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* eslint-disable node/no-missing-require */
+function getJSON(path) {
+  return require(path);
+}
+
+exports.getJSON = getJSON;

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/compliance_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/compliance_client.ts.baseline
@@ -36,7 +36,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 const gapicConfig = getJSON(
-  path.join(dirname, 'cloud_tasks_client_config.json')
+  path.join(dirname, 'compliance_client_config.json')
 );
 
 const jsonProtos = getJSON(

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/compliance_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/compliance_client.ts.baseline
@@ -26,6 +26,7 @@ import * as compliance_client_config from './compliance_client_config.json';
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {getJSON} from '../json-helper.cjs';
 // @ts-ignore
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -34,9 +35,17 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * `src/v1beta1/compliance_client_config.json`.
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
-const gapicConfig = JSON.parse(fs.readFileSync(path.join(dirname, 'compliance_client_config.json'),'utf8'));
-const jsonProtos = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', 'protos/protos.json'), 'utf8'));
-const version = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', '..', 'package.json'), 'utf8')).version;
+const gapicConfig = getJSON(
+  path.join(dirname, 'cloud_tasks_client_config.json')
+);
+
+const jsonProtos = getJSON(
+  path.join(dirname, '..', '..', '..', 'protos/protos.json')
+);
+
+const version = getJSON(
+  path.join(dirname, '..', '..', '..', '..', 'package.json')
+).version;
 
 /**
  *  This service is used to test that GAPICs implement various REST-related features correctly. This mostly means transcoding proto3 requests to REST format

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/echo_client.ts.baseline
@@ -26,6 +26,7 @@ import * as echo_client_config from './echo_client_config.json';
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {getJSON} from '../json-helper.cjs';
 // @ts-ignore
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -34,9 +35,17 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * `src/v1beta1/echo_client_config.json`.
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
-const gapicConfig = JSON.parse(fs.readFileSync(path.join(dirname, 'echo_client_config.json'),'utf8'));
-const jsonProtos = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', 'protos/protos.json'), 'utf8'));
-const version = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', '..', 'package.json'), 'utf8')).version;
+const gapicConfig = getJSON(
+  path.join(dirname, 'cloud_tasks_client_config.json')
+);
+
+const jsonProtos = getJSON(
+  path.join(dirname, '..', '..', '..', 'protos/protos.json')
+);
+
+const version = getJSON(
+  path.join(dirname, '..', '..', '..', '..', 'package.json')
+).version;
 
 /**
  *  This service is used showcase the four main types of rpcs - unary, server

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/echo_client.ts.baseline
@@ -36,7 +36,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 const gapicConfig = getJSON(
-  path.join(dirname, 'cloud_tasks_client_config.json')
+  path.join(dirname, 'echo_client_config.json')
 );
 
 const jsonProtos = getJSON(

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/identity_client.ts.baseline
@@ -26,6 +26,7 @@ import * as identity_client_config from './identity_client_config.json';
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {getJSON} from '../json-helper.cjs';
 // @ts-ignore
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -34,9 +35,17 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * `src/v1beta1/identity_client_config.json`.
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
-const gapicConfig = JSON.parse(fs.readFileSync(path.join(dirname, 'identity_client_config.json'),'utf8'));
-const jsonProtos = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', 'protos/protos.json'), 'utf8'));
-const version = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', '..', 'package.json'), 'utf8')).version;
+const gapicConfig = getJSON(
+  path.join(dirname, 'cloud_tasks_client_config.json')
+);
+
+const jsonProtos = getJSON(
+  path.join(dirname, '..', '..', '..', 'protos/protos.json')
+);
+
+const version = getJSON(
+  path.join(dirname, '..', '..', '..', '..', 'package.json')
+).version;
 
 /**
  *  A simple identity service.

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/identity_client.ts.baseline
@@ -36,7 +36,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 const gapicConfig = getJSON(
-  path.join(dirname, 'cloud_tasks_client_config.json')
+  path.join(dirname, 'identity_client_config.json')
 );
 
 const jsonProtos = getJSON(

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/messaging_client.ts.baseline
@@ -26,6 +26,7 @@ import * as messaging_client_config from './messaging_client_config.json';
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {getJSON} from '../json-helper.cjs';
 // @ts-ignore
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -34,9 +35,17 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * `src/v1beta1/messaging_client_config.json`.
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
-const gapicConfig = JSON.parse(fs.readFileSync(path.join(dirname, 'messaging_client_config.json'),'utf8'));
-const jsonProtos = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', 'protos/protos.json'), 'utf8'));
-const version = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', '..', 'package.json'), 'utf8')).version;
+const gapicConfig = getJSON(
+  path.join(dirname, 'cloud_tasks_client_config.json')
+);
+
+const jsonProtos = getJSON(
+  path.join(dirname, '..', '..', '..', 'protos/protos.json')
+);
+
+const version = getJSON(
+  path.join(dirname, '..', '..', '..', '..', 'package.json')
+).version;
 
 /**
  *  A simple messaging service that implements chat rooms and profile posts.

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/messaging_client.ts.baseline
@@ -36,7 +36,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 const gapicConfig = getJSON(
-  path.join(dirname, 'cloud_tasks_client_config.json')
+  path.join(dirname, 'messaging_client_config.json')
 );
 
 const jsonProtos = getJSON(

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/sequence_service_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/sequence_service_client.ts.baseline
@@ -26,6 +26,7 @@ import * as sequence_service_client_config from './sequence_service_client_confi
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {getJSON} from '../json-helper.cjs';
 // @ts-ignore
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -34,9 +35,17 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * `src/v1beta1/sequence_service_client_config.json`.
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
-const gapicConfig = JSON.parse(fs.readFileSync(path.join(dirname, 'sequence_service_client_config.json'),'utf8'));
-const jsonProtos = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', 'protos/protos.json'), 'utf8'));
-const version = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', '..', 'package.json'), 'utf8')).version;
+const gapicConfig = getJSON(
+  path.join(dirname, 'cloud_tasks_client_config.json')
+);
+
+const jsonProtos = getJSON(
+  path.join(dirname, '..', '..', '..', 'protos/protos.json')
+);
+
+const version = getJSON(
+  path.join(dirname, '..', '..', '..', '..', 'package.json')
+).version;
 
 /**
  * @class

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/sequence_service_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/sequence_service_client.ts.baseline
@@ -36,7 +36,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 const gapicConfig = getJSON(
-  path.join(dirname, 'cloud_tasks_client_config.json')
+  path.join(dirname, 'sequence_service_client_config.json')
 );
 
 const jsonProtos = getJSON(

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/testing_client.ts.baseline
@@ -26,6 +26,7 @@ import * as testing_client_config from './testing_client_config.json';
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {getJSON} from '../json-helper.cjs';
 // @ts-ignore
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -34,9 +35,17 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * `src/v1beta1/testing_client_config.json`.
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
-const gapicConfig = JSON.parse(fs.readFileSync(path.join(dirname, 'testing_client_config.json'),'utf8'));
-const jsonProtos = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', 'protos/protos.json'), 'utf8'));
-const version = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', '..', 'package.json'), 'utf8')).version;
+const gapicConfig = getJSON(
+  path.join(dirname, 'cloud_tasks_client_config.json')
+);
+
+const jsonProtos = getJSON(
+  path.join(dirname, '..', '..', '..', 'protos/protos.json')
+);
+
+const version = getJSON(
+  path.join(dirname, '..', '..', '..', '..', 'package.json')
+).version;
 
 /**
  *  A service to facilitate running discrete sets of tests

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/testing_client.ts.baseline
@@ -36,7 +36,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 const gapicConfig = getJSON(
-  path.join(dirname, 'cloud_tasks_client_config.json')
+  path.join(dirname, 'testing_client_config.json')
 );
 
 const jsonProtos = getJSON(

--- a/baselines/disable-packing-test-esm/package.json
+++ b/baselines/disable-packing-test-esm/package.json
@@ -71,7 +71,7 @@
     "test:cjs": "c8 mocha build/cjs/test",
     "test:esm": "c8 mocha build/esm/test",
     "test": "npm run test:cjs && npm run test:esm",
-    "compile:esm": "tsc -p ./tsconfig.esm.json",
+    "compile:esm": "tsc -p ./tsconfig.esm.json && cp -r esm/src/json-helper.cjs build/esm/src/json-helper.cjs",
     "babel": "babel esm --out-dir build/cjs --ignore \"esm/**/*.d.ts\" --extensions \".ts\" --out-file-extension .cjs --copy-files",
     "compile:cjs": "tsc -p ./tsconfig.json && npm run babel",
     "compile": "npm run compile:esm && npm run compile:cjs && cp -r protos build/protos",

--- a/baselines/disable-packing-test-esm/package.json
+++ b/baselines/disable-packing-test-esm/package.json
@@ -18,6 +18,16 @@
         "types": "./build/cjs/src/index.d.ts",
         "default": "./build/cjs/src/index.cjs"
       }
+    },
+    "./build/protos/protos": {
+      "import": {
+        "types": "./build/protos/protos/protos.d.ts",
+        "default": "./build/protos/protos/protos.js"
+      },
+      "require": {
+        "types": "./build/protos/protos/protos.d.ts",
+        "default": "./build/protos/protos/protos.cjs"
+      }
     }
   },
   "files": [

--- a/baselines/disable-packing-test-esm/tsconfig.esm.json.baseline
+++ b/baselines/disable-packing-test-esm/tsconfig.esm.json.baseline
@@ -20,5 +20,8 @@
     "esm/test/*.ts",
     "esm/test/**/*.ts",
     "esm/system-test/*.ts"
+  ],
+  "exclude": [
+    "esm/src/json-heper.cjs"
   ]
 }

--- a/baselines/disable-packing-test-esm/tsconfig.esm.json.baseline
+++ b/baselines/disable-packing-test-esm/tsconfig.esm.json.baseline
@@ -22,6 +22,6 @@
     "esm/system-test/*.ts"
   ],
   "exclude": [
-    "esm/src/json-heper.cjs"
+    "esm/src/json-helper.cjs"
   ]
 }

--- a/baselines/dlp-esm/esm/src/json-helper.cjs.baseline
+++ b/baselines/dlp-esm/esm/src/json-helper.cjs.baseline
@@ -1,0 +1,20 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* eslint-disable node/no-missing-require */
+function getJSON(path) {
+  return require(path);
+}
+
+exports.getJSON = getJSON;

--- a/baselines/dlp-esm/esm/src/v2/dlp_service_client.ts.baseline
+++ b/baselines/dlp-esm/esm/src/v2/dlp_service_client.ts.baseline
@@ -36,7 +36,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 const gapicConfig = getJSON(
-  path.join(dirname, 'cloud_tasks_client_config.json')
+  path.join(dirname, 'dlp_service_client_config.json')
 );
 
 const jsonProtos = getJSON(

--- a/baselines/dlp-esm/esm/src/v2/dlp_service_client.ts.baseline
+++ b/baselines/dlp-esm/esm/src/v2/dlp_service_client.ts.baseline
@@ -26,6 +26,7 @@ import * as dlp_service_client_config from './dlp_service_client_config.json';
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {getJSON} from '../json-helper.cjs';
 // @ts-ignore
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -34,9 +35,17 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * `src/v2/dlp_service_client_config.json`.
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
-const gapicConfig = JSON.parse(fs.readFileSync(path.join(dirname, 'dlp_service_client_config.json'),'utf8'));
-const jsonProtos = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', 'protos/protos.json'), 'utf8'));
-const version = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', '..', 'package.json'), 'utf8')).version;
+const gapicConfig = getJSON(
+  path.join(dirname, 'cloud_tasks_client_config.json')
+);
+
+const jsonProtos = getJSON(
+  path.join(dirname, '..', '..', '..', 'protos/protos.json')
+);
+
+const version = getJSON(
+  path.join(dirname, '..', '..', '..', '..', 'package.json')
+).version;
 
 /**
  *  The Cloud Data Loss Prevention (DLP) API is a service that allows clients

--- a/baselines/dlp-esm/package.json
+++ b/baselines/dlp-esm/package.json
@@ -66,7 +66,7 @@
     "test:cjs": "c8 mocha build/cjs/test",
     "test:esm": "c8 mocha build/esm/test",
     "test": "npm run test:cjs && npm run test:esm",
-    "compile:esm": "tsc -p ./tsconfig.esm.json",
+    "compile:esm": "tsc -p ./tsconfig.esm.json && cp -r esm/src/json-helper.cjs build/esm/src/json-helper.cjs",
     "babel": "babel esm --out-dir build/cjs --ignore \"esm/**/*.d.ts\" --extensions \".ts\" --out-file-extension .cjs --copy-files",
     "compile:cjs": "tsc -p ./tsconfig.json && npm run babel",
     "compile": "npm run compile:esm && npm run compile:cjs && cp -r protos build/protos",

--- a/baselines/dlp-esm/package.json
+++ b/baselines/dlp-esm/package.json
@@ -18,6 +18,16 @@
         "types": "./build/cjs/src/index.d.ts",
         "default": "./build/cjs/src/index.cjs"
       }
+    },
+    "./build/protos/protos": {
+      "import": {
+        "types": "./build/protos/protos/protos.d.ts",
+        "default": "./build/protos/protos/protos.js"
+      },
+      "require": {
+        "types": "./build/protos/protos/protos.d.ts",
+        "default": "./build/protos/protos/protos.cjs"
+      }
     }
   },
   "files": [

--- a/baselines/dlp-esm/tsconfig.esm.json.baseline
+++ b/baselines/dlp-esm/tsconfig.esm.json.baseline
@@ -20,5 +20,8 @@
     "esm/test/*.ts",
     "esm/test/**/*.ts",
     "esm/system-test/*.ts"
+  ],
+  "exclude": [
+    "esm/src/json-heper.cjs"
   ]
 }

--- a/baselines/dlp-esm/tsconfig.esm.json.baseline
+++ b/baselines/dlp-esm/tsconfig.esm.json.baseline
@@ -22,6 +22,6 @@
     "esm/system-test/*.ts"
   ],
   "exclude": [
-    "esm/src/json-heper.cjs"
+    "esm/src/json-helper.cjs"
   ]
 }

--- a/baselines/kms-esm/esm/src/json-helper.cjs.baseline
+++ b/baselines/kms-esm/esm/src/json-helper.cjs.baseline
@@ -1,0 +1,20 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* eslint-disable node/no-missing-require */
+function getJSON(path) {
+  return require(path);
+}
+
+exports.getJSON = getJSON;

--- a/baselines/kms-esm/esm/src/v1/key_management_service_client.ts.baseline
+++ b/baselines/kms-esm/esm/src/v1/key_management_service_client.ts.baseline
@@ -36,7 +36,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 const gapicConfig = getJSON(
-  path.join(dirname, 'cloud_tasks_client_config.json')
+  path.join(dirname, 'key_management_service_client_config.json')
 );
 
 const jsonProtos = getJSON(

--- a/baselines/kms-esm/esm/src/v1/key_management_service_client.ts.baseline
+++ b/baselines/kms-esm/esm/src/v1/key_management_service_client.ts.baseline
@@ -26,6 +26,7 @@ import * as key_management_service_client_config from './key_management_service_
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {getJSON} from '../json-helper.cjs';
 // @ts-ignore
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -34,9 +35,17 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * `src/v1/key_management_service_client_config.json`.
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
-const gapicConfig = JSON.parse(fs.readFileSync(path.join(dirname, 'key_management_service_client_config.json'),'utf8'));
-const jsonProtos = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', 'protos/protos.json'), 'utf8'));
-const version = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', '..', 'package.json'), 'utf8')).version;
+const gapicConfig = getJSON(
+  path.join(dirname, 'cloud_tasks_client_config.json')
+);
+
+const jsonProtos = getJSON(
+  path.join(dirname, '..', '..', '..', 'protos/protos.json')
+);
+
+const version = getJSON(
+  path.join(dirname, '..', '..', '..', '..', 'package.json')
+).version;
 
 /**
  *  Google Cloud Key Management Service

--- a/baselines/kms-esm/package.json
+++ b/baselines/kms-esm/package.json
@@ -66,7 +66,7 @@
     "test:cjs": "c8 mocha build/cjs/test",
     "test:esm": "c8 mocha build/esm/test",
     "test": "npm run test:cjs && npm run test:esm",
-    "compile:esm": "tsc -p ./tsconfig.esm.json",
+    "compile:esm": "tsc -p ./tsconfig.esm.json && cp -r esm/src/json-helper.cjs build/esm/src/json-helper.cjs",
     "babel": "babel esm --out-dir build/cjs --ignore \"esm/**/*.d.ts\" --extensions \".ts\" --out-file-extension .cjs --copy-files",
     "compile:cjs": "tsc -p ./tsconfig.json && npm run babel",
     "compile": "npm run compile:esm && npm run compile:cjs && cp -r protos build/protos",

--- a/baselines/kms-esm/package.json
+++ b/baselines/kms-esm/package.json
@@ -18,6 +18,16 @@
         "types": "./build/cjs/src/index.d.ts",
         "default": "./build/cjs/src/index.cjs"
       }
+    },
+    "./build/protos/protos": {
+      "import": {
+        "types": "./build/protos/protos/protos.d.ts",
+        "default": "./build/protos/protos/protos.js"
+      },
+      "require": {
+        "types": "./build/protos/protos/protos.d.ts",
+        "default": "./build/protos/protos/protos.cjs"
+      }
     }
   },
   "files": [

--- a/baselines/kms-esm/tsconfig.esm.json.baseline
+++ b/baselines/kms-esm/tsconfig.esm.json.baseline
@@ -20,5 +20,8 @@
     "esm/test/*.ts",
     "esm/test/**/*.ts",
     "esm/system-test/*.ts"
+  ],
+  "exclude": [
+    "esm/src/json-heper.cjs"
   ]
 }

--- a/baselines/kms-esm/tsconfig.esm.json.baseline
+++ b/baselines/kms-esm/tsconfig.esm.json.baseline
@@ -22,6 +22,6 @@
     "esm/system-test/*.ts"
   ],
   "exclude": [
-    "esm/src/json-heper.cjs"
+    "esm/src/json-helper.cjs"
   ]
 }

--- a/baselines/logging-esm/esm/src/json-helper.cjs.baseline
+++ b/baselines/logging-esm/esm/src/json-helper.cjs.baseline
@@ -1,0 +1,20 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* eslint-disable node/no-missing-require */
+function getJSON(path) {
+  return require(path);
+}
+
+exports.getJSON = getJSON;

--- a/baselines/logging-esm/esm/src/v2/config_service_v2_client.ts.baseline
+++ b/baselines/logging-esm/esm/src/v2/config_service_v2_client.ts.baseline
@@ -26,6 +26,7 @@ import * as config_service_v2_client_config from './config_service_v2_client_con
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {getJSON} from '../json-helper.cjs';
 // @ts-ignore
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -34,9 +35,17 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * `src/v2/config_service_v2_client_config.json`.
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
-const gapicConfig = JSON.parse(fs.readFileSync(path.join(dirname, 'config_service_v2_client_config.json'),'utf8'));
-const jsonProtos = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', 'protos/protos.json'), 'utf8'));
-const version = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', '..', 'package.json'), 'utf8')).version;
+const gapicConfig = getJSON(
+  path.join(dirname, 'cloud_tasks_client_config.json')
+);
+
+const jsonProtos = getJSON(
+  path.join(dirname, '..', '..', '..', 'protos/protos.json')
+);
+
+const version = getJSON(
+  path.join(dirname, '..', '..', '..', '..', 'package.json')
+).version;
 
 /**
  *  Service for configuring sinks used to route log entries.

--- a/baselines/logging-esm/esm/src/v2/config_service_v2_client.ts.baseline
+++ b/baselines/logging-esm/esm/src/v2/config_service_v2_client.ts.baseline
@@ -36,7 +36,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 const gapicConfig = getJSON(
-  path.join(dirname, 'cloud_tasks_client_config.json')
+  path.join(dirname, 'config_service_v2_client_config.json')
 );
 
 const jsonProtos = getJSON(

--- a/baselines/logging-esm/esm/src/v2/logging_service_v2_client.ts.baseline
+++ b/baselines/logging-esm/esm/src/v2/logging_service_v2_client.ts.baseline
@@ -36,7 +36,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 const gapicConfig = getJSON(
-  path.join(dirname, 'cloud_tasks_client_config.json')
+  path.join(dirname, 'logging_service_v2_client_config.json')
 );
 
 const jsonProtos = getJSON(

--- a/baselines/logging-esm/esm/src/v2/logging_service_v2_client.ts.baseline
+++ b/baselines/logging-esm/esm/src/v2/logging_service_v2_client.ts.baseline
@@ -26,6 +26,7 @@ import * as logging_service_v2_client_config from './logging_service_v2_client_c
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {getJSON} from '../json-helper.cjs';
 // @ts-ignore
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -34,9 +35,17 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * `src/v2/logging_service_v2_client_config.json`.
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
-const gapicConfig = JSON.parse(fs.readFileSync(path.join(dirname, 'logging_service_v2_client_config.json'),'utf8'));
-const jsonProtos = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', 'protos/protos.json'), 'utf8'));
-const version = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', '..', 'package.json'), 'utf8')).version;
+const gapicConfig = getJSON(
+  path.join(dirname, 'cloud_tasks_client_config.json')
+);
+
+const jsonProtos = getJSON(
+  path.join(dirname, '..', '..', '..', 'protos/protos.json')
+);
+
+const version = getJSON(
+  path.join(dirname, '..', '..', '..', '..', 'package.json')
+).version;
 
 /**
  *  Service for ingesting and querying logs.

--- a/baselines/logging-esm/esm/src/v2/metrics_service_v2_client.ts.baseline
+++ b/baselines/logging-esm/esm/src/v2/metrics_service_v2_client.ts.baseline
@@ -26,6 +26,7 @@ import * as metrics_service_v2_client_config from './metrics_service_v2_client_c
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {getJSON} from '../json-helper.cjs';
 // @ts-ignore
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -34,9 +35,17 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * `src/v2/metrics_service_v2_client_config.json`.
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
-const gapicConfig = JSON.parse(fs.readFileSync(path.join(dirname, 'metrics_service_v2_client_config.json'),'utf8'));
-const jsonProtos = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', 'protos/protos.json'), 'utf8'));
-const version = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', '..', 'package.json'), 'utf8')).version;
+const gapicConfig = getJSON(
+  path.join(dirname, 'cloud_tasks_client_config.json')
+);
+
+const jsonProtos = getJSON(
+  path.join(dirname, '..', '..', '..', 'protos/protos.json')
+);
+
+const version = getJSON(
+  path.join(dirname, '..', '..', '..', '..', 'package.json')
+).version;
 
 /**
  *  Service for configuring logs-based metrics.

--- a/baselines/logging-esm/esm/src/v2/metrics_service_v2_client.ts.baseline
+++ b/baselines/logging-esm/esm/src/v2/metrics_service_v2_client.ts.baseline
@@ -36,7 +36,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 const gapicConfig = getJSON(
-  path.join(dirname, 'cloud_tasks_client_config.json')
+  path.join(dirname, 'metrics_service_v2_client_config.json')
 );
 
 const jsonProtos = getJSON(

--- a/baselines/logging-esm/package.json
+++ b/baselines/logging-esm/package.json
@@ -68,7 +68,7 @@
     "test:cjs": "c8 mocha build/cjs/test",
     "test:esm": "c8 mocha build/esm/test",
     "test": "npm run test:cjs && npm run test:esm",
-    "compile:esm": "tsc -p ./tsconfig.esm.json",
+    "compile:esm": "tsc -p ./tsconfig.esm.json && cp -r esm/src/json-helper.cjs build/esm/src/json-helper.cjs",
     "babel": "babel esm --out-dir build/cjs --ignore \"esm/**/*.d.ts\" --extensions \".ts\" --out-file-extension .cjs --copy-files",
     "compile:cjs": "tsc -p ./tsconfig.json && npm run babel",
     "compile": "npm run compile:esm && npm run compile:cjs && cp -r protos build/protos",

--- a/baselines/logging-esm/package.json
+++ b/baselines/logging-esm/package.json
@@ -18,6 +18,16 @@
         "types": "./build/cjs/src/index.d.ts",
         "default": "./build/cjs/src/index.cjs"
       }
+    },
+    "./build/protos/protos": {
+      "import": {
+        "types": "./build/protos/protos/protos.d.ts",
+        "default": "./build/protos/protos/protos.js"
+      },
+      "require": {
+        "types": "./build/protos/protos/protos.d.ts",
+        "default": "./build/protos/protos/protos.cjs"
+      }
     }
   },
   "files": [

--- a/baselines/logging-esm/tsconfig.esm.json.baseline
+++ b/baselines/logging-esm/tsconfig.esm.json.baseline
@@ -20,5 +20,8 @@
     "esm/test/*.ts",
     "esm/test/**/*.ts",
     "esm/system-test/*.ts"
+  ],
+  "exclude": [
+    "esm/src/json-heper.cjs"
   ]
 }

--- a/baselines/logging-esm/tsconfig.esm.json.baseline
+++ b/baselines/logging-esm/tsconfig.esm.json.baseline
@@ -22,6 +22,6 @@
     "esm/system-test/*.ts"
   ],
   "exclude": [
-    "esm/src/json-heper.cjs"
+    "esm/src/json-helper.cjs"
   ]
 }

--- a/baselines/monitoring-esm/esm/src/json-helper.cjs.baseline
+++ b/baselines/monitoring-esm/esm/src/json-helper.cjs.baseline
@@ -1,0 +1,20 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* eslint-disable node/no-missing-require */
+function getJSON(path) {
+  return require(path);
+}
+
+exports.getJSON = getJSON;

--- a/baselines/monitoring-esm/esm/src/v3/alert_policy_service_client.ts.baseline
+++ b/baselines/monitoring-esm/esm/src/v3/alert_policy_service_client.ts.baseline
@@ -36,7 +36,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 const gapicConfig = getJSON(
-  path.join(dirname, 'cloud_tasks_client_config.json')
+  path.join(dirname, 'alert_policy_service_client_config.json')
 );
 
 const jsonProtos = getJSON(

--- a/baselines/monitoring-esm/esm/src/v3/alert_policy_service_client.ts.baseline
+++ b/baselines/monitoring-esm/esm/src/v3/alert_policy_service_client.ts.baseline
@@ -26,6 +26,7 @@ import * as alert_policy_service_client_config from './alert_policy_service_clie
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {getJSON} from '../json-helper.cjs';
 // @ts-ignore
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -34,9 +35,17 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * `src/v3/alert_policy_service_client_config.json`.
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
-const gapicConfig = JSON.parse(fs.readFileSync(path.join(dirname, 'alert_policy_service_client_config.json'),'utf8'));
-const jsonProtos = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', 'protos/protos.json'), 'utf8'));
-const version = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', '..', 'package.json'), 'utf8')).version;
+const gapicConfig = getJSON(
+  path.join(dirname, 'cloud_tasks_client_config.json')
+);
+
+const jsonProtos = getJSON(
+  path.join(dirname, '..', '..', '..', 'protos/protos.json')
+);
+
+const version = getJSON(
+  path.join(dirname, '..', '..', '..', '..', 'package.json')
+).version;
 
 /**
  *  The AlertPolicyService API is used to manage (list, create, delete,

--- a/baselines/monitoring-esm/esm/src/v3/group_service_client.ts.baseline
+++ b/baselines/monitoring-esm/esm/src/v3/group_service_client.ts.baseline
@@ -26,6 +26,7 @@ import * as group_service_client_config from './group_service_client_config.json
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {getJSON} from '../json-helper.cjs';
 // @ts-ignore
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -34,9 +35,17 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * `src/v3/group_service_client_config.json`.
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
-const gapicConfig = JSON.parse(fs.readFileSync(path.join(dirname, 'group_service_client_config.json'),'utf8'));
-const jsonProtos = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', 'protos/protos.json'), 'utf8'));
-const version = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', '..', 'package.json'), 'utf8')).version;
+const gapicConfig = getJSON(
+  path.join(dirname, 'cloud_tasks_client_config.json')
+);
+
+const jsonProtos = getJSON(
+  path.join(dirname, '..', '..', '..', 'protos/protos.json')
+);
+
+const version = getJSON(
+  path.join(dirname, '..', '..', '..', '..', 'package.json')
+).version;
 
 /**
  *  The Group API lets you inspect and manage your

--- a/baselines/monitoring-esm/esm/src/v3/group_service_client.ts.baseline
+++ b/baselines/monitoring-esm/esm/src/v3/group_service_client.ts.baseline
@@ -36,7 +36,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 const gapicConfig = getJSON(
-  path.join(dirname, 'cloud_tasks_client_config.json')
+  path.join(dirname, 'group_service_client_config.json')
 );
 
 const jsonProtos = getJSON(

--- a/baselines/monitoring-esm/esm/src/v3/metric_service_client.ts.baseline
+++ b/baselines/monitoring-esm/esm/src/v3/metric_service_client.ts.baseline
@@ -26,6 +26,7 @@ import * as metric_service_client_config from './metric_service_client_config.js
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {getJSON} from '../json-helper.cjs';
 // @ts-ignore
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -34,9 +35,17 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * `src/v3/metric_service_client_config.json`.
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
-const gapicConfig = JSON.parse(fs.readFileSync(path.join(dirname, 'metric_service_client_config.json'),'utf8'));
-const jsonProtos = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', 'protos/protos.json'), 'utf8'));
-const version = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', '..', 'package.json'), 'utf8')).version;
+const gapicConfig = getJSON(
+  path.join(dirname, 'cloud_tasks_client_config.json')
+);
+
+const jsonProtos = getJSON(
+  path.join(dirname, '..', '..', '..', 'protos/protos.json')
+);
+
+const version = getJSON(
+  path.join(dirname, '..', '..', '..', '..', 'package.json')
+).version;
 
 /**
  *  Manages metric descriptors, monitored resource descriptors, and

--- a/baselines/monitoring-esm/esm/src/v3/metric_service_client.ts.baseline
+++ b/baselines/monitoring-esm/esm/src/v3/metric_service_client.ts.baseline
@@ -36,7 +36,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 const gapicConfig = getJSON(
-  path.join(dirname, 'cloud_tasks_client_config.json')
+  path.join(dirname, 'metric_service_client_config.json')
 );
 
 const jsonProtos = getJSON(

--- a/baselines/monitoring-esm/esm/src/v3/notification_channel_service_client.ts.baseline
+++ b/baselines/monitoring-esm/esm/src/v3/notification_channel_service_client.ts.baseline
@@ -26,6 +26,7 @@ import * as notification_channel_service_client_config from './notification_chan
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {getJSON} from '../json-helper.cjs';
 // @ts-ignore
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -34,9 +35,17 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * `src/v3/notification_channel_service_client_config.json`.
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
-const gapicConfig = JSON.parse(fs.readFileSync(path.join(dirname, 'notification_channel_service_client_config.json'),'utf8'));
-const jsonProtos = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', 'protos/protos.json'), 'utf8'));
-const version = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', '..', 'package.json'), 'utf8')).version;
+const gapicConfig = getJSON(
+  path.join(dirname, 'cloud_tasks_client_config.json')
+);
+
+const jsonProtos = getJSON(
+  path.join(dirname, '..', '..', '..', 'protos/protos.json')
+);
+
+const version = getJSON(
+  path.join(dirname, '..', '..', '..', '..', 'package.json')
+).version;
 
 /**
  *  The Notification Channel API provides access to configuration that

--- a/baselines/monitoring-esm/esm/src/v3/notification_channel_service_client.ts.baseline
+++ b/baselines/monitoring-esm/esm/src/v3/notification_channel_service_client.ts.baseline
@@ -36,7 +36,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 const gapicConfig = getJSON(
-  path.join(dirname, 'cloud_tasks_client_config.json')
+  path.join(dirname, 'notification_channel_service_client_config.json')
 );
 
 const jsonProtos = getJSON(

--- a/baselines/monitoring-esm/esm/src/v3/service_monitoring_service_client.ts.baseline
+++ b/baselines/monitoring-esm/esm/src/v3/service_monitoring_service_client.ts.baseline
@@ -36,7 +36,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 const gapicConfig = getJSON(
-  path.join(dirname, 'cloud_tasks_client_config.json')
+  path.join(dirname, 'service_monitoring_service_client_config.json')
 );
 
 const jsonProtos = getJSON(

--- a/baselines/monitoring-esm/esm/src/v3/service_monitoring_service_client.ts.baseline
+++ b/baselines/monitoring-esm/esm/src/v3/service_monitoring_service_client.ts.baseline
@@ -26,6 +26,7 @@ import * as service_monitoring_service_client_config from './service_monitoring_
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {getJSON} from '../json-helper.cjs';
 // @ts-ignore
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -34,9 +35,17 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * `src/v3/service_monitoring_service_client_config.json`.
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
-const gapicConfig = JSON.parse(fs.readFileSync(path.join(dirname, 'service_monitoring_service_client_config.json'),'utf8'));
-const jsonProtos = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', 'protos/protos.json'), 'utf8'));
-const version = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', '..', 'package.json'), 'utf8')).version;
+const gapicConfig = getJSON(
+  path.join(dirname, 'cloud_tasks_client_config.json')
+);
+
+const jsonProtos = getJSON(
+  path.join(dirname, '..', '..', '..', 'protos/protos.json')
+);
+
+const version = getJSON(
+  path.join(dirname, '..', '..', '..', '..', 'package.json')
+).version;
 
 /**
  *  The Stackdriver Monitoring Service-Oriented Monitoring API has endpoints for

--- a/baselines/monitoring-esm/esm/src/v3/uptime_check_service_client.ts.baseline
+++ b/baselines/monitoring-esm/esm/src/v3/uptime_check_service_client.ts.baseline
@@ -36,7 +36,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 const gapicConfig = getJSON(
-  path.join(dirname, 'cloud_tasks_client_config.json')
+  path.join(dirname, 'uptime_check_service_client_config.json')
 );
 
 const jsonProtos = getJSON(

--- a/baselines/monitoring-esm/esm/src/v3/uptime_check_service_client.ts.baseline
+++ b/baselines/monitoring-esm/esm/src/v3/uptime_check_service_client.ts.baseline
@@ -26,6 +26,7 @@ import * as uptime_check_service_client_config from './uptime_check_service_clie
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {getJSON} from '../json-helper.cjs';
 // @ts-ignore
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -34,9 +35,17 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * `src/v3/uptime_check_service_client_config.json`.
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
-const gapicConfig = JSON.parse(fs.readFileSync(path.join(dirname, 'uptime_check_service_client_config.json'),'utf8'));
-const jsonProtos = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', 'protos/protos.json'), 'utf8'));
-const version = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', '..', 'package.json'), 'utf8')).version;
+const gapicConfig = getJSON(
+  path.join(dirname, 'cloud_tasks_client_config.json')
+);
+
+const jsonProtos = getJSON(
+  path.join(dirname, '..', '..', '..', 'protos/protos.json')
+);
+
+const version = getJSON(
+  path.join(dirname, '..', '..', '..', '..', 'package.json')
+).version;
 
 /**
  *  The UptimeCheckService API is used to manage (list, create, delete, edit)

--- a/baselines/monitoring-esm/package.json
+++ b/baselines/monitoring-esm/package.json
@@ -71,7 +71,7 @@
     "test:cjs": "c8 mocha build/cjs/test",
     "test:esm": "c8 mocha build/esm/test",
     "test": "npm run test:cjs && npm run test:esm",
-    "compile:esm": "tsc -p ./tsconfig.esm.json",
+    "compile:esm": "tsc -p ./tsconfig.esm.json && cp -r esm/src/json-helper.cjs build/esm/src/json-helper.cjs",
     "babel": "babel esm --out-dir build/cjs --ignore \"esm/**/*.d.ts\" --extensions \".ts\" --out-file-extension .cjs --copy-files",
     "compile:cjs": "tsc -p ./tsconfig.json && npm run babel",
     "compile": "npm run compile:esm && npm run compile:cjs && cp -r protos build/protos",

--- a/baselines/monitoring-esm/package.json
+++ b/baselines/monitoring-esm/package.json
@@ -18,6 +18,16 @@
         "types": "./build/cjs/src/index.d.ts",
         "default": "./build/cjs/src/index.cjs"
       }
+    },
+    "./build/protos/protos": {
+      "import": {
+        "types": "./build/protos/protos/protos.d.ts",
+        "default": "./build/protos/protos/protos.js"
+      },
+      "require": {
+        "types": "./build/protos/protos/protos.d.ts",
+        "default": "./build/protos/protos/protos.cjs"
+      }
     }
   },
   "files": [

--- a/baselines/monitoring-esm/tsconfig.esm.json.baseline
+++ b/baselines/monitoring-esm/tsconfig.esm.json.baseline
@@ -20,5 +20,8 @@
     "esm/test/*.ts",
     "esm/test/**/*.ts",
     "esm/system-test/*.ts"
+  ],
+  "exclude": [
+    "esm/src/json-heper.cjs"
   ]
 }

--- a/baselines/monitoring-esm/tsconfig.esm.json.baseline
+++ b/baselines/monitoring-esm/tsconfig.esm.json.baseline
@@ -22,6 +22,6 @@
     "esm/system-test/*.ts"
   ],
   "exclude": [
-    "esm/src/json-heper.cjs"
+    "esm/src/json-helper.cjs"
   ]
 }

--- a/baselines/naming-esm/esm/src/json-helper.cjs.baseline
+++ b/baselines/naming-esm/esm/src/json-helper.cjs.baseline
@@ -1,0 +1,20 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* eslint-disable node/no-missing-require */
+function getJSON(path) {
+  return require(path);
+}
+
+exports.getJSON = getJSON;

--- a/baselines/naming-esm/esm/src/v1beta1/naming_client.ts.baseline
+++ b/baselines/naming-esm/esm/src/v1beta1/naming_client.ts.baseline
@@ -36,7 +36,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 const gapicConfig = getJSON(
-  path.join(dirname, 'cloud_tasks_client_config.json')
+  path.join(dirname, 'naming_client_config.json')
 );
 
 const jsonProtos = getJSON(

--- a/baselines/naming-esm/esm/src/v1beta1/naming_client.ts.baseline
+++ b/baselines/naming-esm/esm/src/v1beta1/naming_client.ts.baseline
@@ -26,6 +26,7 @@ import * as naming_client_config from './naming_client_config.json';
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {getJSON} from '../json-helper.cjs';
 // @ts-ignore
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -34,9 +35,17 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * `src/v1beta1/naming_client_config.json`.
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
-const gapicConfig = JSON.parse(fs.readFileSync(path.join(dirname, 'naming_client_config.json'),'utf8'));
-const jsonProtos = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', 'protos/protos.json'), 'utf8'));
-const version = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', '..', 'package.json'), 'utf8')).version;
+const gapicConfig = getJSON(
+  path.join(dirname, 'cloud_tasks_client_config.json')
+);
+
+const jsonProtos = getJSON(
+  path.join(dirname, '..', '..', '..', 'protos/protos.json')
+);
+
+const version = getJSON(
+  path.join(dirname, '..', '..', '..', '..', 'package.json')
+).version;
 
 /**
  *  Fake service to test various possible naming problems.

--- a/baselines/naming-esm/package.json
+++ b/baselines/naming-esm/package.json
@@ -66,7 +66,7 @@
     "test:cjs": "c8 mocha build/cjs/test",
     "test:esm": "c8 mocha build/esm/test",
     "test": "npm run test:cjs && npm run test:esm",
-    "compile:esm": "tsc -p ./tsconfig.esm.json",
+    "compile:esm": "tsc -p ./tsconfig.esm.json && cp -r esm/src/json-helper.cjs build/esm/src/json-helper.cjs",
     "babel": "babel esm --out-dir build/cjs --ignore \"esm/**/*.d.ts\" --extensions \".ts\" --out-file-extension .cjs --copy-files",
     "compile:cjs": "tsc -p ./tsconfig.json && npm run babel",
     "compile": "npm run compile:esm && npm run compile:cjs && cp -r protos build/protos",

--- a/baselines/naming-esm/package.json
+++ b/baselines/naming-esm/package.json
@@ -18,6 +18,16 @@
         "types": "./build/cjs/src/index.d.ts",
         "default": "./build/cjs/src/index.cjs"
       }
+    },
+    "./build/protos/protos": {
+      "import": {
+        "types": "./build/protos/protos/protos.d.ts",
+        "default": "./build/protos/protos/protos.js"
+      },
+      "require": {
+        "types": "./build/protos/protos/protos.d.ts",
+        "default": "./build/protos/protos/protos.cjs"
+      }
     }
   },
   "files": [

--- a/baselines/naming-esm/tsconfig.esm.json.baseline
+++ b/baselines/naming-esm/tsconfig.esm.json.baseline
@@ -20,5 +20,8 @@
     "esm/test/*.ts",
     "esm/test/**/*.ts",
     "esm/system-test/*.ts"
+  ],
+  "exclude": [
+    "esm/src/json-heper.cjs"
   ]
 }

--- a/baselines/naming-esm/tsconfig.esm.json.baseline
+++ b/baselines/naming-esm/tsconfig.esm.json.baseline
@@ -22,6 +22,6 @@
     "esm/system-test/*.ts"
   ],
   "exclude": [
-    "esm/src/json-heper.cjs"
+    "esm/src/json-helper.cjs"
   ]
 }

--- a/baselines/redis-esm/esm/src/json-helper.cjs.baseline
+++ b/baselines/redis-esm/esm/src/json-helper.cjs.baseline
@@ -1,0 +1,20 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* eslint-disable node/no-missing-require */
+function getJSON(path) {
+  return require(path);
+}
+
+exports.getJSON = getJSON;

--- a/baselines/redis-esm/esm/src/v1beta1/cloud_redis_client.ts.baseline
+++ b/baselines/redis-esm/esm/src/v1beta1/cloud_redis_client.ts.baseline
@@ -26,6 +26,7 @@ import * as cloud_redis_client_config from './cloud_redis_client_config.json';
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {getJSON} from '../json-helper.cjs';
 // @ts-ignore
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -34,9 +35,17 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * `src/v1beta1/cloud_redis_client_config.json`.
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
-const gapicConfig = JSON.parse(fs.readFileSync(path.join(dirname, 'cloud_redis_client_config.json'),'utf8'));
-const jsonProtos = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', 'protos/protos.json'), 'utf8'));
-const version = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', '..', 'package.json'), 'utf8')).version;
+const gapicConfig = getJSON(
+  path.join(dirname, 'cloud_tasks_client_config.json')
+);
+
+const jsonProtos = getJSON(
+  path.join(dirname, '..', '..', '..', 'protos/protos.json')
+);
+
+const version = getJSON(
+  path.join(dirname, '..', '..', '..', '..', 'package.json')
+).version;
 
 /**
  *  Configures and manages Cloud Memorystore for Redis instances

--- a/baselines/redis-esm/esm/src/v1beta1/cloud_redis_client.ts.baseline
+++ b/baselines/redis-esm/esm/src/v1beta1/cloud_redis_client.ts.baseline
@@ -36,7 +36,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 const gapicConfig = getJSON(
-  path.join(dirname, 'cloud_tasks_client_config.json')
+  path.join(dirname, 'cloud_redis_client_config.json')
 );
 
 const jsonProtos = getJSON(

--- a/baselines/redis-esm/package.json
+++ b/baselines/redis-esm/package.json
@@ -66,7 +66,7 @@
     "test:cjs": "c8 mocha build/cjs/test",
     "test:esm": "c8 mocha build/esm/test",
     "test": "npm run test:cjs && npm run test:esm",
-    "compile:esm": "tsc -p ./tsconfig.esm.json",
+    "compile:esm": "tsc -p ./tsconfig.esm.json && cp -r esm/src/json-helper.cjs build/esm/src/json-helper.cjs",
     "babel": "babel esm --out-dir build/cjs --ignore \"esm/**/*.d.ts\" --extensions \".ts\" --out-file-extension .cjs --copy-files",
     "compile:cjs": "tsc -p ./tsconfig.json && npm run babel",
     "compile": "npm run compile:esm && npm run compile:cjs && cp -r protos build/protos",

--- a/baselines/redis-esm/package.json
+++ b/baselines/redis-esm/package.json
@@ -18,6 +18,16 @@
         "types": "./build/cjs/src/index.d.ts",
         "default": "./build/cjs/src/index.cjs"
       }
+    },
+    "./build/protos/protos": {
+      "import": {
+        "types": "./build/protos/protos/protos.d.ts",
+        "default": "./build/protos/protos/protos.js"
+      },
+      "require": {
+        "types": "./build/protos/protos/protos.d.ts",
+        "default": "./build/protos/protos/protos.cjs"
+      }
     }
   },
   "files": [

--- a/baselines/redis-esm/tsconfig.esm.json.baseline
+++ b/baselines/redis-esm/tsconfig.esm.json.baseline
@@ -20,5 +20,8 @@
     "esm/test/*.ts",
     "esm/test/**/*.ts",
     "esm/system-test/*.ts"
+  ],
+  "exclude": [
+    "esm/src/json-heper.cjs"
   ]
 }

--- a/baselines/redis-esm/tsconfig.esm.json.baseline
+++ b/baselines/redis-esm/tsconfig.esm.json.baseline
@@ -22,6 +22,6 @@
     "esm/system-test/*.ts"
   ],
   "exclude": [
-    "esm/src/json-heper.cjs"
+    "esm/src/json-helper.cjs"
   ]
 }

--- a/baselines/routingtest-esm/esm/src/json-helper.cjs.baseline
+++ b/baselines/routingtest-esm/esm/src/json-helper.cjs.baseline
@@ -1,0 +1,20 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* eslint-disable node/no-missing-require */
+function getJSON(path) {
+  return require(path);
+}
+
+exports.getJSON = getJSON;

--- a/baselines/routingtest-esm/esm/src/v1/test_service_client.ts.baseline
+++ b/baselines/routingtest-esm/esm/src/v1/test_service_client.ts.baseline
@@ -36,7 +36,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 const gapicConfig = getJSON(
-  path.join(dirname, 'cloud_tasks_client_config.json')
+  path.join(dirname, 'test_service_client_config.json')
 );
 
 const jsonProtos = getJSON(

--- a/baselines/routingtest-esm/esm/src/v1/test_service_client.ts.baseline
+++ b/baselines/routingtest-esm/esm/src/v1/test_service_client.ts.baseline
@@ -26,6 +26,7 @@ import * as test_service_client_config from './test_service_client_config.json';
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {getJSON} from '../json-helper.cjs';
 // @ts-ignore
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -34,9 +35,17 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * `src/v1/test_service_client_config.json`.
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
-const gapicConfig = JSON.parse(fs.readFileSync(path.join(dirname, 'test_service_client_config.json'),'utf8'));
-const jsonProtos = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', 'protos/protos.json'), 'utf8'));
-const version = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', '..', 'package.json'), 'utf8')).version;
+const gapicConfig = getJSON(
+  path.join(dirname, 'cloud_tasks_client_config.json')
+);
+
+const jsonProtos = getJSON(
+  path.join(dirname, '..', '..', '..', 'protos/protos.json')
+);
+
+const version = getJSON(
+  path.join(dirname, '..', '..', '..', '..', 'package.json')
+).version;
 
 /**
  *  This is a service description.

--- a/baselines/routingtest-esm/package.json
+++ b/baselines/routingtest-esm/package.json
@@ -66,7 +66,7 @@
     "test:cjs": "c8 mocha build/cjs/test",
     "test:esm": "c8 mocha build/esm/test",
     "test": "npm run test:cjs && npm run test:esm",
-    "compile:esm": "tsc -p ./tsconfig.esm.json",
+    "compile:esm": "tsc -p ./tsconfig.esm.json && cp -r esm/src/json-helper.cjs build/esm/src/json-helper.cjs",
     "babel": "babel esm --out-dir build/cjs --ignore \"esm/**/*.d.ts\" --extensions \".ts\" --out-file-extension .cjs --copy-files",
     "compile:cjs": "tsc -p ./tsconfig.json && npm run babel",
     "compile": "npm run compile:esm && npm run compile:cjs && cp -r protos build/protos",

--- a/baselines/routingtest-esm/package.json
+++ b/baselines/routingtest-esm/package.json
@@ -18,6 +18,16 @@
         "types": "./build/cjs/src/index.d.ts",
         "default": "./build/cjs/src/index.cjs"
       }
+    },
+    "./build/protos/protos": {
+      "import": {
+        "types": "./build/protos/protos/protos.d.ts",
+        "default": "./build/protos/protos/protos.js"
+      },
+      "require": {
+        "types": "./build/protos/protos/protos.d.ts",
+        "default": "./build/protos/protos/protos.cjs"
+      }
     }
   },
   "files": [

--- a/baselines/routingtest-esm/tsconfig.esm.json.baseline
+++ b/baselines/routingtest-esm/tsconfig.esm.json.baseline
@@ -20,5 +20,8 @@
     "esm/test/*.ts",
     "esm/test/**/*.ts",
     "esm/system-test/*.ts"
+  ],
+  "exclude": [
+    "esm/src/json-heper.cjs"
   ]
 }

--- a/baselines/routingtest-esm/tsconfig.esm.json.baseline
+++ b/baselines/routingtest-esm/tsconfig.esm.json.baseline
@@ -22,6 +22,6 @@
     "esm/system-test/*.ts"
   ],
   "exclude": [
-    "esm/src/json-heper.cjs"
+    "esm/src/json-helper.cjs"
   ]
 }

--- a/baselines/showcase-esm/esm/src/json-helper.cjs.baseline
+++ b/baselines/showcase-esm/esm/src/json-helper.cjs.baseline
@@ -1,0 +1,20 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* eslint-disable node/no-missing-require */
+function getJSON(path) {
+  return require(path);
+}
+
+exports.getJSON = getJSON;

--- a/baselines/showcase-esm/esm/src/v1beta1/compliance_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/compliance_client.ts.baseline
@@ -36,7 +36,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 const gapicConfig = getJSON(
-  path.join(dirname, 'cloud_tasks_client_config.json')
+  path.join(dirname, 'compliance_client_config.json')
 );
 
 const jsonProtos = getJSON(

--- a/baselines/showcase-esm/esm/src/v1beta1/compliance_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/compliance_client.ts.baseline
@@ -26,6 +26,7 @@ import * as compliance_client_config from './compliance_client_config.json';
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {getJSON} from '../json-helper.cjs';
 // @ts-ignore
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -34,9 +35,17 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * `src/v1beta1/compliance_client_config.json`.
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
-const gapicConfig = JSON.parse(fs.readFileSync(path.join(dirname, 'compliance_client_config.json'),'utf8'));
-const jsonProtos = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', 'protos/protos.json'), 'utf8'));
-const version = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', '..', 'package.json'), 'utf8')).version;
+const gapicConfig = getJSON(
+  path.join(dirname, 'cloud_tasks_client_config.json')
+);
+
+const jsonProtos = getJSON(
+  path.join(dirname, '..', '..', '..', 'protos/protos.json')
+);
+
+const version = getJSON(
+  path.join(dirname, '..', '..', '..', '..', 'package.json')
+).version;
 
 /**
  *  This service is used to test that GAPICs implement various REST-related features correctly. This mostly means transcoding proto3 requests to REST format

--- a/baselines/showcase-esm/esm/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/echo_client.ts.baseline
@@ -26,6 +26,7 @@ import * as echo_client_config from './echo_client_config.json';
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {getJSON} from '../json-helper.cjs';
 // @ts-ignore
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -34,9 +35,17 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * `src/v1beta1/echo_client_config.json`.
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
-const gapicConfig = JSON.parse(fs.readFileSync(path.join(dirname, 'echo_client_config.json'),'utf8'));
-const jsonProtos = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', 'protos/protos.json'), 'utf8'));
-const version = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', '..', 'package.json'), 'utf8')).version;
+const gapicConfig = getJSON(
+  path.join(dirname, 'cloud_tasks_client_config.json')
+);
+
+const jsonProtos = getJSON(
+  path.join(dirname, '..', '..', '..', 'protos/protos.json')
+);
+
+const version = getJSON(
+  path.join(dirname, '..', '..', '..', '..', 'package.json')
+).version;
 
 /**
  *  This service is used showcase the four main types of rpcs - unary, server

--- a/baselines/showcase-esm/esm/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/echo_client.ts.baseline
@@ -36,7 +36,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 const gapicConfig = getJSON(
-  path.join(dirname, 'cloud_tasks_client_config.json')
+  path.join(dirname, 'echo_client_config.json')
 );
 
 const jsonProtos = getJSON(

--- a/baselines/showcase-esm/esm/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/identity_client.ts.baseline
@@ -26,6 +26,7 @@ import * as identity_client_config from './identity_client_config.json';
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {getJSON} from '../json-helper.cjs';
 // @ts-ignore
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -34,9 +35,17 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * `src/v1beta1/identity_client_config.json`.
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
-const gapicConfig = JSON.parse(fs.readFileSync(path.join(dirname, 'identity_client_config.json'),'utf8'));
-const jsonProtos = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', 'protos/protos.json'), 'utf8'));
-const version = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', '..', 'package.json'), 'utf8')).version;
+const gapicConfig = getJSON(
+  path.join(dirname, 'cloud_tasks_client_config.json')
+);
+
+const jsonProtos = getJSON(
+  path.join(dirname, '..', '..', '..', 'protos/protos.json')
+);
+
+const version = getJSON(
+  path.join(dirname, '..', '..', '..', '..', 'package.json')
+).version;
 
 /**
  *  A simple identity service.

--- a/baselines/showcase-esm/esm/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/identity_client.ts.baseline
@@ -36,7 +36,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 const gapicConfig = getJSON(
-  path.join(dirname, 'cloud_tasks_client_config.json')
+  path.join(dirname, 'identity_client_config.json')
 );
 
 const jsonProtos = getJSON(

--- a/baselines/showcase-esm/esm/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/messaging_client.ts.baseline
@@ -26,6 +26,7 @@ import * as messaging_client_config from './messaging_client_config.json';
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {getJSON} from '../json-helper.cjs';
 // @ts-ignore
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -34,9 +35,17 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * `src/v1beta1/messaging_client_config.json`.
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
-const gapicConfig = JSON.parse(fs.readFileSync(path.join(dirname, 'messaging_client_config.json'),'utf8'));
-const jsonProtos = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', 'protos/protos.json'), 'utf8'));
-const version = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', '..', 'package.json'), 'utf8')).version;
+const gapicConfig = getJSON(
+  path.join(dirname, 'cloud_tasks_client_config.json')
+);
+
+const jsonProtos = getJSON(
+  path.join(dirname, '..', '..', '..', 'protos/protos.json')
+);
+
+const version = getJSON(
+  path.join(dirname, '..', '..', '..', '..', 'package.json')
+).version;
 
 /**
  *  A simple messaging service that implements chat rooms and profile posts.

--- a/baselines/showcase-esm/esm/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/messaging_client.ts.baseline
@@ -36,7 +36,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 const gapicConfig = getJSON(
-  path.join(dirname, 'cloud_tasks_client_config.json')
+  path.join(dirname, 'messaging_client_config.json')
 );
 
 const jsonProtos = getJSON(

--- a/baselines/showcase-esm/esm/src/v1beta1/sequence_service_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/sequence_service_client.ts.baseline
@@ -26,6 +26,7 @@ import * as sequence_service_client_config from './sequence_service_client_confi
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {getJSON} from '../json-helper.cjs';
 // @ts-ignore
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -34,9 +35,17 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * `src/v1beta1/sequence_service_client_config.json`.
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
-const gapicConfig = JSON.parse(fs.readFileSync(path.join(dirname, 'sequence_service_client_config.json'),'utf8'));
-const jsonProtos = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', 'protos/protos.json'), 'utf8'));
-const version = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', '..', 'package.json'), 'utf8')).version;
+const gapicConfig = getJSON(
+  path.join(dirname, 'cloud_tasks_client_config.json')
+);
+
+const jsonProtos = getJSON(
+  path.join(dirname, '..', '..', '..', 'protos/protos.json')
+);
+
+const version = getJSON(
+  path.join(dirname, '..', '..', '..', '..', 'package.json')
+).version;
 
 /**
  * @class

--- a/baselines/showcase-esm/esm/src/v1beta1/sequence_service_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/sequence_service_client.ts.baseline
@@ -36,7 +36,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 const gapicConfig = getJSON(
-  path.join(dirname, 'cloud_tasks_client_config.json')
+  path.join(dirname, 'sequence_service_client_config.json')
 );
 
 const jsonProtos = getJSON(

--- a/baselines/showcase-esm/esm/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/testing_client.ts.baseline
@@ -26,6 +26,7 @@ import * as testing_client_config from './testing_client_config.json';
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {getJSON} from '../json-helper.cjs';
 // @ts-ignore
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -34,9 +35,17 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * `src/v1beta1/testing_client_config.json`.
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
-const gapicConfig = JSON.parse(fs.readFileSync(path.join(dirname, 'testing_client_config.json'),'utf8'));
-const jsonProtos = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', 'protos/protos.json'), 'utf8'));
-const version = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', '..', 'package.json'), 'utf8')).version;
+const gapicConfig = getJSON(
+  path.join(dirname, 'cloud_tasks_client_config.json')
+);
+
+const jsonProtos = getJSON(
+  path.join(dirname, '..', '..', '..', 'protos/protos.json')
+);
+
+const version = getJSON(
+  path.join(dirname, '..', '..', '..', '..', 'package.json')
+).version;
 
 /**
  *  A service to facilitate running discrete sets of tests

--- a/baselines/showcase-esm/esm/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/testing_client.ts.baseline
@@ -36,7 +36,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 const gapicConfig = getJSON(
-  path.join(dirname, 'cloud_tasks_client_config.json')
+  path.join(dirname, 'testing_client_config.json')
 );
 
 const jsonProtos = getJSON(

--- a/baselines/showcase-esm/package.json
+++ b/baselines/showcase-esm/package.json
@@ -71,7 +71,7 @@
     "test:cjs": "c8 mocha build/cjs/test",
     "test:esm": "c8 mocha build/esm/test",
     "test": "npm run test:cjs && npm run test:esm",
-    "compile:esm": "tsc -p ./tsconfig.esm.json",
+    "compile:esm": "tsc -p ./tsconfig.esm.json && cp -r esm/src/json-helper.cjs build/esm/src/json-helper.cjs",
     "babel": "babel esm --out-dir build/cjs --ignore \"esm/**/*.d.ts\" --extensions \".ts\" --out-file-extension .cjs --copy-files",
     "compile:cjs": "tsc -p ./tsconfig.json && npm run babel",
     "compile": "npm run compile:esm && npm run compile:cjs && cp -r protos build/protos",

--- a/baselines/showcase-esm/package.json
+++ b/baselines/showcase-esm/package.json
@@ -18,6 +18,16 @@
         "types": "./build/cjs/src/index.d.ts",
         "default": "./build/cjs/src/index.cjs"
       }
+    },
+    "./build/protos/protos": {
+      "import": {
+        "types": "./build/protos/protos/protos.d.ts",
+        "default": "./build/protos/protos/protos.js"
+      },
+      "require": {
+        "types": "./build/protos/protos/protos.d.ts",
+        "default": "./build/protos/protos/protos.cjs"
+      }
     }
   },
   "files": [

--- a/baselines/showcase-esm/tsconfig.esm.json.baseline
+++ b/baselines/showcase-esm/tsconfig.esm.json.baseline
@@ -20,5 +20,8 @@
     "esm/test/*.ts",
     "esm/test/**/*.ts",
     "esm/system-test/*.ts"
+  ],
+  "exclude": [
+    "esm/src/json-heper.cjs"
   ]
 }

--- a/baselines/showcase-esm/tsconfig.esm.json.baseline
+++ b/baselines/showcase-esm/tsconfig.esm.json.baseline
@@ -22,6 +22,6 @@
     "esm/system-test/*.ts"
   ],
   "exclude": [
-    "esm/src/json-heper.cjs"
+    "esm/src/json-helper.cjs"
   ]
 }

--- a/baselines/showcase-legacy-esm/esm/src/json-helper.cjs.baseline
+++ b/baselines/showcase-legacy-esm/esm/src/json-helper.cjs.baseline
@@ -1,0 +1,20 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* eslint-disable node/no-missing-require */
+function getJSON(path) {
+  return require(path);
+}
+
+exports.getJSON = getJSON;

--- a/baselines/showcase-legacy-esm/esm/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase-legacy-esm/esm/src/v1beta1/echo_client.ts.baseline
@@ -35,7 +35,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 const gapicConfig = getJSON(
-  path.join(dirname, 'cloud_tasks_client_config.json')
+  path.join(dirname, 'echo_client_config.json')
 );
 
 const jsonProtos = getJSON(

--- a/baselines/showcase-legacy-esm/esm/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase-legacy-esm/esm/src/v1beta1/echo_client.ts.baseline
@@ -38,10 +38,6 @@ const gapicConfig = getJSON(
   path.join(dirname, 'echo_client_config.json')
 );
 
-const jsonProtos = getJSON(
-  path.join(dirname, '..', '..', '..', 'protos/protos.json')
-);
-
 const version = getJSON(
   path.join(dirname, '..', '..', '..', '..', 'package.json')
 ).version;

--- a/baselines/showcase-legacy-esm/esm/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase-legacy-esm/esm/src/v1beta1/echo_client.ts.baseline
@@ -25,6 +25,7 @@ import * as echo_client_config from './echo_client_config.json';
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {getJSON} from '../json-helper.cjs';
 // @ts-ignore
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -33,8 +34,17 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * `src/v1beta1/echo_client_config.json`.
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
-const gapicConfig = JSON.parse(fs.readFileSync(path.join(dirname, 'echo_client_config.json'),'utf8'));
-const version = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', '..', 'package.json'), 'utf8')).version;
+const gapicConfig = getJSON(
+  path.join(dirname, 'cloud_tasks_client_config.json')
+);
+
+const jsonProtos = getJSON(
+  path.join(dirname, '..', '..', '..', 'protos/protos.json')
+);
+
+const version = getJSON(
+  path.join(dirname, '..', '..', '..', '..', 'package.json')
+).version;
 
 /**
  *  This service is used showcase the four main types of rpcs - unary, server

--- a/baselines/showcase-legacy-esm/package.json
+++ b/baselines/showcase-legacy-esm/package.json
@@ -66,7 +66,7 @@
     "test:cjs": "c8 mocha build/cjs/test",
     "test:esm": "c8 mocha build/esm/test",
     "test": "npm run test:cjs && npm run test:esm",
-    "compile:esm": "tsc -p ./tsconfig.esm.json",
+    "compile:esm": "tsc -p ./tsconfig.esm.json && cp -r esm/src/json-helper.cjs build/esm/src/json-helper.cjs",
     "babel": "babel esm --out-dir build/cjs --ignore \"esm/**/*.d.ts\" --extensions \".ts\" --out-file-extension .cjs --copy-files",
     "compile:cjs": "tsc -p ./tsconfig.json && npm run babel",
     "compile": "npm run compile:esm && npm run compile:cjs && cp -r protos build/protos",

--- a/baselines/showcase-legacy-esm/package.json
+++ b/baselines/showcase-legacy-esm/package.json
@@ -18,6 +18,16 @@
         "types": "./build/cjs/src/index.d.ts",
         "default": "./build/cjs/src/index.cjs"
       }
+    },
+    "./build/protos/protos": {
+      "import": {
+        "types": "./build/protos/protos/protos.d.ts",
+        "default": "./build/protos/protos/protos.js"
+      },
+      "require": {
+        "types": "./build/protos/protos/protos.d.ts",
+        "default": "./build/protos/protos/protos.cjs"
+      }
     }
   },
   "files": [

--- a/baselines/showcase-legacy-esm/tsconfig.esm.json.baseline
+++ b/baselines/showcase-legacy-esm/tsconfig.esm.json.baseline
@@ -20,5 +20,8 @@
     "esm/test/*.ts",
     "esm/test/**/*.ts",
     "esm/system-test/*.ts"
+  ],
+  "exclude": [
+    "esm/src/json-heper.cjs"
   ]
 }

--- a/baselines/showcase-legacy-esm/tsconfig.esm.json.baseline
+++ b/baselines/showcase-legacy-esm/tsconfig.esm.json.baseline
@@ -22,6 +22,6 @@
     "esm/system-test/*.ts"
   ],
   "exclude": [
-    "esm/src/json-heper.cjs"
+    "esm/src/json-helper.cjs"
   ]
 }

--- a/baselines/tasks-esm/esm/src/json-helper.cjs.baseline
+++ b/baselines/tasks-esm/esm/src/json-helper.cjs.baseline
@@ -1,0 +1,20 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* eslint-disable node/no-missing-require */
+function getJSON(path) {
+  return require(path);
+}
+
+exports.getJSON = getJSON;

--- a/baselines/tasks-esm/esm/src/v2/cloud_tasks_client.ts.baseline
+++ b/baselines/tasks-esm/esm/src/v2/cloud_tasks_client.ts.baseline
@@ -26,6 +26,7 @@ import * as cloud_tasks_client_config from './cloud_tasks_client_config.json';
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {getJSON} from '../json-helper.cjs';
 // @ts-ignore
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -34,9 +35,17 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * `src/v2/cloud_tasks_client_config.json`.
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
-const gapicConfig = JSON.parse(fs.readFileSync(path.join(dirname, 'cloud_tasks_client_config.json'),'utf8'));
-const jsonProtos = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', 'protos/protos.json'), 'utf8'));
-const version = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', '..', 'package.json'), 'utf8')).version;
+const gapicConfig = getJSON(
+  path.join(dirname, 'cloud_tasks_client_config.json')
+);
+
+const jsonProtos = getJSON(
+  path.join(dirname, '..', '..', '..', 'protos/protos.json')
+);
+
+const version = getJSON(
+  path.join(dirname, '..', '..', '..', '..', 'package.json')
+).version;
 
 /**
  *  Cloud Tasks allows developers to manage the execution of background

--- a/baselines/tasks-esm/package.json
+++ b/baselines/tasks-esm/package.json
@@ -66,7 +66,7 @@
     "test:cjs": "c8 mocha build/cjs/test",
     "test:esm": "c8 mocha build/esm/test",
     "test": "npm run test:cjs && npm run test:esm",
-    "compile:esm": "tsc -p ./tsconfig.esm.json",
+    "compile:esm": "tsc -p ./tsconfig.esm.json && cp -r esm/src/json-helper.cjs build/esm/src/json-helper.cjs",
     "babel": "babel esm --out-dir build/cjs --ignore \"esm/**/*.d.ts\" --extensions \".ts\" --out-file-extension .cjs --copy-files",
     "compile:cjs": "tsc -p ./tsconfig.json && npm run babel",
     "compile": "npm run compile:esm && npm run compile:cjs && cp -r protos build/protos",

--- a/baselines/tasks-esm/package.json
+++ b/baselines/tasks-esm/package.json
@@ -18,6 +18,16 @@
         "types": "./build/cjs/src/index.d.ts",
         "default": "./build/cjs/src/index.cjs"
       }
+    },
+    "./build/protos/protos": {
+      "import": {
+        "types": "./build/protos/protos/protos.d.ts",
+        "default": "./build/protos/protos/protos.js"
+      },
+      "require": {
+        "types": "./build/protos/protos/protos.d.ts",
+        "default": "./build/protos/protos/protos.cjs"
+      }
     }
   },
   "files": [

--- a/baselines/tasks-esm/tsconfig.esm.json.baseline
+++ b/baselines/tasks-esm/tsconfig.esm.json.baseline
@@ -20,5 +20,8 @@
     "esm/test/*.ts",
     "esm/test/**/*.ts",
     "esm/system-test/*.ts"
+  ],
+  "exclude": [
+    "esm/src/json-heper.cjs"
   ]
 }

--- a/baselines/tasks-esm/tsconfig.esm.json.baseline
+++ b/baselines/tasks-esm/tsconfig.esm.json.baseline
@@ -22,6 +22,6 @@
     "esm/system-test/*.ts"
   ],
   "exclude": [
-    "esm/src/json-heper.cjs"
+    "esm/src/json-helper.cjs"
   ]
 }

--- a/baselines/texttospeech-esm/esm/src/json-helper.cjs.baseline
+++ b/baselines/texttospeech-esm/esm/src/json-helper.cjs.baseline
@@ -1,0 +1,20 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* eslint-disable node/no-missing-require */
+function getJSON(path) {
+  return require(path);
+}
+
+exports.getJSON = getJSON;

--- a/baselines/texttospeech-esm/esm/src/v1/text_to_speech_client.ts.baseline
+++ b/baselines/texttospeech-esm/esm/src/v1/text_to_speech_client.ts.baseline
@@ -36,7 +36,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 const gapicConfig = getJSON(
-  path.join(dirname, 'cloud_tasks_client_config.json')
+  path.join(dirname, 'text_to_speech_client_config.json')
 );
 
 const jsonProtos = getJSON(

--- a/baselines/texttospeech-esm/esm/src/v1/text_to_speech_client.ts.baseline
+++ b/baselines/texttospeech-esm/esm/src/v1/text_to_speech_client.ts.baseline
@@ -26,6 +26,7 @@ import * as text_to_speech_client_config from './text_to_speech_client_config.js
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {getJSON} from '../json-helper.cjs';
 // @ts-ignore
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -34,9 +35,17 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * `src/v1/text_to_speech_client_config.json`.
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
-const gapicConfig = JSON.parse(fs.readFileSync(path.join(dirname, 'text_to_speech_client_config.json'),'utf8'));
-const jsonProtos = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', 'protos/protos.json'), 'utf8'));
-const version = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', '..', 'package.json'), 'utf8')).version;
+const gapicConfig = getJSON(
+  path.join(dirname, 'cloud_tasks_client_config.json')
+);
+
+const jsonProtos = getJSON(
+  path.join(dirname, '..', '..', '..', 'protos/protos.json')
+);
+
+const version = getJSON(
+  path.join(dirname, '..', '..', '..', '..', 'package.json')
+).version;
 
 /**
  *  Service that implements Google Cloud Text-to-Speech API.

--- a/baselines/texttospeech-esm/package.json
+++ b/baselines/texttospeech-esm/package.json
@@ -66,7 +66,7 @@
     "test:cjs": "c8 mocha build/cjs/test",
     "test:esm": "c8 mocha build/esm/test",
     "test": "npm run test:cjs && npm run test:esm",
-    "compile:esm": "tsc -p ./tsconfig.esm.json",
+    "compile:esm": "tsc -p ./tsconfig.esm.json && cp -r esm/src/json-helper.cjs build/esm/src/json-helper.cjs",
     "babel": "babel esm --out-dir build/cjs --ignore \"esm/**/*.d.ts\" --extensions \".ts\" --out-file-extension .cjs --copy-files",
     "compile:cjs": "tsc -p ./tsconfig.json && npm run babel",
     "compile": "npm run compile:esm && npm run compile:cjs && cp -r protos build/protos",

--- a/baselines/texttospeech-esm/package.json
+++ b/baselines/texttospeech-esm/package.json
@@ -18,6 +18,16 @@
         "types": "./build/cjs/src/index.d.ts",
         "default": "./build/cjs/src/index.cjs"
       }
+    },
+    "./build/protos/protos": {
+      "import": {
+        "types": "./build/protos/protos/protos.d.ts",
+        "default": "./build/protos/protos/protos.js"
+      },
+      "require": {
+        "types": "./build/protos/protos/protos.d.ts",
+        "default": "./build/protos/protos/protos.cjs"
+      }
     }
   },
   "files": [

--- a/baselines/texttospeech-esm/tsconfig.esm.json.baseline
+++ b/baselines/texttospeech-esm/tsconfig.esm.json.baseline
@@ -20,5 +20,8 @@
     "esm/test/*.ts",
     "esm/test/**/*.ts",
     "esm/system-test/*.ts"
+  ],
+  "exclude": [
+    "esm/src/json-heper.cjs"
   ]
 }

--- a/baselines/texttospeech-esm/tsconfig.esm.json.baseline
+++ b/baselines/texttospeech-esm/tsconfig.esm.json.baseline
@@ -22,6 +22,6 @@
     "esm/system-test/*.ts"
   ],
   "exclude": [
-    "esm/src/json-heper.cjs"
+    "esm/src/json-helper.cjs"
   ]
 }

--- a/baselines/translate-esm/esm/src/json-helper.cjs.baseline
+++ b/baselines/translate-esm/esm/src/json-helper.cjs.baseline
@@ -1,0 +1,20 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* eslint-disable node/no-missing-require */
+function getJSON(path) {
+  return require(path);
+}
+
+exports.getJSON = getJSON;

--- a/baselines/translate-esm/esm/src/v3beta1/translation_service_client.ts.baseline
+++ b/baselines/translate-esm/esm/src/v3beta1/translation_service_client.ts.baseline
@@ -36,7 +36,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 const gapicConfig = getJSON(
-  path.join(dirname, 'cloud_tasks_client_config.json')
+  path.join(dirname, 'translation_service_client_config.json')
 );
 
 const jsonProtos = getJSON(

--- a/baselines/translate-esm/esm/src/v3beta1/translation_service_client.ts.baseline
+++ b/baselines/translate-esm/esm/src/v3beta1/translation_service_client.ts.baseline
@@ -26,6 +26,7 @@ import * as translation_service_client_config from './translation_service_client
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {getJSON} from '../json-helper.cjs';
 // @ts-ignore
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -34,9 +35,17 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * `src/v3beta1/translation_service_client_config.json`.
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
-const gapicConfig = JSON.parse(fs.readFileSync(path.join(dirname, 'translation_service_client_config.json'),'utf8'));
-const jsonProtos = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', 'protos/protos.json'), 'utf8'));
-const version = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', '..', 'package.json'), 'utf8')).version;
+const gapicConfig = getJSON(
+  path.join(dirname, 'cloud_tasks_client_config.json')
+);
+
+const jsonProtos = getJSON(
+  path.join(dirname, '..', '..', '..', 'protos/protos.json')
+);
+
+const version = getJSON(
+  path.join(dirname, '..', '..', '..', '..', 'package.json')
+).version;
 
 /**
  *  Provides natural language translation operations.

--- a/baselines/translate-esm/package.json
+++ b/baselines/translate-esm/package.json
@@ -66,7 +66,7 @@
     "test:cjs": "c8 mocha build/cjs/test",
     "test:esm": "c8 mocha build/esm/test",
     "test": "npm run test:cjs && npm run test:esm",
-    "compile:esm": "tsc -p ./tsconfig.esm.json",
+    "compile:esm": "tsc -p ./tsconfig.esm.json && cp -r esm/src/json-helper.cjs build/esm/src/json-helper.cjs",
     "babel": "babel esm --out-dir build/cjs --ignore \"esm/**/*.d.ts\" --extensions \".ts\" --out-file-extension .cjs --copy-files",
     "compile:cjs": "tsc -p ./tsconfig.json && npm run babel",
     "compile": "npm run compile:esm && npm run compile:cjs && cp -r protos build/protos",

--- a/baselines/translate-esm/package.json
+++ b/baselines/translate-esm/package.json
@@ -18,6 +18,16 @@
         "types": "./build/cjs/src/index.d.ts",
         "default": "./build/cjs/src/index.cjs"
       }
+    },
+    "./build/protos/protos": {
+      "import": {
+        "types": "./build/protos/protos/protos.d.ts",
+        "default": "./build/protos/protos/protos.js"
+      },
+      "require": {
+        "types": "./build/protos/protos/protos.d.ts",
+        "default": "./build/protos/protos/protos.cjs"
+      }
     }
   },
   "files": [

--- a/baselines/translate-esm/tsconfig.esm.json.baseline
+++ b/baselines/translate-esm/tsconfig.esm.json.baseline
@@ -20,5 +20,8 @@
     "esm/test/*.ts",
     "esm/test/**/*.ts",
     "esm/system-test/*.ts"
+  ],
+  "exclude": [
+    "esm/src/json-heper.cjs"
   ]
 }

--- a/baselines/translate-esm/tsconfig.esm.json.baseline
+++ b/baselines/translate-esm/tsconfig.esm.json.baseline
@@ -22,6 +22,6 @@
     "esm/system-test/*.ts"
   ],
   "exclude": [
-    "esm/src/json-heper.cjs"
+    "esm/src/json-helper.cjs"
   ]
 }

--- a/baselines/videointelligence-esm/esm/src/json-helper.cjs.baseline
+++ b/baselines/videointelligence-esm/esm/src/json-helper.cjs.baseline
@@ -1,0 +1,20 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* eslint-disable node/no-missing-require */
+function getJSON(path) {
+  return require(path);
+}
+
+exports.getJSON = getJSON;

--- a/baselines/videointelligence-esm/esm/src/v1/video_intelligence_service_client.ts.baseline
+++ b/baselines/videointelligence-esm/esm/src/v1/video_intelligence_service_client.ts.baseline
@@ -36,7 +36,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 const gapicConfig = getJSON(
-  path.join(dirname, 'cloud_tasks_client_config.json')
+  path.join(dirname, 'video_intelligence_service_client_config.json')
 );
 
 const jsonProtos = getJSON(

--- a/baselines/videointelligence-esm/esm/src/v1/video_intelligence_service_client.ts.baseline
+++ b/baselines/videointelligence-esm/esm/src/v1/video_intelligence_service_client.ts.baseline
@@ -26,6 +26,7 @@ import * as video_intelligence_service_client_config from './video_intelligence_
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {getJSON} from '../json-helper.cjs';
 // @ts-ignore
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -34,9 +35,17 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * `src/v1/video_intelligence_service_client_config.json`.
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
-const gapicConfig = JSON.parse(fs.readFileSync(path.join(dirname, 'video_intelligence_service_client_config.json'),'utf8'));
-const jsonProtos = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', 'protos/protos.json'), 'utf8'));
-const version = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', '..', 'package.json'), 'utf8')).version;
+const gapicConfig = getJSON(
+  path.join(dirname, 'cloud_tasks_client_config.json')
+);
+
+const jsonProtos = getJSON(
+  path.join(dirname, '..', '..', '..', 'protos/protos.json')
+);
+
+const version = getJSON(
+  path.join(dirname, '..', '..', '..', '..', 'package.json')
+).version;
 
 /**
  *  Service that implements Google Cloud Video Intelligence API.

--- a/baselines/videointelligence-esm/package.json
+++ b/baselines/videointelligence-esm/package.json
@@ -66,7 +66,7 @@
     "test:cjs": "c8 mocha build/cjs/test",
     "test:esm": "c8 mocha build/esm/test",
     "test": "npm run test:cjs && npm run test:esm",
-    "compile:esm": "tsc -p ./tsconfig.esm.json",
+    "compile:esm": "tsc -p ./tsconfig.esm.json && cp -r esm/src/json-helper.cjs build/esm/src/json-helper.cjs",
     "babel": "babel esm --out-dir build/cjs --ignore \"esm/**/*.d.ts\" --extensions \".ts\" --out-file-extension .cjs --copy-files",
     "compile:cjs": "tsc -p ./tsconfig.json && npm run babel",
     "compile": "npm run compile:esm && npm run compile:cjs && cp -r protos build/protos",

--- a/baselines/videointelligence-esm/package.json
+++ b/baselines/videointelligence-esm/package.json
@@ -18,6 +18,16 @@
         "types": "./build/cjs/src/index.d.ts",
         "default": "./build/cjs/src/index.cjs"
       }
+    },
+    "./build/protos/protos": {
+      "import": {
+        "types": "./build/protos/protos/protos.d.ts",
+        "default": "./build/protos/protos/protos.js"
+      },
+      "require": {
+        "types": "./build/protos/protos/protos.d.ts",
+        "default": "./build/protos/protos/protos.cjs"
+      }
     }
   },
   "files": [

--- a/baselines/videointelligence-esm/tsconfig.esm.json.baseline
+++ b/baselines/videointelligence-esm/tsconfig.esm.json.baseline
@@ -20,5 +20,8 @@
     "esm/test/*.ts",
     "esm/test/**/*.ts",
     "esm/system-test/*.ts"
+  ],
+  "exclude": [
+    "esm/src/json-heper.cjs"
   ]
 }

--- a/baselines/videointelligence-esm/tsconfig.esm.json.baseline
+++ b/baselines/videointelligence-esm/tsconfig.esm.json.baseline
@@ -22,6 +22,6 @@
     "esm/system-test/*.ts"
   ],
   "exclude": [
-    "esm/src/json-heper.cjs"
+    "esm/src/json-helper.cjs"
   ]
 }

--- a/templates/esm/typescript_gapic/esm/src/$version/$service_client.ts.njk
+++ b/templates/esm/typescript_gapic/esm/src/$version/$service_client.ts.njk
@@ -59,11 +59,11 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
 const gapicConfig = getJSON(
   path.join(dirname, '{{ service.name.toSnakeCase() }}_client_config.json')
 );
-
+{% if not api.legacyProtoLoad %}
 const jsonProtos = getJSON(
   path.join(dirname, '..', '..', '..', 'protos/protos.json')
 );
-
+{% endif %}
 const version = getJSON(
   path.join(dirname, '..', '..', '..', '..', 'package.json')
 ).version;

--- a/templates/esm/typescript_gapic/esm/src/$version/$service_client.ts.njk
+++ b/templates/esm/typescript_gapic/esm/src/$version/$service_client.ts.njk
@@ -57,7 +57,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 const gapicConfig = getJSON(
-  path.join(dirname, 'cloud_tasks_client_config.json')
+  path.join(dirname, '{{ service.name.toSnakeCase() }}_client_config.json')
 );
 
 const jsonProtos = getJSON(

--- a/templates/esm/typescript_gapic/esm/src/$version/$service_client.ts.njk
+++ b/templates/esm/typescript_gapic/esm/src/$version/$service_client.ts.njk
@@ -47,6 +47,7 @@ import * as {{ service.name.toSnakeCase() }}_client_config from './{{ service.na
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {getJSON} from '../json-helper.cjs';
 // @ts-ignore
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -55,11 +56,17 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
  * `src/{{ api.naming.version }}/{{ service.name.toSnakeCase() }}_client_config.json`.
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
-const gapicConfig = JSON.parse(fs.readFileSync(path.join(dirname, '{{ service.name.toSnakeCase() }}_client_config.json'),'utf8'));
-{%- if not api.legacyProtoLoad %}
-const jsonProtos = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', 'protos/protos.json'), 'utf8'));
-{%- endif %}
-const version = JSON.parse(fs.readFileSync(path.join(dirname, '..', '..', '..', '..', 'package.json'), 'utf8')).version;
+const gapicConfig = getJSON(
+  path.join(dirname, 'cloud_tasks_client_config.json')
+);
+
+const jsonProtos = getJSON(
+  path.join(dirname, '..', '..', '..', 'protos/protos.json')
+);
+
+const version = getJSON(
+  path.join(dirname, '..', '..', '..', '..', 'package.json')
+).version;
 
 /**
 {{- util.printCommentsForService(service) }}

--- a/templates/esm/typescript_gapic/esm/src/json-helper.cjs.njk
+++ b/templates/esm/typescript_gapic/esm/src/json-helper.cjs.njk
@@ -1,0 +1,20 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* eslint-disable node/no-missing-require */
+function getJSON(path) {
+  return require(path);
+}
+
+exports.getJSON = getJSON;

--- a/templates/esm/typescript_gapic/package.json
+++ b/templates/esm/typescript_gapic/package.json
@@ -19,6 +19,16 @@
         "types": "./build/cjs/src/index.d.ts",
         "default": "./build/cjs/src/index.cjs"
       }
+    },
+    "./build/protos/protos": {
+      "import": {
+        "types": "./build/protos/protos/protos.d.ts",
+        "default": "./build/protos/protos/protos.js"
+      },
+      "require": {
+        "types": "./build/protos/protos/protos.d.ts",
+        "default": "./build/protos/protos/protos.cjs"
+      }
     }
   },
   "files": [

--- a/templates/esm/typescript_gapic/package.json
+++ b/templates/esm/typescript_gapic/package.json
@@ -67,7 +67,7 @@
     "test:cjs": "c8 mocha build/cjs/test",
     "test:esm": "c8 mocha build/esm/test",
     "test": "npm run test:cjs && npm run test:esm",
-    "compile:esm": "tsc -p ./tsconfig.esm.json",
+    "compile:esm": "tsc -p ./tsconfig.esm.json && cp -r esm/src/json-helper.cjs build/esm/src/json-helper.cjs",
     "babel": "babel esm --out-dir build/cjs --ignore \"esm/**/*.d.ts\" --extensions \".ts\" --out-file-extension .cjs --copy-files",
     "compile:cjs": "tsc -p ./tsconfig.json && npm run babel",
     "compile": "npm run compile:esm && npm run compile:cjs && cp -r protos build/protos",

--- a/templates/esm/typescript_gapic/tsconfig.esm.json.njk
+++ b/templates/esm/typescript_gapic/tsconfig.esm.json.njk
@@ -39,6 +39,6 @@ limitations under the License.
     "esm/system-test/*.ts"
   ],
   "exclude": [
-    "esm/src/json-heper.cjs"
+    "esm/src/json-helper.cjs"
   ]
 }

--- a/templates/esm/typescript_gapic/tsconfig.esm.json.njk
+++ b/templates/esm/typescript_gapic/tsconfig.esm.json.njk
@@ -37,5 +37,8 @@ limitations under the License.
     "esm/test/*.ts",
     "esm/test/**/*.ts",
     "esm/system-test/*.ts"
+  ],
+  "exclude": [
+    "esm/src/json-heper.cjs"
   ]
 }


### PR DESCRIPTION
Until we can use assertions (Node 16+), this solution will allow bundlers to pick up JSON files (this is what nodejs-storage uses).

Fixes https://github.com/googleapis/google-cloud-node/issues/4858