### PR TITLE
fix: do not use gaxServerStreamingRetries for bidi or client streaming

### DIFF
--- a/baselines/bigquery-storage-esm/esm/test/gapic_big_query_storage_v1beta1.ts.baseline
+++ b/baselines/bigquery-storage-esm/esm/test/gapic_big_query_storage_v1beta1.ts.baseline
@@ -738,6 +738,41 @@ describe('v1beta1.BigQueryStorageClient', () => {
             assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
+        it('invokes readRows without error and gaxServerStreamingRetries enabled', async () => {
+            const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({gaxServerStreamingRetries: true});
+            client.initialize();
+            const request = generateSampleMessage(
+              new protos.google.cloud.bigquery.storage.v1beta1.ReadRowsRequest()
+            );
+            request.readPosition ??= {};
+            request.readPosition.stream ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('.google.cloud.bigquery.storage.v1beta1.ReadRowsRequest', ['readPosition', 'stream', 'name']);
+            request.readPosition.stream.name = defaultValue1;
+            const expectedHeaderRequestParams = `read_position.stream.name=${defaultValue1 ?? '' }`;
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.bigquery.storage.v1beta1.ReadRowsResponse()
+            );
+            client.innerApiCalls.readRows = stubServerStreamingCall(expectedResponse);
+            const stream = client.readRows(request);
+            const promise = new Promise((resolve, reject) => {
+                stream.on('data', (response: protos.google.cloud.bigquery.storage.v1beta1.ReadRowsResponse) => {
+                    resolve(response);
+                });
+                stream.on('error', (err: Error) => {
+                    reject(err);
+                });
+            });
+            const response = await promise;
+            assert.deepStrictEqual(response, expectedResponse);
+            const actualRequest = (client.innerApiCalls.readRows as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.readRows as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
+        });
+
         it('invokes readRows with error', async () => {
             const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({
               credentials: {client_email: 'bogus', private_key: 'bogus'},
@@ -799,6 +834,12 @@ describe('v1beta1.BigQueryStorageClient', () => {
                 });
             });
             await assert.rejects(promise, expectedError);
+        });
+        it('should create a client with gaxServerStreamingRetries enabled', () => {
+            const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({
+                gaxServerStreamingRetries: true,
+            });
+            assert(client);
         });
     });
 

--- a/baselines/bigquery-storage/test/gapic_big_query_storage_v1beta1.ts.baseline
+++ b/baselines/bigquery-storage/test/gapic_big_query_storage_v1beta1.ts.baseline
@@ -729,6 +729,41 @@ describe('v1beta1.BigQueryStorageClient', () => {
             assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
+        it('invokes readRows without error and gaxServerStreamingRetries enabled', async () => {
+            const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({gaxServerStreamingRetries: true});
+            client.initialize();
+            const request = generateSampleMessage(
+              new protos.google.cloud.bigquery.storage.v1beta1.ReadRowsRequest()
+            );
+            request.readPosition ??= {};
+            request.readPosition.stream ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('.google.cloud.bigquery.storage.v1beta1.ReadRowsRequest', ['readPosition', 'stream', 'name']);
+            request.readPosition.stream.name = defaultValue1;
+            const expectedHeaderRequestParams = `read_position.stream.name=${defaultValue1}`;
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.bigquery.storage.v1beta1.ReadRowsResponse()
+            );
+            client.innerApiCalls.readRows = stubServerStreamingCall(expectedResponse);
+            const stream = client.readRows(request);
+            const promise = new Promise((resolve, reject) => {
+                stream.on('data', (response: protos.google.cloud.bigquery.storage.v1beta1.ReadRowsResponse) => {
+                    resolve(response);
+                });
+                stream.on('error', (err: Error) => {
+                    reject(err);
+                });
+            });
+            const response = await promise;
+            assert.deepStrictEqual(response, expectedResponse);
+            const actualRequest = (client.innerApiCalls.readRows as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.readRows as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
+        });
+
         it('invokes readRows with error', async () => {
             const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({
               credentials: {client_email: 'bogus', private_key: 'bogus'},
@@ -790,6 +825,12 @@ describe('v1beta1.BigQueryStorageClient', () => {
                 });
             });
             await assert.rejects(promise, expectedError);
+        });
+        it('should create a client with gaxServerStreamingRetries enabled', () => {
+            const client = new bigquerystorageModule.v1beta1.BigQueryStorageClient({
+                gaxServerStreamingRetries: true,
+            });
+            assert(client);
         });
     });
 

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/echo_client.ts.baseline
@@ -248,7 +248,7 @@ export class EchoClient {
     // Provide descriptors for these.
     this.descriptors.stream = {
       expand: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.SERVER_STREAMING, !!opts.fallback, !!opts.gaxServerStreamingRetries),
-      collect: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, !!opts.fallback, !!opts.gaxServerStreamingRetries),
+    collect: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, !!opts.fallback),
       chat: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.BIDI_STREAMING, !!opts.fallback, !!opts.gaxServerStreamingRetries)
     };
 

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/messaging_client.ts.baseline
@@ -247,7 +247,7 @@ export class MessagingClient {
     // Provide descriptors for these.
     this.descriptors.stream = {
       streamBlurbs: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.SERVER_STREAMING, !!opts.fallback, !!opts.gaxServerStreamingRetries),
-      sendBlurbs: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, !!opts.fallback, !!opts.gaxServerStreamingRetries),
+    sendBlurbs: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, !!opts.fallback),
       connect: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.BIDI_STREAMING, !!opts.fallback, !!opts.gaxServerStreamingRetries)
     };
 

--- a/baselines/disable-packing-test-esm/esm/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/test/gapic_echo_v1beta1.ts.baseline
@@ -671,6 +671,29 @@ describe('v1beta1.EchoClient', () => {
             assert.deepStrictEqual(response, expectedResponse);
         });
 
+        it('invokes expand without error and gaxServerStreamingRetries enabled', async () => {
+            const client = new echoModule.v1beta1.EchoClient({gaxServerStreamingRetries: true});
+            client.initialize();
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ExpandRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoResponse()
+            );
+            client.innerApiCalls.expand = stubServerStreamingCall(expectedResponse);
+            const stream = client.expand(request);
+            const promise = new Promise((resolve, reject) => {
+                stream.on('data', (response: protos.google.showcase.v1beta1.EchoResponse) => {
+                    resolve(response);
+                });
+                stream.on('error', (err: Error) => {
+                    reject(err);
+                });
+            });
+            const response = await promise;
+            assert.deepStrictEqual(response, expectedResponse);
+        });
+
         it('invokes expand with error', async () => {
             const client = new echoModule.v1beta1.EchoClient({
               credentials: {client_email: 'bogus', private_key: 'bogus'},
@@ -715,6 +738,12 @@ describe('v1beta1.EchoClient', () => {
                 });
             });
             await assert.rejects(promise, expectedError);
+        });
+        it('should create a client with gaxServerStreamingRetries enabled', () => {
+            const client = new echoModule.v1beta1.EchoClient({
+                gaxServerStreamingRetries: true,
+            });
+            assert(client);
         });
     });
 

--- a/baselines/disable-packing-test-esm/esm/test/gapic_messaging_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/test/gapic_messaging_v1beta1.ts.baseline
@@ -1306,6 +1306,39 @@ describe('v1beta1.MessagingClient', () => {
             assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
+        it('invokes streamBlurbs without error and gaxServerStreamingRetries enabled', async () => {
+            const client = new messagingModule.v1beta1.MessagingClient({gaxServerStreamingRetries: true});
+            client.initialize();
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.StreamBlurbsRequest()
+            );
+            const defaultValue1 =
+              getTypeDefaultValue('.google.showcase.v1beta1.StreamBlurbsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1 ?? '' }`;
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.StreamBlurbsResponse()
+            );
+            client.innerApiCalls.streamBlurbs = stubServerStreamingCall(expectedResponse);
+            const stream = client.streamBlurbs(request);
+            const promise = new Promise((resolve, reject) => {
+                stream.on('data', (response: protos.google.showcase.v1beta1.StreamBlurbsResponse) => {
+                    resolve(response);
+                });
+                stream.on('error', (err: Error) => {
+                    reject(err);
+                });
+            });
+            const response = await promise;
+            assert.deepStrictEqual(response, expectedResponse);
+            const actualRequest = (client.innerApiCalls.streamBlurbs as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.streamBlurbs as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
+        });
+
         it('invokes streamBlurbs with error', async () => {
             const client = new messagingModule.v1beta1.MessagingClient({
               credentials: {client_email: 'bogus', private_key: 'bogus'},
@@ -1363,6 +1396,12 @@ describe('v1beta1.MessagingClient', () => {
                 });
             });
             await assert.rejects(promise, expectedError);
+        });
+        it('should create a client with gaxServerStreamingRetries enabled', () => {
+            const client = new messagingModule.v1beta1.MessagingClient({
+                gaxServerStreamingRetries: true,
+            });
+            assert(client);
         });
     });
 

--- a/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
@@ -225,7 +225,7 @@ export class EchoClient {
     // Provide descriptors for these.
     this.descriptors.stream = {
       expand: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.SERVER_STREAMING, !!opts.fallback, !!opts.gaxServerStreamingRetries),
-      collect: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, !!opts.fallback, !!opts.gaxServerStreamingRetries),
+    collect: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, !!opts.fallback),
       chat: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.BIDI_STREAMING, !!opts.fallback, !!opts.gaxServerStreamingRetries)
     };
 

--- a/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
@@ -224,7 +224,7 @@ export class MessagingClient {
     // Provide descriptors for these.
     this.descriptors.stream = {
       streamBlurbs: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.SERVER_STREAMING, !!opts.fallback, !!opts.gaxServerStreamingRetries),
-      sendBlurbs: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, !!opts.fallback, !!opts.gaxServerStreamingRetries),
+    sendBlurbs: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, !!opts.fallback),
       connect: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.BIDI_STREAMING, !!opts.fallback, !!opts.gaxServerStreamingRetries)
     };
 

--- a/baselines/disable-packing-test/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_echo_v1beta1.ts.baseline
@@ -662,6 +662,29 @@ describe('v1beta1.EchoClient', () => {
             assert.deepStrictEqual(response, expectedResponse);
         });
 
+        it('invokes expand without error and gaxServerStreamingRetries enabled', async () => {
+            const client = new echoModule.v1beta1.EchoClient({gaxServerStreamingRetries: true});
+            client.initialize();
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ExpandRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoResponse()
+            );
+            client.innerApiCalls.expand = stubServerStreamingCall(expectedResponse);
+            const stream = client.expand(request);
+            const promise = new Promise((resolve, reject) => {
+                stream.on('data', (response: protos.google.showcase.v1beta1.EchoResponse) => {
+                    resolve(response);
+                });
+                stream.on('error', (err: Error) => {
+                    reject(err);
+                });
+            });
+            const response = await promise;
+            assert.deepStrictEqual(response, expectedResponse);
+        });
+
         it('invokes expand with error', async () => {
             const client = new echoModule.v1beta1.EchoClient({
               credentials: {client_email: 'bogus', private_key: 'bogus'},
@@ -706,6 +729,12 @@ describe('v1beta1.EchoClient', () => {
                 });
             });
             await assert.rejects(promise, expectedError);
+        });
+        it('should create a client with gaxServerStreamingRetries enabled', () => {
+            const client = new echoModule.v1beta1.EchoClient({
+                gaxServerStreamingRetries: true,
+            });
+            assert(client);
         });
     });
 

--- a/baselines/disable-packing-test/test/gapic_messaging_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_messaging_v1beta1.ts.baseline
@@ -1297,6 +1297,39 @@ describe('v1beta1.MessagingClient', () => {
             assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
+        it('invokes streamBlurbs without error and gaxServerStreamingRetries enabled', async () => {
+            const client = new messagingModule.v1beta1.MessagingClient({gaxServerStreamingRetries: true});
+            client.initialize();
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.StreamBlurbsRequest()
+            );
+            const defaultValue1 =
+              getTypeDefaultValue('.google.showcase.v1beta1.StreamBlurbsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.StreamBlurbsResponse()
+            );
+            client.innerApiCalls.streamBlurbs = stubServerStreamingCall(expectedResponse);
+            const stream = client.streamBlurbs(request);
+            const promise = new Promise((resolve, reject) => {
+                stream.on('data', (response: protos.google.showcase.v1beta1.StreamBlurbsResponse) => {
+                    resolve(response);
+                });
+                stream.on('error', (err: Error) => {
+                    reject(err);
+                });
+            });
+            const response = await promise;
+            assert.deepStrictEqual(response, expectedResponse);
+            const actualRequest = (client.innerApiCalls.streamBlurbs as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.streamBlurbs as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
+        });
+
         it('invokes streamBlurbs with error', async () => {
             const client = new messagingModule.v1beta1.MessagingClient({
               credentials: {client_email: 'bogus', private_key: 'bogus'},
@@ -1354,6 +1387,12 @@ describe('v1beta1.MessagingClient', () => {
                 });
             });
             await assert.rejects(promise, expectedError);
+        });
+        it('should create a client with gaxServerStreamingRetries enabled', () => {
+            const client = new messagingModule.v1beta1.MessagingClient({
+                gaxServerStreamingRetries: true,
+            });
+            assert(client);
         });
     });
 

--- a/baselines/showcase-esm/esm/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/echo_client.ts.baseline
@@ -251,7 +251,7 @@ export class EchoClient {
     // Provide descriptors for these.
     this.descriptors.stream = {
       expand: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.SERVER_STREAMING, !!opts.fallback, !!opts.gaxServerStreamingRetries),
-      collect: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, !!opts.fallback, !!opts.gaxServerStreamingRetries),
+    collect: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, !!opts.fallback),
       chat: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.BIDI_STREAMING, !!opts.fallback, !!opts.gaxServerStreamingRetries)
     };
 

--- a/baselines/showcase-esm/esm/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/messaging_client.ts.baseline
@@ -250,7 +250,7 @@ export class MessagingClient {
     // Provide descriptors for these.
     this.descriptors.stream = {
       streamBlurbs: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.SERVER_STREAMING, !!opts.fallback, !!opts.gaxServerStreamingRetries),
-      sendBlurbs: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, !!opts.fallback, !!opts.gaxServerStreamingRetries),
+    sendBlurbs: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, !!opts.fallback),
       connect: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.BIDI_STREAMING, !!opts.fallback, !!opts.gaxServerStreamingRetries)
     };
 

--- a/baselines/showcase-esm/esm/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase-esm/esm/test/gapic_echo_v1beta1.ts.baseline
@@ -677,6 +677,29 @@ describe('v1beta1.EchoClient', () => {
             assert.deepStrictEqual(response, expectedResponse);
         });
 
+        it('invokes expand without error and gaxServerStreamingRetries enabled', async () => {
+            const client = new echoModule.v1beta1.EchoClient({gaxServerStreamingRetries: true});
+            client.initialize();
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ExpandRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoResponse()
+            );
+            client.innerApiCalls.expand = stubServerStreamingCall(expectedResponse);
+            const stream = client.expand(request);
+            const promise = new Promise((resolve, reject) => {
+                stream.on('data', (response: protos.google.showcase.v1beta1.EchoResponse) => {
+                    resolve(response);
+                });
+                stream.on('error', (err: Error) => {
+                    reject(err);
+                });
+            });
+            const response = await promise;
+            assert.deepStrictEqual(response, expectedResponse);
+        });
+
         it('invokes expand with error', async () => {
             const client = new echoModule.v1beta1.EchoClient({
               credentials: {client_email: 'bogus', private_key: 'bogus'},
@@ -721,6 +744,12 @@ describe('v1beta1.EchoClient', () => {
                 });
             });
             await assert.rejects(promise, expectedError);
+        });
+        it('should create a client with gaxServerStreamingRetries enabled', () => {
+            const client = new echoModule.v1beta1.EchoClient({
+                gaxServerStreamingRetries: true,
+            });
+            assert(client);
         });
     });
 

--- a/baselines/showcase-esm/esm/test/gapic_messaging_v1beta1.ts.baseline
+++ b/baselines/showcase-esm/esm/test/gapic_messaging_v1beta1.ts.baseline
@@ -1306,6 +1306,39 @@ describe('v1beta1.MessagingClient', () => {
             assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
+        it('invokes streamBlurbs without error and gaxServerStreamingRetries enabled', async () => {
+            const client = new messagingModule.v1beta1.MessagingClient({gaxServerStreamingRetries: true});
+            client.initialize();
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.StreamBlurbsRequest()
+            );
+            const defaultValue1 =
+              getTypeDefaultValue('.google.showcase.v1beta1.StreamBlurbsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1 ?? '' }`;
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.StreamBlurbsResponse()
+            );
+            client.innerApiCalls.streamBlurbs = stubServerStreamingCall(expectedResponse);
+            const stream = client.streamBlurbs(request);
+            const promise = new Promise((resolve, reject) => {
+                stream.on('data', (response: protos.google.showcase.v1beta1.StreamBlurbsResponse) => {
+                    resolve(response);
+                });
+                stream.on('error', (err: Error) => {
+                    reject(err);
+                });
+            });
+            const response = await promise;
+            assert.deepStrictEqual(response, expectedResponse);
+            const actualRequest = (client.innerApiCalls.streamBlurbs as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.streamBlurbs as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
+        });
+
         it('invokes streamBlurbs with error', async () => {
             const client = new messagingModule.v1beta1.MessagingClient({
               credentials: {client_email: 'bogus', private_key: 'bogus'},
@@ -1363,6 +1396,12 @@ describe('v1beta1.MessagingClient', () => {
                 });
             });
             await assert.rejects(promise, expectedError);
+        });
+        it('should create a client with gaxServerStreamingRetries enabled', () => {
+            const client = new messagingModule.v1beta1.MessagingClient({
+                gaxServerStreamingRetries: true,
+            });
+            assert(client);
         });
     });
 

--- a/baselines/showcase-legacy-esm/esm/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase-legacy-esm/esm/src/v1beta1/echo_client.ts.baseline
@@ -185,7 +185,7 @@ export class EchoClient {
     // Provide descriptors for these.
     this.descriptors.stream = {
       expand: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.SERVER_STREAMING, !!opts.fallback, !!opts.gaxServerStreamingRetries),
-      collect: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, !!opts.fallback, !!opts.gaxServerStreamingRetries),
+    collect: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, !!opts.fallback),
       chat: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.BIDI_STREAMING, !!opts.fallback, !!opts.gaxServerStreamingRetries)
     };
 

--- a/baselines/showcase-legacy-esm/esm/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase-legacy-esm/esm/test/gapic_echo_v1beta1.ts.baseline
@@ -650,6 +650,29 @@ describe('v1beta1.EchoClient', () => {
             assert.deepStrictEqual(response, expectedResponse);
         });
 
+        it('invokes expand without error and gaxServerStreamingRetries enabled', async () => {
+            const client = new echoModule.v1beta1.EchoClient({gaxServerStreamingRetries: true});
+            client.initialize();
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ExpandRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoResponse()
+            );
+            client.innerApiCalls.expand = stubServerStreamingCall(expectedResponse);
+            const stream = client.expand(request);
+            const promise = new Promise((resolve, reject) => {
+                stream.on('data', (response: protos.google.showcase.v1beta1.EchoResponse) => {
+                    resolve(response);
+                });
+                stream.on('error', (err: Error) => {
+                    reject(err);
+                });
+            });
+            const response = await promise;
+            assert.deepStrictEqual(response, expectedResponse);
+        });
+
         it('invokes expand with error', async () => {
             const client = new echoModule.v1beta1.EchoClient({
               credentials: {client_email: 'bogus', private_key: 'bogus'},
@@ -694,6 +717,12 @@ describe('v1beta1.EchoClient', () => {
                 });
             });
             await assert.rejects(promise, expectedError);
+        });
+        it('should create a client with gaxServerStreamingRetries enabled', () => {
+            const client = new echoModule.v1beta1.EchoClient({
+                gaxServerStreamingRetries: true,
+            });
+            assert(client);
         });
     });
 

--- a/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
@@ -167,7 +167,7 @@ export class EchoClient {
     // Provide descriptors for these.
     this.descriptors.stream = {
       expand: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.SERVER_STREAMING, !!opts.fallback, !!opts.gaxServerStreamingRetries),
-      collect: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, !!opts.fallback, !!opts.gaxServerStreamingRetries),
+    collect: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, !!opts.fallback),
       chat: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.BIDI_STREAMING, !!opts.fallback, !!opts.gaxServerStreamingRetries)
     };
 

--- a/baselines/showcase-legacy/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase-legacy/test/gapic_echo_v1beta1.ts.baseline
@@ -649,6 +649,29 @@ describe('v1beta1.EchoClient', () => {
             assert.deepStrictEqual(response, expectedResponse);
         });
 
+        it('invokes expand without error and gaxServerStreamingRetries enabled', async () => {
+            const client = new echoModule.v1beta1.EchoClient({gaxServerStreamingRetries: true});
+            client.initialize();
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ExpandRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoResponse()
+            );
+            client.innerApiCalls.expand = stubServerStreamingCall(expectedResponse);
+            const stream = client.expand(request);
+            const promise = new Promise((resolve, reject) => {
+                stream.on('data', (response: protos.google.showcase.v1beta1.EchoResponse) => {
+                    resolve(response);
+                });
+                stream.on('error', (err: Error) => {
+                    reject(err);
+                });
+            });
+            const response = await promise;
+            assert.deepStrictEqual(response, expectedResponse);
+        });
+
         it('invokes expand with error', async () => {
             const client = new echoModule.v1beta1.EchoClient({
               credentials: {client_email: 'bogus', private_key: 'bogus'},
@@ -693,6 +716,12 @@ describe('v1beta1.EchoClient', () => {
                 });
             });
             await assert.rejects(promise, expectedError);
+        });
+        it('should create a client with gaxServerStreamingRetries enabled', () => {
+            const client = new echoModule.v1beta1.EchoClient({
+                gaxServerStreamingRetries: true,
+            });
+            assert(client);
         });
     });
 

--- a/baselines/showcase/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/echo_client.ts.baseline
@@ -228,7 +228,7 @@ export class EchoClient {
     // Provide descriptors for these.
     this.descriptors.stream = {
       expand: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.SERVER_STREAMING, !!opts.fallback, !!opts.gaxServerStreamingRetries),
-      collect: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, !!opts.fallback, !!opts.gaxServerStreamingRetries),
+    collect: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, !!opts.fallback),
       chat: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.BIDI_STREAMING, !!opts.fallback, !!opts.gaxServerStreamingRetries)
     };
 

--- a/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
@@ -227,7 +227,7 @@ export class MessagingClient {
     // Provide descriptors for these.
     this.descriptors.stream = {
       streamBlurbs: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.SERVER_STREAMING, !!opts.fallback, !!opts.gaxServerStreamingRetries),
-      sendBlurbs: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, !!opts.fallback, !!opts.gaxServerStreamingRetries),
+    sendBlurbs: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, !!opts.fallback),
       connect: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.BIDI_STREAMING, !!opts.fallback, !!opts.gaxServerStreamingRetries)
     };
 

--- a/baselines/showcase/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_echo_v1beta1.ts.baseline
@@ -668,6 +668,29 @@ describe('v1beta1.EchoClient', () => {
             assert.deepStrictEqual(response, expectedResponse);
         });
 
+        it('invokes expand without error and gaxServerStreamingRetries enabled', async () => {
+            const client = new echoModule.v1beta1.EchoClient({gaxServerStreamingRetries: true});
+            client.initialize();
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ExpandRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoResponse()
+            );
+            client.innerApiCalls.expand = stubServerStreamingCall(expectedResponse);
+            const stream = client.expand(request);
+            const promise = new Promise((resolve, reject) => {
+                stream.on('data', (response: protos.google.showcase.v1beta1.EchoResponse) => {
+                    resolve(response);
+                });
+                stream.on('error', (err: Error) => {
+                    reject(err);
+                });
+            });
+            const response = await promise;
+            assert.deepStrictEqual(response, expectedResponse);
+        });
+
         it('invokes expand with error', async () => {
             const client = new echoModule.v1beta1.EchoClient({
               credentials: {client_email: 'bogus', private_key: 'bogus'},
@@ -712,6 +735,12 @@ describe('v1beta1.EchoClient', () => {
                 });
             });
             await assert.rejects(promise, expectedError);
+        });
+        it('should create a client with gaxServerStreamingRetries enabled', () => {
+            const client = new echoModule.v1beta1.EchoClient({
+                gaxServerStreamingRetries: true,
+            });
+            assert(client);
         });
     });
 

--- a/baselines/showcase/test/gapic_messaging_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_messaging_v1beta1.ts.baseline
@@ -1297,6 +1297,39 @@ describe('v1beta1.MessagingClient', () => {
             assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
+        it('invokes streamBlurbs without error and gaxServerStreamingRetries enabled', async () => {
+            const client = new messagingModule.v1beta1.MessagingClient({gaxServerStreamingRetries: true});
+            client.initialize();
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.StreamBlurbsRequest()
+            );
+            const defaultValue1 =
+              getTypeDefaultValue('.google.showcase.v1beta1.StreamBlurbsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.StreamBlurbsResponse()
+            );
+            client.innerApiCalls.streamBlurbs = stubServerStreamingCall(expectedResponse);
+            const stream = client.streamBlurbs(request);
+            const promise = new Promise((resolve, reject) => {
+                stream.on('data', (response: protos.google.showcase.v1beta1.StreamBlurbsResponse) => {
+                    resolve(response);
+                });
+                stream.on('error', (err: Error) => {
+                    reject(err);
+                });
+            });
+            const response = await promise;
+            assert.deepStrictEqual(response, expectedResponse);
+            const actualRequest = (client.innerApiCalls.streamBlurbs as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.streamBlurbs as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
+        });
+
         it('invokes streamBlurbs with error', async () => {
             const client = new messagingModule.v1beta1.MessagingClient({
               credentials: {client_email: 'bogus', private_key: 'bogus'},
@@ -1354,6 +1387,12 @@ describe('v1beta1.MessagingClient', () => {
                 });
             });
             await assert.rejects(promise, expectedError);
+        });
+        it('should create a client with gaxServerStreamingRetries enabled', () => {
+            const client = new messagingModule.v1beta1.MessagingClient({
+                gaxServerStreamingRetries: true,
+            });
+            assert(client);
         });
     });
 

--- a/templates/cjs/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/cjs/typescript_gapic/src/$version/$service_client.ts.njk
@@ -299,8 +299,14 @@ export class {{ service.name }}Client {
     this.descriptors.stream = {
 {%- set streamingJoiner = joiner() %}
 {%- for method in service.streaming %}
+  {%- if method.serverStreaming %}
       {{- streamingJoiner() }}
       {{ method.name.toCamelCase() }}: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.{{ method.streaming }}, !!opts.fallback, !!opts.gaxServerStreamingRetries)
+  {%- endif %}
+  {%- if not method.serverStreaming %}
+    {{- streamingJoiner() }}
+    {{ method.name.toCamelCase() }}: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.{{ method.streaming }}, !!opts.fallback)
+  {%- endif %}
 {%- endfor %}
     };
 {%- endif %}

--- a/templates/cjs/typescript_gapic/test/gapic_$service_$version.ts.njk
+++ b/templates/cjs/typescript_gapic/test/gapic_$service_$version.ts.njk
@@ -387,28 +387,6 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {{- util.verifyUUID(method) }}
         });
         
-        it('invokes {{ method.name.toCamelCase() }} without error and gaxServerStreamingRetries enabled', async () => {
-            const client = new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client({gaxServerStreamingRetries: true});
-            {%- if method.options and method.options.deprecated %}
-            const stub = sinon.stub(client, 'warn');
-            {%- endif %}
-            client.{{ id.get("initialize") }}();
-            {{ util.initRequestWithHeaderParam(method) -}}
-            {{ util.initResponse(method) }}
-            client.innerApiCalls.{{ method.name.toCamelCase(true) }} = stubSimpleCall(expectedResponse);
-            const [response] = await client.{{ method.name.toCamelCase() }}(request);
-            {%- if method.options and method.options.deprecated %}
-            assert(stub.calledOnce);
-            {%- endif %}
-            {%- if method.isDiregapicLRO %}
-            assert.deepStrictEqual(response.latestResponse, expectedResponse);
-            {%- else %}
-            assert.deepStrictEqual(response, expectedResponse);
-            {%- endif %}
-            {{- util.verifyHeaderRequestParams(method) }}
-            {{- util.verifyUUID(method) }}
-        });
-
         it('invokes {{ method.name.toCamelCase() }} without error using callback', async () => {
             const client = new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client(
                 {{- util.initClientOptions(api.rest) -}}
@@ -612,6 +590,32 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
     describe('{{ method.name.toCamelCase() }}', () => {
         it('invokes {{ method.name.toCamelCase() }} without error', async () => {
             const client = new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client({{- util.initClientOptions(api.rest) -}});
+            {%- if method.options and method.options.deprecated %}
+            const stub = sinon.stub(client, 'warn');
+            {%- endif %}
+            client.{{ id.get("initialize") }}();
+            {{ util.initRequestWithHeaderParam(method) -}}
+            {{ util.initResponse(method) }}
+            client.innerApiCalls.{{ method.name.toCamelCase(true) }} = stubServerStreamingCall(expectedResponse);
+            const stream = client.{{ method.name.toCamelCase() }}(request);
+            const promise = new Promise((resolve, reject) => {
+                stream.on('data', (response: protos{{ method.outputInterface }}) => {
+                    resolve(response);
+                });
+                stream.on('error', (err: Error) => {
+                    reject(err);
+                });
+            });
+            const response = await promise;
+            {%- if method.options and method.options.deprecated %}
+            assert(stub.calledOnce);
+            {%- endif %}
+            assert.deepStrictEqual(response, expectedResponse);
+            {{- util.verifyHeaderRequestParams(method) }}
+        });
+
+        it('invokes {{ method.name.toCamelCase() }} without error and gaxServerStreamingRetries enabled', async () => {
+            const client = new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client({gaxServerStreamingRetries: true});
             {%- if method.options and method.options.deprecated %}
             const stub = sinon.stub(client, 'warn');
             {%- endif %}

--- a/templates/cjs/typescript_gapic/test/gapic_$service_$version.ts.njk
+++ b/templates/cjs/typescript_gapic/test/gapic_$service_$version.ts.njk
@@ -386,7 +386,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {{- util.verifyHeaderRequestParams(method) }}
             {{- util.verifyUUID(method) }}
         });
-        
+
         it('invokes {{ method.name.toCamelCase() }} without error using callback', async () => {
             const client = new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client(
                 {{- util.initClientOptions(api.rest) -}}

--- a/templates/cjs/typescript_gapic/test/gapic_$service_$version.ts.njk
+++ b/templates/cjs/typescript_gapic/test/gapic_$service_$version.ts.njk
@@ -663,6 +663,12 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {%- endif %}
         });
     });
+        it('should create a client with gaxServerStreamingRetries enabled', () => {
+            const client = new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client({
+                gaxServerStreamingRetries: true,
+            });
+            assert(client);
+        });
 {%- endfor %}
 {%- for method in service.bidiStreaming %}
 

--- a/templates/cjs/typescript_gapic/test/gapic_$service_$version.ts.njk
+++ b/templates/cjs/typescript_gapic/test/gapic_$service_$version.ts.njk
@@ -386,6 +386,28 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {{- util.verifyHeaderRequestParams(method) }}
             {{- util.verifyUUID(method) }}
         });
+        
+        it('invokes {{ method.name.toCamelCase() }} without error and gaxServerStreamingRetries enabled', async () => {
+            const client = new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client({gaxServerStreamingRetries: true});
+            {%- if method.options and method.options.deprecated %}
+            const stub = sinon.stub(client, 'warn');
+            {%- endif %}
+            client.{{ id.get("initialize") }}();
+            {{ util.initRequestWithHeaderParam(method) -}}
+            {{ util.initResponse(method) }}
+            client.innerApiCalls.{{ method.name.toCamelCase(true) }} = stubSimpleCall(expectedResponse);
+            const [response] = await client.{{ method.name.toCamelCase() }}(request);
+            {%- if method.options and method.options.deprecated %}
+            assert(stub.calledOnce);
+            {%- endif %}
+            {%- if method.isDiregapicLRO %}
+            assert.deepStrictEqual(response.latestResponse, expectedResponse);
+            {%- else %}
+            assert.deepStrictEqual(response, expectedResponse);
+            {%- endif %}
+            {{- util.verifyHeaderRequestParams(method) }}
+            {{- util.verifyUUID(method) }}
+        });
 
         it('invokes {{ method.name.toCamelCase() }} without error using callback', async () => {
             const client = new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client(
@@ -662,13 +684,14 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             assert(stub.calledOnce);
             {%- endif %}
         });
-    });
         it('should create a client with gaxServerStreamingRetries enabled', () => {
             const client = new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client({
                 gaxServerStreamingRetries: true,
             });
             assert(client);
         });
+    });
+
 {%- endfor %}
 {%- for method in service.bidiStreaming %}
 

--- a/templates/esm/typescript_gapic/esm/src/$version/$service_client.ts.njk
+++ b/templates/esm/typescript_gapic/esm/src/$version/$service_client.ts.njk
@@ -312,8 +312,14 @@ export class {{ service.name }}Client {
     this.descriptors.stream = {
 {%- set streamingJoiner = joiner() %}
 {%- for method in service.streaming %}
+  {%- if method.serverStreaming %}
       {{- streamingJoiner() }}
       {{ method.name.toCamelCase() }}: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.{{ method.streaming }}, !!opts.fallback, !!opts.gaxServerStreamingRetries)
+  {%- endif %}
+  {%- if not method.serverStreaming %}
+    {{- streamingJoiner() }}
+    {{ method.name.toCamelCase() }}: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.{{ method.streaming }}, !!opts.fallback)
+  {%- endif %}
 {%- endfor %}
     };
 {%- endif %}

--- a/templates/esm/typescript_gapic/esm/test/gapic_$service_$version.ts.njk
+++ b/templates/esm/typescript_gapic/esm/test/gapic_$service_$version.ts.njk
@@ -630,18 +630,22 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initResponse(method) }}
-            client.innerApiCalls.{{ method.name.toCamelCase(true) }} = stubSimpleCall(expectedResponse);
-            const [response] = await client.{{ method.name.toCamelCase() }}(request);
+            client.innerApiCalls.{{ method.name.toCamelCase(true) }} = stubServerStreamingCall(expectedResponse);
+            const stream = client.{{ method.name.toCamelCase() }}(request);
+            const promise = new Promise((resolve, reject) => {
+                stream.on('data', (response: protos{{ method.outputInterface }}) => {
+                    resolve(response);
+                });
+                stream.on('error', (err: Error) => {
+                    reject(err);
+                });
+            });
+            const response = await promise;
             {%- if method.options and method.options.deprecated %}
             assert(stub.calledOnce);
             {%- endif %}
-            {%- if method.isDiregapicLRO %}
-            assert.deepStrictEqual(response.latestResponse, expectedResponse);
-            {%- else %}
             assert.deepStrictEqual(response, expectedResponse);
-            {%- endif %}
             {{- util.verifyHeaderRequestParams(method) }}
-            {{- util.verifyUUID(method) }}
         });
 
         it('invokes {{ method.name.toCamelCase() }} with error', async () => {

--- a/templates/esm/typescript_gapic/esm/test/gapic_$service_$version.ts.njk
+++ b/templates/esm/typescript_gapic/esm/test/gapic_$service_$version.ts.njk
@@ -670,6 +670,12 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             assert(stub.calledOnce);
             {%- endif %}
         });
+        it('should create a client with gaxServerStreamingRetries enabled', () => {
+            const client = new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client({
+                gaxServerStreamingRetries: true,
+            });
+            assert(client);
+        });
     });
 {%- endfor %}
 {%- for method in service.bidiStreaming %}

--- a/templates/esm/typescript_gapic/esm/test/gapic_$service_$version.ts.njk
+++ b/templates/esm/typescript_gapic/esm/test/gapic_$service_$version.ts.njk
@@ -622,6 +622,28 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {{- util.verifyHeaderRequestParams(method) }}
         });
 
+        it('invokes {{ method.name.toCamelCase() }} without error and gaxServerStreamingRetries enabled', async () => {
+            const client = new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client({gaxServerStreamingRetries: true});
+            {%- if method.options and method.options.deprecated %}
+            const stub = sinon.stub(client, 'warn');
+            {%- endif %}
+            client.{{ id.get("initialize") }}();
+            {{ util.initRequestWithHeaderParam(method) -}}
+            {{ util.initResponse(method) }}
+            client.innerApiCalls.{{ method.name.toCamelCase(true) }} = stubSimpleCall(expectedResponse);
+            const [response] = await client.{{ method.name.toCamelCase() }}(request);
+            {%- if method.options and method.options.deprecated %}
+            assert(stub.calledOnce);
+            {%- endif %}
+            {%- if method.isDiregapicLRO %}
+            assert.deepStrictEqual(response.latestResponse, expectedResponse);
+            {%- else %}
+            assert.deepStrictEqual(response, expectedResponse);
+            {%- endif %}
+            {{- util.verifyHeaderRequestParams(method) }}
+            {{- util.verifyUUID(method) }}
+        });
+
         it('invokes {{ method.name.toCamelCase() }} with error', async () => {
             const client = new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client({{- util.initClientOptions(api.rest) -}});
             {%- if method.options and method.options.deprecated %}


### PR DESCRIPTION
In preparation for selectively opting client libraries into the change, this PR adds some more fine grained changes for gax server streaming retries:

- only passes the gaxServerStreamingRetries opt-in flag for server streaming calls (not for bidi and client streaming)
- adds happy path generated test cases

I have tested this successfully on nodejs-bigquery-storage and am testing it now with a new regeneration of the showcase test application as part of https://github.com/googleapis/gax-nodejs/pull/1587