### PR TITLE
fix: avoid unhandled exception when reusing a closed client

### DIFF
--- a/baselines/bigquery-storage-esm/esm/src/v1beta1/big_query_storage_client.ts.baseline
+++ b/baselines/bigquery-storage-esm/esm/src/v1beta1/big_query_storage_client.ts.baseline
@@ -259,7 +259,7 @@ export class BigQueryStorageClient {
         stub => (...args: Array<{}>) => {
           if (this._terminated) {
             if (methodName in this.descriptors.stream) {
-              const stream = new PassThrough();
+              const stream = new PassThrough({objectMode: true});
               setImmediate(() => {
                 stream.emit('error', new this._gaxModule.GoogleError('The client has already been closed.'));
               });

--- a/baselines/bigquery-storage/src/v1beta1/big_query_storage_client.ts.baseline
+++ b/baselines/bigquery-storage/src/v1beta1/big_query_storage_client.ts.baseline
@@ -236,7 +236,7 @@ export class BigQueryStorageClient {
         stub => (...args: Array<{}>) => {
           if (this._terminated) {
             if (methodName in this.descriptors.stream) {
-              const stream = new PassThrough();
+              const stream = new PassThrough({objectMode: true});
               setImmediate(() => {
                 stream.emit('error', new this._gaxModule.GoogleError('The client has already been closed.'));
               });

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/echo_client.ts.baseline
@@ -326,7 +326,7 @@ export class EchoClient {
         stub => (...args: Array<{}>) => {
           if (this._terminated) {
             if (methodName in this.descriptors.stream) {
-              const stream = new PassThrough();
+              const stream = new PassThrough({objectMode: true});
               setImmediate(() => {
                 stream.emit('error', new this._gaxModule.GoogleError('The client has already been closed.'));
               });

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/messaging_client.ts.baseline
@@ -325,7 +325,7 @@ export class MessagingClient {
         stub => (...args: Array<{}>) => {
           if (this._terminated) {
             if (methodName in this.descriptors.stream) {
-              const stream = new PassThrough();
+              const stream = new PassThrough({objectMode: true});
               setImmediate(() => {
                 stream.emit('error', new this._gaxModule.GoogleError('The client has already been closed.'));
               });

--- a/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
@@ -303,7 +303,7 @@ export class EchoClient {
         stub => (...args: Array<{}>) => {
           if (this._terminated) {
             if (methodName in this.descriptors.stream) {
-              const stream = new PassThrough();
+              const stream = new PassThrough({objectMode: true});
               setImmediate(() => {
                 stream.emit('error', new this._gaxModule.GoogleError('The client has already been closed.'));
               });

--- a/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
@@ -302,7 +302,7 @@ export class MessagingClient {
         stub => (...args: Array<{}>) => {
           if (this._terminated) {
             if (methodName in this.descriptors.stream) {
-              const stream = new PassThrough();
+              const stream = new PassThrough({objectMode: true});
               setImmediate(() => {
                 stream.emit('error', new this._gaxModule.GoogleError('The client has already been closed.'));
               });

--- a/baselines/logging-esm/esm/src/v2/logging_service_v2_client.ts.baseline
+++ b/baselines/logging-esm/esm/src/v2/logging_service_v2_client.ts.baseline
@@ -369,7 +369,7 @@ export class LoggingServiceV2Client {
         stub => (...args: Array<{}>) => {
           if (this._terminated) {
             if (methodName in this.descriptors.stream) {
-              const stream = new PassThrough();
+              const stream = new PassThrough({objectMode: true});
               setImmediate(() => {
                 stream.emit('error', new this._gaxModule.GoogleError('The client has already been closed.'));
               });

--- a/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
@@ -346,7 +346,7 @@ export class LoggingServiceV2Client {
         stub => (...args: Array<{}>) => {
           if (this._terminated) {
             if (methodName in this.descriptors.stream) {
-              const stream = new PassThrough();
+              const stream = new PassThrough({objectMode: true});
               setImmediate(() => {
                 stream.emit('error', new this._gaxModule.GoogleError('The client has already been closed.'));
               });

--- a/baselines/showcase-esm/esm/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/echo_client.ts.baseline
@@ -332,7 +332,7 @@ export class EchoClient {
         stub => (...args: Array<{}>) => {
           if (this._terminated) {
             if (methodName in this.descriptors.stream) {
-              const stream = new PassThrough();
+              const stream = new PassThrough({objectMode: true});
               setImmediate(() => {
                 stream.emit('error', new this._gaxModule.GoogleError('The client has already been closed.'));
               });

--- a/baselines/showcase-esm/esm/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/messaging_client.ts.baseline
@@ -331,7 +331,7 @@ export class MessagingClient {
         stub => (...args: Array<{}>) => {
           if (this._terminated) {
             if (methodName in this.descriptors.stream) {
-              const stream = new PassThrough();
+              const stream = new PassThrough({objectMode: true});
               setImmediate(() => {
                 stream.emit('error', new this._gaxModule.GoogleError('The client has already been closed.'));
               });

--- a/baselines/showcase-legacy-esm/esm/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase-legacy-esm/esm/src/v1beta1/echo_client.ts.baseline
@@ -260,7 +260,7 @@ export class EchoClient {
         stub => (...args: Array<{}>) => {
           if (this._terminated) {
             if (methodName in this.descriptors.stream) {
-              const stream = new PassThrough();
+              const stream = new PassThrough({objectMode: true});
               setImmediate(() => {
                 stream.emit('error', new this._gaxModule.GoogleError('The client has already been closed.'));
               });

--- a/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
@@ -242,7 +242,7 @@ export class EchoClient {
         stub => (...args: Array<{}>) => {
           if (this._terminated) {
             if (methodName in this.descriptors.stream) {
-              const stream = new PassThrough();
+              const stream = new PassThrough({objectMode: true});
               setImmediate(() => {
                 stream.emit('error', new this._gaxModule.GoogleError('The client has already been closed.'));
               });

--- a/baselines/showcase/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/echo_client.ts.baseline
@@ -309,7 +309,7 @@ export class EchoClient {
         stub => (...args: Array<{}>) => {
           if (this._terminated) {
             if (methodName in this.descriptors.stream) {
-              const stream = new PassThrough();
+              const stream = new PassThrough({objectMode: true});
               setImmediate(() => {
                 stream.emit('error', new this._gaxModule.GoogleError('The client has already been closed.'));
               });

--- a/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
@@ -308,7 +308,7 @@ export class MessagingClient {
         stub => (...args: Array<{}>) => {
           if (this._terminated) {
             if (methodName in this.descriptors.stream) {
-              const stream = new PassThrough();
+              const stream = new PassThrough({objectMode: true});
               setImmediate(() => {
                 stream.emit('error', new this._gaxModule.GoogleError('The client has already been closed.'));
               });

--- a/templates/cjs/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/cjs/typescript_gapic/src/$version/$service_client.ts.njk
@@ -452,7 +452,7 @@ export class {{ service.name }}Client {
           if (this._terminated) {
             {%- if service.streaming.length > 0 %}
             if (methodName in this.descriptors.stream) {
-              const stream = new PassThrough();
+              const stream = new PassThrough({objectMode: true});
               setImmediate(() => {
                 stream.emit('error', new this._gaxModule.GoogleError('The client has already been closed.'));
               });

--- a/templates/esm/typescript_gapic/esm/src/$version/$service_client.ts.njk
+++ b/templates/esm/typescript_gapic/esm/src/$version/$service_client.ts.njk
@@ -465,7 +465,7 @@ export class {{ service.name }}Client {
           if (this._terminated) {
             {%- if service.streaming.length > 0 %}
             if (methodName in this.descriptors.stream) {
-              const stream = new PassThrough();
+              const stream = new PassThrough({objectMode: true});
               setImmediate(() => {
                 stream.emit('error', new this._gaxModule.GoogleError('The client has already been closed.'));
               });


### PR DESCRIPTION
Example:

* Execute streamingRecognize
* When done, close the client
* Execute streamingRecognize again, with data already in the stream
* Unhandled exception occurs.

```
TypeError [ERR_INVALID_ARG_TYPE]: The "chunk" argument must be of type string or an instance of Buffer or Uint8Array. Received an instance of Object
    at _write (node:internal/streams/writable:474:13)
    at Writable.write (node:internal/streams/writable:502:10)
    at Duplexify._write (/project/node_modules/duplexify/index.js:212:22)
    at doWrite (/project/node_modules/duplexify/node_modules/readable-stream/lib/_stream_writable.js:390:139)
    at writeOrBuffer (/project/node_modules/duplexify/node_modules/readable-stream/lib/_stream_writable.js:381:5)
    at Writable.write (/project/node_modules/duplexify/node_modules/readable-stream/lib/_stream_writable.js:302:11)
    at Pumpify.<anonymous> (/project/node_modules/@google-cloud/speech/build/src/helpers.js:79:27)
    at Object.onceWrapper (node:events:633:26)
    at Pumpify.emit (node:events:518:28)
    at obj.<computed> [as _write] (/project/node_modules/stubs/index.js:28:22)
    at doWrite (/project/node_modules/duplexify/node_modules/readable-stream/lib/_stream_writable.js:390:139)
    at writeOrBuffer (/project/node_modules/duplexify/node_modules/readable-stream/lib/_stream_writable.js:381:5)
    at Writable.write (/project/node_modules/duplexify/node_modules/readable-stream/lib/_stream_writable.js:302:11)
    at PassThrough.ondata (node:internal/streams/readable:1007:22)
    at PassThrough.emit (node:events:518:28)
    at addChunk (node:internal/streams/readable:559:12) {
  code: 'ERR_INVALID_ARG_TYPE'
```

Reproduction: https://gist.github.com/orgads/13cbf44c91923da27d8772b5f10489c9

This happens because streamingRecognize writes streamingConfig on first chunk. Usually the stream is open in object mode, so it works, but when the client is terminated, PassThrough is used without object mode.

Change PassThrough to object mode, so it terminates gracefully.

This was reported in [1] and fixed in [2], but was then reverted in [3] which re-generated the code. Fix properly in the generator now.

[1] https://github.com/googleapis/google-cloud-node/issues/5464
[2] https://github.com/googleapis/google-cloud-node/pull/5465
[3] https://github.com/googleapis/google-cloud-node/pull/5565