### PR TITLE
fix: typo in page stream comment template

### DIFF
--- a/baselines/asset-esm/.jsdoc.cjs.baseline
+++ b/baselines/asset-esm/.jsdoc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2024 Google LLC',
+    copyright: 'Copyright 2025 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: '@google-cloud/asset',

--- a/baselines/asset-esm/.mocharc.cjs.baseline
+++ b/baselines/asset-esm/.mocharc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/asset-esm/.prettierrc.cjs.baseline
+++ b/baselines/asset-esm/.prettierrc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/asset-esm/esm/src/index.ts.baseline
+++ b/baselines/asset-esm/esm/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/asset-esm/esm/src/v1/asset_service_client.ts.baseline
+++ b/baselines/asset-esm/esm/src/v1/asset_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/asset-esm/esm/src/v1/index.ts.baseline
+++ b/baselines/asset-esm/esm/src/v1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/asset-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
+++ b/baselines/asset-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/asset-esm/esm/system-test/fixtures/sample/src/index.js.baseline
+++ b/baselines/asset-esm/esm/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/asset-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/asset-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,5 +1,5 @@
 /* eslint-disable node/no-missing-require, no-unused-vars, no-undef */
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/asset-esm/esm/system-test/install.ts.baseline
+++ b/baselines/asset-esm/esm/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/asset-esm/esm/test/gapic_asset_service_v1.ts.baseline
+++ b/baselines/asset-esm/esm/test/gapic_asset_service_v1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/asset-esm/samples/generated/v1/asset_service.batch_get_assets_history.js.baseline
+++ b/baselines/asset-esm/samples/generated/v1/asset_service.batch_get_assets_history.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/asset-esm/samples/generated/v1/asset_service.create_feed.js.baseline
+++ b/baselines/asset-esm/samples/generated/v1/asset_service.create_feed.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/asset-esm/samples/generated/v1/asset_service.delete_feed.js.baseline
+++ b/baselines/asset-esm/samples/generated/v1/asset_service.delete_feed.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/asset-esm/samples/generated/v1/asset_service.export_assets.js.baseline
+++ b/baselines/asset-esm/samples/generated/v1/asset_service.export_assets.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/asset-esm/samples/generated/v1/asset_service.get_feed.js.baseline
+++ b/baselines/asset-esm/samples/generated/v1/asset_service.get_feed.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/asset-esm/samples/generated/v1/asset_service.list_feeds.js.baseline
+++ b/baselines/asset-esm/samples/generated/v1/asset_service.list_feeds.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/asset-esm/samples/generated/v1/asset_service.update_feed.js.baseline
+++ b/baselines/asset-esm/samples/generated/v1/asset_service.update_feed.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/asset/.jsdoc.js.baseline
+++ b/baselines/asset/.jsdoc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2024 Google LLC',
+    copyright: 'Copyright 2025 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: '@google-cloud/asset',

--- a/baselines/asset/.mocharc.js.baseline
+++ b/baselines/asset/.mocharc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/asset/.prettierrc.js.baseline
+++ b/baselines/asset/.prettierrc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/asset/samples/generated/v1/asset_service.batch_get_assets_history.js.baseline
+++ b/baselines/asset/samples/generated/v1/asset_service.batch_get_assets_history.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/asset/samples/generated/v1/asset_service.create_feed.js.baseline
+++ b/baselines/asset/samples/generated/v1/asset_service.create_feed.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/asset/samples/generated/v1/asset_service.delete_feed.js.baseline
+++ b/baselines/asset/samples/generated/v1/asset_service.delete_feed.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/asset/samples/generated/v1/asset_service.export_assets.js.baseline
+++ b/baselines/asset/samples/generated/v1/asset_service.export_assets.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/asset/samples/generated/v1/asset_service.get_feed.js.baseline
+++ b/baselines/asset/samples/generated/v1/asset_service.get_feed.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/asset/samples/generated/v1/asset_service.list_feeds.js.baseline
+++ b/baselines/asset/samples/generated/v1/asset_service.list_feeds.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/asset/samples/generated/v1/asset_service.update_feed.js.baseline
+++ b/baselines/asset/samples/generated/v1/asset_service.update_feed.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/asset/src/index.ts.baseline
+++ b/baselines/asset/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/asset/src/v1/asset_service_client.ts.baseline
+++ b/baselines/asset/src/v1/asset_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/asset/src/v1/index.ts.baseline
+++ b/baselines/asset/src/v1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/asset/system-test/fixtures/sample/src/index.js.baseline
+++ b/baselines/asset/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/asset/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/asset/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/asset/system-test/install.ts.baseline
+++ b/baselines/asset/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/asset/test/gapic_asset_service_v1.ts.baseline
+++ b/baselines/asset/test/gapic_asset_service_v1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-storage-esm/.jsdoc.cjs.baseline
+++ b/baselines/bigquery-storage-esm/.jsdoc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2024 Google LLC',
+    copyright: 'Copyright 2025 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'storage',

--- a/baselines/bigquery-storage-esm/.mocharc.cjs.baseline
+++ b/baselines/bigquery-storage-esm/.mocharc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-storage-esm/.prettierrc.cjs.baseline
+++ b/baselines/bigquery-storage-esm/.prettierrc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-storage-esm/esm/src/index.ts.baseline
+++ b/baselines/bigquery-storage-esm/esm/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-storage-esm/esm/src/v1beta1/big_query_storage_client.ts.baseline
+++ b/baselines/bigquery-storage-esm/esm/src/v1beta1/big_query_storage_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-storage-esm/esm/src/v1beta1/index.ts.baseline
+++ b/baselines/bigquery-storage-esm/esm/src/v1beta1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-storage-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
+++ b/baselines/bigquery-storage-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-storage-esm/esm/system-test/fixtures/sample/src/index.js.baseline
+++ b/baselines/bigquery-storage-esm/esm/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-storage-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/bigquery-storage-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,5 +1,5 @@
 /* eslint-disable node/no-missing-require, no-unused-vars, no-undef */
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-storage-esm/esm/system-test/install.ts.baseline
+++ b/baselines/bigquery-storage-esm/esm/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-storage-esm/esm/test/gapic_big_query_storage_v1beta1.ts.baseline
+++ b/baselines/bigquery-storage-esm/esm/test/gapic_big_query_storage_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-storage-esm/samples/generated/v1beta1/big_query_storage.batch_create_read_session_streams.js.baseline
+++ b/baselines/bigquery-storage-esm/samples/generated/v1beta1/big_query_storage.batch_create_read_session_streams.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-storage-esm/samples/generated/v1beta1/big_query_storage.create_read_session.js.baseline
+++ b/baselines/bigquery-storage-esm/samples/generated/v1beta1/big_query_storage.create_read_session.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-storage-esm/samples/generated/v1beta1/big_query_storage.finalize_stream.js.baseline
+++ b/baselines/bigquery-storage-esm/samples/generated/v1beta1/big_query_storage.finalize_stream.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-storage-esm/samples/generated/v1beta1/big_query_storage.read_rows.js.baseline
+++ b/baselines/bigquery-storage-esm/samples/generated/v1beta1/big_query_storage.read_rows.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-storage-esm/samples/generated/v1beta1/big_query_storage.split_read_stream.js.baseline
+++ b/baselines/bigquery-storage-esm/samples/generated/v1beta1/big_query_storage.split_read_stream.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-storage/.jsdoc.js.baseline
+++ b/baselines/bigquery-storage/.jsdoc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2024 Google LLC',
+    copyright: 'Copyright 2025 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'storage',

--- a/baselines/bigquery-storage/.mocharc.js.baseline
+++ b/baselines/bigquery-storage/.mocharc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-storage/.prettierrc.js.baseline
+++ b/baselines/bigquery-storage/.prettierrc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-storage/samples/generated/v1beta1/big_query_storage.batch_create_read_session_streams.js.baseline
+++ b/baselines/bigquery-storage/samples/generated/v1beta1/big_query_storage.batch_create_read_session_streams.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-storage/samples/generated/v1beta1/big_query_storage.create_read_session.js.baseline
+++ b/baselines/bigquery-storage/samples/generated/v1beta1/big_query_storage.create_read_session.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-storage/samples/generated/v1beta1/big_query_storage.finalize_stream.js.baseline
+++ b/baselines/bigquery-storage/samples/generated/v1beta1/big_query_storage.finalize_stream.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-storage/samples/generated/v1beta1/big_query_storage.read_rows.js.baseline
+++ b/baselines/bigquery-storage/samples/generated/v1beta1/big_query_storage.read_rows.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-storage/samples/generated/v1beta1/big_query_storage.split_read_stream.js.baseline
+++ b/baselines/bigquery-storage/samples/generated/v1beta1/big_query_storage.split_read_stream.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-storage/src/index.ts.baseline
+++ b/baselines/bigquery-storage/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-storage/src/v1beta1/big_query_storage_client.ts.baseline
+++ b/baselines/bigquery-storage/src/v1beta1/big_query_storage_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-storage/src/v1beta1/index.ts.baseline
+++ b/baselines/bigquery-storage/src/v1beta1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-storage/system-test/fixtures/sample/src/index.js.baseline
+++ b/baselines/bigquery-storage/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-storage/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/bigquery-storage/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-storage/system-test/install.ts.baseline
+++ b/baselines/bigquery-storage/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-storage/test/gapic_big_query_storage_v1beta1.ts.baseline
+++ b/baselines/bigquery-storage/test/gapic_big_query_storage_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/.jsdoc.cjs.baseline
+++ b/baselines/bigquery-v2-esm/.jsdoc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2024 Google LLC',
+    copyright: 'Copyright 2025 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'bigquery',

--- a/baselines/bigquery-v2-esm/.mocharc.cjs.baseline
+++ b/baselines/bigquery-v2-esm/.mocharc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/.prettierrc.cjs.baseline
+++ b/baselines/bigquery-v2-esm/.prettierrc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/esm/src/index.ts.baseline
+++ b/baselines/bigquery-v2-esm/esm/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/esm/src/v2/dataset_service_client.ts.baseline
+++ b/baselines/bigquery-v2-esm/esm/src/v2/dataset_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -938,7 +938,7 @@ export class DatasetServiceClient {
  *   An object stream which emits an object representing {@link protos.google.cloud.bigquery.v2.ListFormatDataset|ListFormatDataset} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listDatasetsAsync()`
+ *   We recommend using `listDatasetsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/bigquery-v2-esm/esm/src/v2/index.ts.baseline
+++ b/baselines/bigquery-v2-esm/esm/src/v2/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/esm/src/v2/job_service_client.ts.baseline
+++ b/baselines/bigquery-v2-esm/esm/src/v2/job_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1006,7 +1006,7 @@ export class JobServiceClient {
  *   An object stream which emits an object representing {@link protos.google.cloud.bigquery.v2.ListFormatJob|ListFormatJob} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listJobsAsync()`
+ *   We recommend using `listJobsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/bigquery-v2-esm/esm/src/v2/model_service_client.ts.baseline
+++ b/baselines/bigquery-v2-esm/esm/src/v2/model_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -692,7 +692,7 @@ export class ModelServiceClient {
  *   An object stream which emits an object representing {@link protos.google.cloud.bigquery.v2.Model|Model} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listModelsAsync()`
+ *   We recommend using `listModelsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/bigquery-v2-esm/esm/src/v2/project_service_client.ts.baseline
+++ b/baselines/bigquery-v2-esm/esm/src/v2/project_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/esm/src/v2/routine_service_client.ts.baseline
+++ b/baselines/bigquery-v2-esm/esm/src/v2/routine_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -850,7 +850,7 @@ export class RoutineServiceClient {
  *   An object stream which emits an object representing {@link protos.google.cloud.bigquery.v2.Routine|Routine} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listRoutinesAsync()`
+ *   We recommend using `listRoutinesStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/bigquery-v2-esm/esm/src/v2/row_access_policy_service_client.ts.baseline
+++ b/baselines/bigquery-v2-esm/esm/src/v2/row_access_policy_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -455,7 +455,7 @@ export class RowAccessPolicyServiceClient {
  *   An object stream which emits an object representing {@link protos.google.cloud.bigquery.v2.RowAccessPolicy|RowAccessPolicy} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listRowAccessPoliciesAsync()`
+ *   We recommend using `listRowAccessPoliciesStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/bigquery-v2-esm/esm/src/v2/table_service_client.ts.baseline
+++ b/baselines/bigquery-v2-esm/esm/src/v2/table_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -865,7 +865,7 @@ export class TableServiceClient {
  *   An object stream which emits an object representing {@link protos.google.cloud.bigquery.v2.ListFormatTable|ListFormatTable} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listTablesAsync()`
+ *   We recommend using `listTablesStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/bigquery-v2-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
+++ b/baselines/bigquery-v2-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/esm/system-test/fixtures/sample/src/index.js.baseline
+++ b/baselines/bigquery-v2-esm/esm/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/bigquery-v2-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,5 +1,5 @@
 /* eslint-disable node/no-missing-require, no-unused-vars, no-undef */
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/esm/system-test/install.ts.baseline
+++ b/baselines/bigquery-v2-esm/esm/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/esm/test/gapic_dataset_service_v2.ts.baseline
+++ b/baselines/bigquery-v2-esm/esm/test/gapic_dataset_service_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/esm/test/gapic_job_service_v2.ts.baseline
+++ b/baselines/bigquery-v2-esm/esm/test/gapic_job_service_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/esm/test/gapic_model_service_v2.ts.baseline
+++ b/baselines/bigquery-v2-esm/esm/test/gapic_model_service_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/esm/test/gapic_project_service_v2.ts.baseline
+++ b/baselines/bigquery-v2-esm/esm/test/gapic_project_service_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/esm/test/gapic_routine_service_v2.ts.baseline
+++ b/baselines/bigquery-v2-esm/esm/test/gapic_routine_service_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/esm/test/gapic_row_access_policy_service_v2.ts.baseline
+++ b/baselines/bigquery-v2-esm/esm/test/gapic_row_access_policy_service_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/esm/test/gapic_table_service_v2.ts.baseline
+++ b/baselines/bigquery-v2-esm/esm/test/gapic_table_service_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/samples/generated/v2/dataset_service.delete_dataset.js.baseline
+++ b/baselines/bigquery-v2-esm/samples/generated/v2/dataset_service.delete_dataset.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/samples/generated/v2/dataset_service.get_dataset.js.baseline
+++ b/baselines/bigquery-v2-esm/samples/generated/v2/dataset_service.get_dataset.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/samples/generated/v2/dataset_service.insert_dataset.js.baseline
+++ b/baselines/bigquery-v2-esm/samples/generated/v2/dataset_service.insert_dataset.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/samples/generated/v2/dataset_service.list_datasets.js.baseline
+++ b/baselines/bigquery-v2-esm/samples/generated/v2/dataset_service.list_datasets.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/samples/generated/v2/dataset_service.patch_dataset.js.baseline
+++ b/baselines/bigquery-v2-esm/samples/generated/v2/dataset_service.patch_dataset.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/samples/generated/v2/dataset_service.undelete_dataset.js.baseline
+++ b/baselines/bigquery-v2-esm/samples/generated/v2/dataset_service.undelete_dataset.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/samples/generated/v2/dataset_service.update_dataset.js.baseline
+++ b/baselines/bigquery-v2-esm/samples/generated/v2/dataset_service.update_dataset.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/samples/generated/v2/job_service.cancel_job.js.baseline
+++ b/baselines/bigquery-v2-esm/samples/generated/v2/job_service.cancel_job.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/samples/generated/v2/job_service.delete_job.js.baseline
+++ b/baselines/bigquery-v2-esm/samples/generated/v2/job_service.delete_job.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/samples/generated/v2/job_service.get_job.js.baseline
+++ b/baselines/bigquery-v2-esm/samples/generated/v2/job_service.get_job.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/samples/generated/v2/job_service.get_query_results.js.baseline
+++ b/baselines/bigquery-v2-esm/samples/generated/v2/job_service.get_query_results.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/samples/generated/v2/job_service.insert_job.js.baseline
+++ b/baselines/bigquery-v2-esm/samples/generated/v2/job_service.insert_job.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/samples/generated/v2/job_service.list_jobs.js.baseline
+++ b/baselines/bigquery-v2-esm/samples/generated/v2/job_service.list_jobs.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/samples/generated/v2/job_service.query.js.baseline
+++ b/baselines/bigquery-v2-esm/samples/generated/v2/job_service.query.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/samples/generated/v2/model_service.delete_model.js.baseline
+++ b/baselines/bigquery-v2-esm/samples/generated/v2/model_service.delete_model.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/samples/generated/v2/model_service.get_model.js.baseline
+++ b/baselines/bigquery-v2-esm/samples/generated/v2/model_service.get_model.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/samples/generated/v2/model_service.list_models.js.baseline
+++ b/baselines/bigquery-v2-esm/samples/generated/v2/model_service.list_models.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/samples/generated/v2/model_service.patch_model.js.baseline
+++ b/baselines/bigquery-v2-esm/samples/generated/v2/model_service.patch_model.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/samples/generated/v2/project_service.get_service_account.js.baseline
+++ b/baselines/bigquery-v2-esm/samples/generated/v2/project_service.get_service_account.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/samples/generated/v2/routine_service.delete_routine.js.baseline
+++ b/baselines/bigquery-v2-esm/samples/generated/v2/routine_service.delete_routine.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/samples/generated/v2/routine_service.get_routine.js.baseline
+++ b/baselines/bigquery-v2-esm/samples/generated/v2/routine_service.get_routine.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/samples/generated/v2/routine_service.insert_routine.js.baseline
+++ b/baselines/bigquery-v2-esm/samples/generated/v2/routine_service.insert_routine.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/samples/generated/v2/routine_service.list_routines.js.baseline
+++ b/baselines/bigquery-v2-esm/samples/generated/v2/routine_service.list_routines.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/samples/generated/v2/routine_service.patch_routine.js.baseline
+++ b/baselines/bigquery-v2-esm/samples/generated/v2/routine_service.patch_routine.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/samples/generated/v2/routine_service.update_routine.js.baseline
+++ b/baselines/bigquery-v2-esm/samples/generated/v2/routine_service.update_routine.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/samples/generated/v2/row_access_policy_service.list_row_access_policies.js.baseline
+++ b/baselines/bigquery-v2-esm/samples/generated/v2/row_access_policy_service.list_row_access_policies.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/samples/generated/v2/table_service.delete_table.js.baseline
+++ b/baselines/bigquery-v2-esm/samples/generated/v2/table_service.delete_table.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/samples/generated/v2/table_service.get_table.js.baseline
+++ b/baselines/bigquery-v2-esm/samples/generated/v2/table_service.get_table.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/samples/generated/v2/table_service.insert_table.js.baseline
+++ b/baselines/bigquery-v2-esm/samples/generated/v2/table_service.insert_table.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/samples/generated/v2/table_service.list_tables.js.baseline
+++ b/baselines/bigquery-v2-esm/samples/generated/v2/table_service.list_tables.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/samples/generated/v2/table_service.patch_table.js.baseline
+++ b/baselines/bigquery-v2-esm/samples/generated/v2/table_service.patch_table.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2-esm/samples/generated/v2/table_service.update_table.js.baseline
+++ b/baselines/bigquery-v2-esm/samples/generated/v2/table_service.update_table.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/.jsdoc.js.baseline
+++ b/baselines/bigquery-v2/.jsdoc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2024 Google LLC',
+    copyright: 'Copyright 2025 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'bigquery',

--- a/baselines/bigquery-v2/.mocharc.js.baseline
+++ b/baselines/bigquery-v2/.mocharc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/.prettierrc.js.baseline
+++ b/baselines/bigquery-v2/.prettierrc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/samples/generated/v2/dataset_service.delete_dataset.js.baseline
+++ b/baselines/bigquery-v2/samples/generated/v2/dataset_service.delete_dataset.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/samples/generated/v2/dataset_service.get_dataset.js.baseline
+++ b/baselines/bigquery-v2/samples/generated/v2/dataset_service.get_dataset.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/samples/generated/v2/dataset_service.insert_dataset.js.baseline
+++ b/baselines/bigquery-v2/samples/generated/v2/dataset_service.insert_dataset.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/samples/generated/v2/dataset_service.list_datasets.js.baseline
+++ b/baselines/bigquery-v2/samples/generated/v2/dataset_service.list_datasets.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/samples/generated/v2/dataset_service.patch_dataset.js.baseline
+++ b/baselines/bigquery-v2/samples/generated/v2/dataset_service.patch_dataset.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/samples/generated/v2/dataset_service.undelete_dataset.js.baseline
+++ b/baselines/bigquery-v2/samples/generated/v2/dataset_service.undelete_dataset.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/samples/generated/v2/dataset_service.update_dataset.js.baseline
+++ b/baselines/bigquery-v2/samples/generated/v2/dataset_service.update_dataset.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/samples/generated/v2/job_service.cancel_job.js.baseline
+++ b/baselines/bigquery-v2/samples/generated/v2/job_service.cancel_job.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/samples/generated/v2/job_service.delete_job.js.baseline
+++ b/baselines/bigquery-v2/samples/generated/v2/job_service.delete_job.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/samples/generated/v2/job_service.get_job.js.baseline
+++ b/baselines/bigquery-v2/samples/generated/v2/job_service.get_job.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/samples/generated/v2/job_service.get_query_results.js.baseline
+++ b/baselines/bigquery-v2/samples/generated/v2/job_service.get_query_results.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/samples/generated/v2/job_service.insert_job.js.baseline
+++ b/baselines/bigquery-v2/samples/generated/v2/job_service.insert_job.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/samples/generated/v2/job_service.list_jobs.js.baseline
+++ b/baselines/bigquery-v2/samples/generated/v2/job_service.list_jobs.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/samples/generated/v2/job_service.query.js.baseline
+++ b/baselines/bigquery-v2/samples/generated/v2/job_service.query.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/samples/generated/v2/model_service.delete_model.js.baseline
+++ b/baselines/bigquery-v2/samples/generated/v2/model_service.delete_model.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/samples/generated/v2/model_service.get_model.js.baseline
+++ b/baselines/bigquery-v2/samples/generated/v2/model_service.get_model.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/samples/generated/v2/model_service.list_models.js.baseline
+++ b/baselines/bigquery-v2/samples/generated/v2/model_service.list_models.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/samples/generated/v2/model_service.patch_model.js.baseline
+++ b/baselines/bigquery-v2/samples/generated/v2/model_service.patch_model.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/samples/generated/v2/project_service.get_service_account.js.baseline
+++ b/baselines/bigquery-v2/samples/generated/v2/project_service.get_service_account.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/samples/generated/v2/routine_service.delete_routine.js.baseline
+++ b/baselines/bigquery-v2/samples/generated/v2/routine_service.delete_routine.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/samples/generated/v2/routine_service.get_routine.js.baseline
+++ b/baselines/bigquery-v2/samples/generated/v2/routine_service.get_routine.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/samples/generated/v2/routine_service.insert_routine.js.baseline
+++ b/baselines/bigquery-v2/samples/generated/v2/routine_service.insert_routine.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/samples/generated/v2/routine_service.list_routines.js.baseline
+++ b/baselines/bigquery-v2/samples/generated/v2/routine_service.list_routines.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/samples/generated/v2/routine_service.patch_routine.js.baseline
+++ b/baselines/bigquery-v2/samples/generated/v2/routine_service.patch_routine.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/samples/generated/v2/routine_service.update_routine.js.baseline
+++ b/baselines/bigquery-v2/samples/generated/v2/routine_service.update_routine.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/samples/generated/v2/row_access_policy_service.list_row_access_policies.js.baseline
+++ b/baselines/bigquery-v2/samples/generated/v2/row_access_policy_service.list_row_access_policies.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/samples/generated/v2/table_service.delete_table.js.baseline
+++ b/baselines/bigquery-v2/samples/generated/v2/table_service.delete_table.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/samples/generated/v2/table_service.get_table.js.baseline
+++ b/baselines/bigquery-v2/samples/generated/v2/table_service.get_table.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/samples/generated/v2/table_service.insert_table.js.baseline
+++ b/baselines/bigquery-v2/samples/generated/v2/table_service.insert_table.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/samples/generated/v2/table_service.list_tables.js.baseline
+++ b/baselines/bigquery-v2/samples/generated/v2/table_service.list_tables.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/samples/generated/v2/table_service.patch_table.js.baseline
+++ b/baselines/bigquery-v2/samples/generated/v2/table_service.patch_table.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/samples/generated/v2/table_service.update_table.js.baseline
+++ b/baselines/bigquery-v2/samples/generated/v2/table_service.update_table.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/src/index.ts.baseline
+++ b/baselines/bigquery-v2/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/src/v2/dataset_service_client.ts.baseline
+++ b/baselines/bigquery-v2/src/v2/dataset_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -916,7 +916,7 @@ export class DatasetServiceClient {
  *   An object stream which emits an object representing {@link protos.google.cloud.bigquery.v2.ListFormatDataset|ListFormatDataset} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listDatasetsAsync()`
+ *   We recommend using `listDatasetsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/bigquery-v2/src/v2/index.ts.baseline
+++ b/baselines/bigquery-v2/src/v2/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/src/v2/job_service_client.ts.baseline
+++ b/baselines/bigquery-v2/src/v2/job_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -984,7 +984,7 @@ export class JobServiceClient {
  *   An object stream which emits an object representing {@link protos.google.cloud.bigquery.v2.ListFormatJob|ListFormatJob} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listJobsAsync()`
+ *   We recommend using `listJobsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/bigquery-v2/src/v2/model_service_client.ts.baseline
+++ b/baselines/bigquery-v2/src/v2/model_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -670,7 +670,7 @@ export class ModelServiceClient {
  *   An object stream which emits an object representing {@link protos.google.cloud.bigquery.v2.Model|Model} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listModelsAsync()`
+ *   We recommend using `listModelsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/bigquery-v2/src/v2/project_service_client.ts.baseline
+++ b/baselines/bigquery-v2/src/v2/project_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/src/v2/routine_service_client.ts.baseline
+++ b/baselines/bigquery-v2/src/v2/routine_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -828,7 +828,7 @@ export class RoutineServiceClient {
  *   An object stream which emits an object representing {@link protos.google.cloud.bigquery.v2.Routine|Routine} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listRoutinesAsync()`
+ *   We recommend using `listRoutinesStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/bigquery-v2/src/v2/row_access_policy_service_client.ts.baseline
+++ b/baselines/bigquery-v2/src/v2/row_access_policy_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -433,7 +433,7 @@ export class RowAccessPolicyServiceClient {
  *   An object stream which emits an object representing {@link protos.google.cloud.bigquery.v2.RowAccessPolicy|RowAccessPolicy} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listRowAccessPoliciesAsync()`
+ *   We recommend using `listRowAccessPoliciesStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/bigquery-v2/src/v2/table_service_client.ts.baseline
+++ b/baselines/bigquery-v2/src/v2/table_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -843,7 +843,7 @@ export class TableServiceClient {
  *   An object stream which emits an object representing {@link protos.google.cloud.bigquery.v2.ListFormatTable|ListFormatTable} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listTablesAsync()`
+ *   We recommend using `listTablesStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/bigquery-v2/system-test/fixtures/sample/src/index.js.baseline
+++ b/baselines/bigquery-v2/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/bigquery-v2/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/system-test/install.ts.baseline
+++ b/baselines/bigquery-v2/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/test/gapic_dataset_service_v2.ts.baseline
+++ b/baselines/bigquery-v2/test/gapic_dataset_service_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/test/gapic_job_service_v2.ts.baseline
+++ b/baselines/bigquery-v2/test/gapic_job_service_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/test/gapic_model_service_v2.ts.baseline
+++ b/baselines/bigquery-v2/test/gapic_model_service_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/test/gapic_project_service_v2.ts.baseline
+++ b/baselines/bigquery-v2/test/gapic_project_service_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/test/gapic_routine_service_v2.ts.baseline
+++ b/baselines/bigquery-v2/test/gapic_routine_service_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/test/gapic_row_access_policy_service_v2.ts.baseline
+++ b/baselines/bigquery-v2/test/gapic_row_access_policy_service_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/bigquery-v2/test/gapic_table_service_v2.ts.baseline
+++ b/baselines/bigquery-v2/test/gapic_table_service_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/compute-esm/.jsdoc.cjs.baseline
+++ b/baselines/compute-esm/.jsdoc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2024 Google LLC',
+    copyright: 'Copyright 2025 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: '@google-cloud/compute',

--- a/baselines/compute-esm/.mocharc.cjs.baseline
+++ b/baselines/compute-esm/.mocharc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/compute-esm/.prettierrc.cjs.baseline
+++ b/baselines/compute-esm/.prettierrc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/compute-esm/esm/src/index.ts.baseline
+++ b/baselines/compute-esm/esm/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/compute-esm/esm/src/v1/addresses_client.ts.baseline
+++ b/baselines/compute-esm/esm/src/v1/addresses_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -731,7 +731,7 @@ export class AddressesClient {
  *   An object stream which emits an object representing {@link protos.google.cloud.compute.v1.Address|Address} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listAsync()`
+ *   We recommend using `listStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/compute-esm/esm/src/v1/index.ts.baseline
+++ b/baselines/compute-esm/esm/src/v1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/compute-esm/esm/src/v1/region_operations_client.ts.baseline
+++ b/baselines/compute-esm/esm/src/v1/region_operations_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/compute-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
+++ b/baselines/compute-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/compute-esm/esm/system-test/fixtures/sample/src/index.js.baseline
+++ b/baselines/compute-esm/esm/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/compute-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/compute-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,5 +1,5 @@
 /* eslint-disable node/no-missing-require, no-unused-vars, no-undef */
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/compute-esm/esm/system-test/install.ts.baseline
+++ b/baselines/compute-esm/esm/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/compute-esm/esm/test/gapic_addresses_v1.ts.baseline
+++ b/baselines/compute-esm/esm/test/gapic_addresses_v1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/compute-esm/esm/test/gapic_region_operations_v1.ts.baseline
+++ b/baselines/compute-esm/esm/test/gapic_region_operations_v1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/compute-esm/samples/generated/v1/addresses.aggregated_list.js.baseline
+++ b/baselines/compute-esm/samples/generated/v1/addresses.aggregated_list.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/compute-esm/samples/generated/v1/addresses.delete.js.baseline
+++ b/baselines/compute-esm/samples/generated/v1/addresses.delete.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/compute-esm/samples/generated/v1/addresses.insert.js.baseline
+++ b/baselines/compute-esm/samples/generated/v1/addresses.insert.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/compute-esm/samples/generated/v1/addresses.list.js.baseline
+++ b/baselines/compute-esm/samples/generated/v1/addresses.list.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/compute-esm/samples/generated/v1/region_operations.get.js.baseline
+++ b/baselines/compute-esm/samples/generated/v1/region_operations.get.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/compute-esm/samples/generated/v1/region_operations.wait.js.baseline
+++ b/baselines/compute-esm/samples/generated/v1/region_operations.wait.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/compute/.jsdoc.js.baseline
+++ b/baselines/compute/.jsdoc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2024 Google LLC',
+    copyright: 'Copyright 2025 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: '@google-cloud/compute',

--- a/baselines/compute/.mocharc.js.baseline
+++ b/baselines/compute/.mocharc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/compute/.prettierrc.js.baseline
+++ b/baselines/compute/.prettierrc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/compute/samples/generated/v1/addresses.aggregated_list.js.baseline
+++ b/baselines/compute/samples/generated/v1/addresses.aggregated_list.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/compute/samples/generated/v1/addresses.delete.js.baseline
+++ b/baselines/compute/samples/generated/v1/addresses.delete.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/compute/samples/generated/v1/addresses.insert.js.baseline
+++ b/baselines/compute/samples/generated/v1/addresses.insert.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/compute/samples/generated/v1/addresses.list.js.baseline
+++ b/baselines/compute/samples/generated/v1/addresses.list.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/compute/samples/generated/v1/region_operations.get.js.baseline
+++ b/baselines/compute/samples/generated/v1/region_operations.get.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/compute/samples/generated/v1/region_operations.wait.js.baseline
+++ b/baselines/compute/samples/generated/v1/region_operations.wait.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/compute/src/index.ts.baseline
+++ b/baselines/compute/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/compute/src/v1/addresses_client.ts.baseline
+++ b/baselines/compute/src/v1/addresses_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -709,7 +709,7 @@ export class AddressesClient {
  *   An object stream which emits an object representing {@link protos.google.cloud.compute.v1.Address|Address} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listAsync()`
+ *   We recommend using `listStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/compute/src/v1/index.ts.baseline
+++ b/baselines/compute/src/v1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/compute/src/v1/region_operations_client.ts.baseline
+++ b/baselines/compute/src/v1/region_operations_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/compute/system-test/fixtures/sample/src/index.js.baseline
+++ b/baselines/compute/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/compute/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/compute/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/compute/system-test/install.ts.baseline
+++ b/baselines/compute/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/compute/test/gapic_addresses_v1.ts.baseline
+++ b/baselines/compute/test/gapic_addresses_v1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/compute/test/gapic_region_operations_v1.ts.baseline
+++ b/baselines/compute/test/gapic_region_operations_v1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/deprecatedtest-esm/.jsdoc.cjs.baseline
+++ b/baselines/deprecatedtest-esm/.jsdoc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2024 Google LLC',
+    copyright: 'Copyright 2025 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'deprecatedtest',

--- a/baselines/deprecatedtest-esm/.mocharc.cjs.baseline
+++ b/baselines/deprecatedtest-esm/.mocharc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/deprecatedtest-esm/.prettierrc.cjs.baseline
+++ b/baselines/deprecatedtest-esm/.prettierrc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/deprecatedtest-esm/esm/src/index.ts.baseline
+++ b/baselines/deprecatedtest-esm/esm/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/deprecatedtest-esm/esm/src/v1/deprecated_service_client.ts.baseline
+++ b/baselines/deprecatedtest-esm/esm/src/v1/deprecated_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/deprecatedtest-esm/esm/src/v1/index.ts.baseline
+++ b/baselines/deprecatedtest-esm/esm/src/v1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/deprecatedtest-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
+++ b/baselines/deprecatedtest-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/deprecatedtest-esm/esm/system-test/fixtures/sample/src/index.js.baseline
+++ b/baselines/deprecatedtest-esm/esm/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/deprecatedtest-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/deprecatedtest-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,5 +1,5 @@
 /* eslint-disable node/no-missing-require, no-unused-vars, no-undef */
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/deprecatedtest-esm/esm/system-test/install.ts.baseline
+++ b/baselines/deprecatedtest-esm/esm/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/deprecatedtest-esm/esm/test/gapic_deprecated_service_v1.ts.baseline
+++ b/baselines/deprecatedtest-esm/esm/test/gapic_deprecated_service_v1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/deprecatedtest-esm/samples/generated/v1/deprecated_service.fast_fibonacci.js.baseline
+++ b/baselines/deprecatedtest-esm/samples/generated/v1/deprecated_service.fast_fibonacci.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/deprecatedtest-esm/samples/generated/v1/deprecated_service.slow_fibonacci.js.baseline
+++ b/baselines/deprecatedtest-esm/samples/generated/v1/deprecated_service.slow_fibonacci.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/deprecatedtest/.jsdoc.js.baseline
+++ b/baselines/deprecatedtest/.jsdoc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2024 Google LLC',
+    copyright: 'Copyright 2025 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'deprecatedtest',

--- a/baselines/deprecatedtest/.mocharc.js.baseline
+++ b/baselines/deprecatedtest/.mocharc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/deprecatedtest/.prettierrc.js.baseline
+++ b/baselines/deprecatedtest/.prettierrc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/deprecatedtest/samples/generated/v1/deprecated_service.fast_fibonacci.js.baseline
+++ b/baselines/deprecatedtest/samples/generated/v1/deprecated_service.fast_fibonacci.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/deprecatedtest/samples/generated/v1/deprecated_service.slow_fibonacci.js.baseline
+++ b/baselines/deprecatedtest/samples/generated/v1/deprecated_service.slow_fibonacci.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/deprecatedtest/src/index.ts.baseline
+++ b/baselines/deprecatedtest/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/deprecatedtest/src/v1/deprecated_service_client.ts.baseline
+++ b/baselines/deprecatedtest/src/v1/deprecated_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/deprecatedtest/src/v1/index.ts.baseline
+++ b/baselines/deprecatedtest/src/v1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/deprecatedtest/system-test/fixtures/sample/src/index.js.baseline
+++ b/baselines/deprecatedtest/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/deprecatedtest/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/deprecatedtest/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/deprecatedtest/system-test/install.ts.baseline
+++ b/baselines/deprecatedtest/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/deprecatedtest/test/gapic_deprecated_service_v1.ts.baseline
+++ b/baselines/deprecatedtest/test/gapic_deprecated_service_v1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/disable-packing-test-esm/.jsdoc.cjs.baseline
+++ b/baselines/disable-packing-test-esm/.jsdoc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2024 Google LLC',
+    copyright: 'Copyright 2025 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'showcase',

--- a/baselines/disable-packing-test-esm/.mocharc.cjs.baseline
+++ b/baselines/disable-packing-test-esm/.mocharc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/disable-packing-test-esm/.prettierrc.cjs.baseline
+++ b/baselines/disable-packing-test-esm/.prettierrc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/disable-packing-test-esm/esm/src/index.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/compliance_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/compliance_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/echo_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1096,7 +1096,7 @@ export class EchoClient {
  *   An object stream which emits an object representing {@link protos.google.showcase.v1beta1.EchoResponse|EchoResponse} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `pagedExpandAsync()`
+ *   We recommend using `pagedExpandStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/identity_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -752,7 +752,7 @@ export class IdentityClient {
  *   An object stream which emits an object representing {@link protos.google.showcase.v1beta1.User|User} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listUsersAsync()`
+ *   We recommend using `listUsersStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/index.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/messaging_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1297,7 +1297,7 @@ export class MessagingClient {
  *   An object stream which emits an object representing {@link protos.google.showcase.v1beta1.Room|Room} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listRoomsAsync()`
+ *   We recommend using `listRoomsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -1467,7 +1467,7 @@ export class MessagingClient {
  *   An object stream which emits an object representing {@link protos.google.showcase.v1beta1.Blurb|Blurb} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listBlurbsAsync()`
+ *   We recommend using `listBlurbsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/sequence_service_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/sequence_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/testing_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -902,7 +902,7 @@ export class TestingClient {
  *   An object stream which emits an object representing {@link protos.google.showcase.v1beta1.Session|Session} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listSessionsAsync()`
+ *   We recommend using `listSessionsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -1060,7 +1060,7 @@ export class TestingClient {
  *   An object stream which emits an object representing {@link protos.google.showcase.v1beta1.Test|Test} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listTestsAsync()`
+ *   We recommend using `listTestsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/disable-packing-test-esm/esm/test/gapic_compliance_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/test/gapic_compliance_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/disable-packing-test-esm/esm/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/test/gapic_echo_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/disable-packing-test-esm/esm/test/gapic_identity_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/test/gapic_identity_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/disable-packing-test-esm/esm/test/gapic_messaging_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/test/gapic_messaging_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/disable-packing-test-esm/esm/test/gapic_sequence_service_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/test/gapic_sequence_service_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/disable-packing-test-esm/esm/test/gapic_testing_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/test/gapic_testing_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/disable-packing-test/.jsdoc.js.baseline
+++ b/baselines/disable-packing-test/.jsdoc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2024 Google LLC',
+    copyright: 'Copyright 2025 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'showcase',

--- a/baselines/disable-packing-test/.mocharc.js.baseline
+++ b/baselines/disable-packing-test/.mocharc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/disable-packing-test/.prettierrc.js.baseline
+++ b/baselines/disable-packing-test/.prettierrc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/disable-packing-test/src/index.ts.baseline
+++ b/baselines/disable-packing-test/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/disable-packing-test/src/v1beta1/compliance_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/compliance_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1074,7 +1074,7 @@ export class EchoClient {
  *   An object stream which emits an object representing {@link protos.google.showcase.v1beta1.EchoResponse|EchoResponse} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `pagedExpandAsync()`
+ *   We recommend using `pagedExpandStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/disable-packing-test/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/identity_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -730,7 +730,7 @@ export class IdentityClient {
  *   An object stream which emits an object representing {@link protos.google.showcase.v1beta1.User|User} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listUsersAsync()`
+ *   We recommend using `listUsersStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/disable-packing-test/src/v1beta1/index.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1275,7 +1275,7 @@ export class MessagingClient {
  *   An object stream which emits an object representing {@link protos.google.showcase.v1beta1.Room|Room} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listRoomsAsync()`
+ *   We recommend using `listRoomsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -1445,7 +1445,7 @@ export class MessagingClient {
  *   An object stream which emits an object representing {@link protos.google.showcase.v1beta1.Blurb|Blurb} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listBlurbsAsync()`
+ *   We recommend using `listBlurbsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/disable-packing-test/src/v1beta1/sequence_service_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/sequence_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/disable-packing-test/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/testing_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -880,7 +880,7 @@ export class TestingClient {
  *   An object stream which emits an object representing {@link protos.google.showcase.v1beta1.Session|Session} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listSessionsAsync()`
+ *   We recommend using `listSessionsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -1038,7 +1038,7 @@ export class TestingClient {
  *   An object stream which emits an object representing {@link protos.google.showcase.v1beta1.Test|Test} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listTestsAsync()`
+ *   We recommend using `listTestsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/disable-packing-test/test/gapic_compliance_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_compliance_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/disable-packing-test/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_echo_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/disable-packing-test/test/gapic_identity_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_identity_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/disable-packing-test/test/gapic_messaging_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_messaging_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/disable-packing-test/test/gapic_sequence_service_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_sequence_service_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/disable-packing-test/test/gapic_testing_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_testing_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp-esm/.jsdoc.cjs.baseline
+++ b/baselines/dlp-esm/.jsdoc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2024 Google LLC',
+    copyright: 'Copyright 2025 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'dlp',

--- a/baselines/dlp-esm/.mocharc.cjs.baseline
+++ b/baselines/dlp-esm/.mocharc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp-esm/.prettierrc.cjs.baseline
+++ b/baselines/dlp-esm/.prettierrc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp-esm/esm/src/index.ts.baseline
+++ b/baselines/dlp-esm/esm/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp-esm/esm/src/v2/dlp_service_client.ts.baseline
+++ b/baselines/dlp-esm/esm/src/v2/dlp_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -2620,7 +2620,7 @@ export class DlpServiceClient {
  *   An object stream which emits an object representing {@link protos.google.privacy.dlp.v2.InspectTemplate|InspectTemplate} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listInspectTemplatesAsync()`
+ *   We recommend using `listInspectTemplatesStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -2855,7 +2855,7 @@ export class DlpServiceClient {
  *   An object stream which emits an object representing {@link protos.google.privacy.dlp.v2.DeidentifyTemplate|DeidentifyTemplate} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listDeidentifyTemplatesAsync()`
+ *   We recommend using `listDeidentifyTemplatesStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -3141,7 +3141,7 @@ export class DlpServiceClient {
  *   An object stream which emits an object representing {@link protos.google.privacy.dlp.v2.JobTrigger|JobTrigger} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listJobTriggersAsync()`
+ *   We recommend using `listJobTriggersStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -3458,7 +3458,7 @@ export class DlpServiceClient {
  *   An object stream which emits an object representing {@link protos.google.privacy.dlp.v2.DlpJob|DlpJob} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listDlpJobsAsync()`
+ *   We recommend using `listDlpJobsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -3723,7 +3723,7 @@ export class DlpServiceClient {
  *   An object stream which emits an object representing {@link protos.google.privacy.dlp.v2.StoredInfoType|StoredInfoType} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listStoredInfoTypesAsync()`
+ *   We recommend using `listStoredInfoTypesStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/dlp-esm/esm/src/v2/index.ts.baseline
+++ b/baselines/dlp-esm/esm/src/v2/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
+++ b/baselines/dlp-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp-esm/esm/system-test/fixtures/sample/src/index.js.baseline
+++ b/baselines/dlp-esm/esm/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/dlp-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,5 +1,5 @@
 /* eslint-disable node/no-missing-require, no-unused-vars, no-undef */
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp-esm/esm/system-test/install.ts.baseline
+++ b/baselines/dlp-esm/esm/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp-esm/esm/test/gapic_dlp_service_v2.ts.baseline
+++ b/baselines/dlp-esm/esm/test/gapic_dlp_service_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp-esm/samples/generated/v2/dlp_service.activate_job_trigger.js.baseline
+++ b/baselines/dlp-esm/samples/generated/v2/dlp_service.activate_job_trigger.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp-esm/samples/generated/v2/dlp_service.cancel_dlp_job.js.baseline
+++ b/baselines/dlp-esm/samples/generated/v2/dlp_service.cancel_dlp_job.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp-esm/samples/generated/v2/dlp_service.create_deidentify_template.js.baseline
+++ b/baselines/dlp-esm/samples/generated/v2/dlp_service.create_deidentify_template.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp-esm/samples/generated/v2/dlp_service.create_dlp_job.js.baseline
+++ b/baselines/dlp-esm/samples/generated/v2/dlp_service.create_dlp_job.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp-esm/samples/generated/v2/dlp_service.create_inspect_template.js.baseline
+++ b/baselines/dlp-esm/samples/generated/v2/dlp_service.create_inspect_template.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp-esm/samples/generated/v2/dlp_service.create_job_trigger.js.baseline
+++ b/baselines/dlp-esm/samples/generated/v2/dlp_service.create_job_trigger.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp-esm/samples/generated/v2/dlp_service.create_stored_info_type.js.baseline
+++ b/baselines/dlp-esm/samples/generated/v2/dlp_service.create_stored_info_type.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp-esm/samples/generated/v2/dlp_service.deidentify_content.js.baseline
+++ b/baselines/dlp-esm/samples/generated/v2/dlp_service.deidentify_content.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp-esm/samples/generated/v2/dlp_service.delete_deidentify_template.js.baseline
+++ b/baselines/dlp-esm/samples/generated/v2/dlp_service.delete_deidentify_template.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp-esm/samples/generated/v2/dlp_service.delete_dlp_job.js.baseline
+++ b/baselines/dlp-esm/samples/generated/v2/dlp_service.delete_dlp_job.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp-esm/samples/generated/v2/dlp_service.delete_inspect_template.js.baseline
+++ b/baselines/dlp-esm/samples/generated/v2/dlp_service.delete_inspect_template.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp-esm/samples/generated/v2/dlp_service.delete_job_trigger.js.baseline
+++ b/baselines/dlp-esm/samples/generated/v2/dlp_service.delete_job_trigger.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp-esm/samples/generated/v2/dlp_service.delete_stored_info_type.js.baseline
+++ b/baselines/dlp-esm/samples/generated/v2/dlp_service.delete_stored_info_type.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp-esm/samples/generated/v2/dlp_service.get_deidentify_template.js.baseline
+++ b/baselines/dlp-esm/samples/generated/v2/dlp_service.get_deidentify_template.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp-esm/samples/generated/v2/dlp_service.get_dlp_job.js.baseline
+++ b/baselines/dlp-esm/samples/generated/v2/dlp_service.get_dlp_job.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp-esm/samples/generated/v2/dlp_service.get_inspect_template.js.baseline
+++ b/baselines/dlp-esm/samples/generated/v2/dlp_service.get_inspect_template.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp-esm/samples/generated/v2/dlp_service.get_job_trigger.js.baseline
+++ b/baselines/dlp-esm/samples/generated/v2/dlp_service.get_job_trigger.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp-esm/samples/generated/v2/dlp_service.get_stored_info_type.js.baseline
+++ b/baselines/dlp-esm/samples/generated/v2/dlp_service.get_stored_info_type.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp-esm/samples/generated/v2/dlp_service.inspect_content.js.baseline
+++ b/baselines/dlp-esm/samples/generated/v2/dlp_service.inspect_content.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp-esm/samples/generated/v2/dlp_service.list_deidentify_templates.js.baseline
+++ b/baselines/dlp-esm/samples/generated/v2/dlp_service.list_deidentify_templates.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp-esm/samples/generated/v2/dlp_service.list_dlp_jobs.js.baseline
+++ b/baselines/dlp-esm/samples/generated/v2/dlp_service.list_dlp_jobs.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp-esm/samples/generated/v2/dlp_service.list_info_types.js.baseline
+++ b/baselines/dlp-esm/samples/generated/v2/dlp_service.list_info_types.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp-esm/samples/generated/v2/dlp_service.list_inspect_templates.js.baseline
+++ b/baselines/dlp-esm/samples/generated/v2/dlp_service.list_inspect_templates.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp-esm/samples/generated/v2/dlp_service.list_job_triggers.js.baseline
+++ b/baselines/dlp-esm/samples/generated/v2/dlp_service.list_job_triggers.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp-esm/samples/generated/v2/dlp_service.list_stored_info_types.js.baseline
+++ b/baselines/dlp-esm/samples/generated/v2/dlp_service.list_stored_info_types.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp-esm/samples/generated/v2/dlp_service.redact_image.js.baseline
+++ b/baselines/dlp-esm/samples/generated/v2/dlp_service.redact_image.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp-esm/samples/generated/v2/dlp_service.reidentify_content.js.baseline
+++ b/baselines/dlp-esm/samples/generated/v2/dlp_service.reidentify_content.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp-esm/samples/generated/v2/dlp_service.update_deidentify_template.js.baseline
+++ b/baselines/dlp-esm/samples/generated/v2/dlp_service.update_deidentify_template.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp-esm/samples/generated/v2/dlp_service.update_inspect_template.js.baseline
+++ b/baselines/dlp-esm/samples/generated/v2/dlp_service.update_inspect_template.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp-esm/samples/generated/v2/dlp_service.update_job_trigger.js.baseline
+++ b/baselines/dlp-esm/samples/generated/v2/dlp_service.update_job_trigger.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp-esm/samples/generated/v2/dlp_service.update_stored_info_type.js.baseline
+++ b/baselines/dlp-esm/samples/generated/v2/dlp_service.update_stored_info_type.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp/.jsdoc.js.baseline
+++ b/baselines/dlp/.jsdoc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2024 Google LLC',
+    copyright: 'Copyright 2025 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'dlp',

--- a/baselines/dlp/.mocharc.js.baseline
+++ b/baselines/dlp/.mocharc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp/.prettierrc.js.baseline
+++ b/baselines/dlp/.prettierrc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp/samples/generated/v2/dlp_service.activate_job_trigger.js.baseline
+++ b/baselines/dlp/samples/generated/v2/dlp_service.activate_job_trigger.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp/samples/generated/v2/dlp_service.cancel_dlp_job.js.baseline
+++ b/baselines/dlp/samples/generated/v2/dlp_service.cancel_dlp_job.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp/samples/generated/v2/dlp_service.create_deidentify_template.js.baseline
+++ b/baselines/dlp/samples/generated/v2/dlp_service.create_deidentify_template.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp/samples/generated/v2/dlp_service.create_dlp_job.js.baseline
+++ b/baselines/dlp/samples/generated/v2/dlp_service.create_dlp_job.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp/samples/generated/v2/dlp_service.create_inspect_template.js.baseline
+++ b/baselines/dlp/samples/generated/v2/dlp_service.create_inspect_template.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp/samples/generated/v2/dlp_service.create_job_trigger.js.baseline
+++ b/baselines/dlp/samples/generated/v2/dlp_service.create_job_trigger.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp/samples/generated/v2/dlp_service.create_stored_info_type.js.baseline
+++ b/baselines/dlp/samples/generated/v2/dlp_service.create_stored_info_type.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp/samples/generated/v2/dlp_service.deidentify_content.js.baseline
+++ b/baselines/dlp/samples/generated/v2/dlp_service.deidentify_content.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp/samples/generated/v2/dlp_service.delete_deidentify_template.js.baseline
+++ b/baselines/dlp/samples/generated/v2/dlp_service.delete_deidentify_template.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp/samples/generated/v2/dlp_service.delete_dlp_job.js.baseline
+++ b/baselines/dlp/samples/generated/v2/dlp_service.delete_dlp_job.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp/samples/generated/v2/dlp_service.delete_inspect_template.js.baseline
+++ b/baselines/dlp/samples/generated/v2/dlp_service.delete_inspect_template.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp/samples/generated/v2/dlp_service.delete_job_trigger.js.baseline
+++ b/baselines/dlp/samples/generated/v2/dlp_service.delete_job_trigger.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp/samples/generated/v2/dlp_service.delete_stored_info_type.js.baseline
+++ b/baselines/dlp/samples/generated/v2/dlp_service.delete_stored_info_type.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp/samples/generated/v2/dlp_service.get_deidentify_template.js.baseline
+++ b/baselines/dlp/samples/generated/v2/dlp_service.get_deidentify_template.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp/samples/generated/v2/dlp_service.get_dlp_job.js.baseline
+++ b/baselines/dlp/samples/generated/v2/dlp_service.get_dlp_job.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp/samples/generated/v2/dlp_service.get_inspect_template.js.baseline
+++ b/baselines/dlp/samples/generated/v2/dlp_service.get_inspect_template.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp/samples/generated/v2/dlp_service.get_job_trigger.js.baseline
+++ b/baselines/dlp/samples/generated/v2/dlp_service.get_job_trigger.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp/samples/generated/v2/dlp_service.get_stored_info_type.js.baseline
+++ b/baselines/dlp/samples/generated/v2/dlp_service.get_stored_info_type.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp/samples/generated/v2/dlp_service.inspect_content.js.baseline
+++ b/baselines/dlp/samples/generated/v2/dlp_service.inspect_content.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp/samples/generated/v2/dlp_service.list_deidentify_templates.js.baseline
+++ b/baselines/dlp/samples/generated/v2/dlp_service.list_deidentify_templates.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp/samples/generated/v2/dlp_service.list_dlp_jobs.js.baseline
+++ b/baselines/dlp/samples/generated/v2/dlp_service.list_dlp_jobs.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp/samples/generated/v2/dlp_service.list_info_types.js.baseline
+++ b/baselines/dlp/samples/generated/v2/dlp_service.list_info_types.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp/samples/generated/v2/dlp_service.list_inspect_templates.js.baseline
+++ b/baselines/dlp/samples/generated/v2/dlp_service.list_inspect_templates.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp/samples/generated/v2/dlp_service.list_job_triggers.js.baseline
+++ b/baselines/dlp/samples/generated/v2/dlp_service.list_job_triggers.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp/samples/generated/v2/dlp_service.list_stored_info_types.js.baseline
+++ b/baselines/dlp/samples/generated/v2/dlp_service.list_stored_info_types.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp/samples/generated/v2/dlp_service.redact_image.js.baseline
+++ b/baselines/dlp/samples/generated/v2/dlp_service.redact_image.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp/samples/generated/v2/dlp_service.reidentify_content.js.baseline
+++ b/baselines/dlp/samples/generated/v2/dlp_service.reidentify_content.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp/samples/generated/v2/dlp_service.update_deidentify_template.js.baseline
+++ b/baselines/dlp/samples/generated/v2/dlp_service.update_deidentify_template.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp/samples/generated/v2/dlp_service.update_inspect_template.js.baseline
+++ b/baselines/dlp/samples/generated/v2/dlp_service.update_inspect_template.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp/samples/generated/v2/dlp_service.update_job_trigger.js.baseline
+++ b/baselines/dlp/samples/generated/v2/dlp_service.update_job_trigger.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp/samples/generated/v2/dlp_service.update_stored_info_type.js.baseline
+++ b/baselines/dlp/samples/generated/v2/dlp_service.update_stored_info_type.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp/src/index.ts.baseline
+++ b/baselines/dlp/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp/src/v2/dlp_service_client.ts.baseline
+++ b/baselines/dlp/src/v2/dlp_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -2598,7 +2598,7 @@ export class DlpServiceClient {
  *   An object stream which emits an object representing {@link protos.google.privacy.dlp.v2.InspectTemplate|InspectTemplate} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listInspectTemplatesAsync()`
+ *   We recommend using `listInspectTemplatesStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -2833,7 +2833,7 @@ export class DlpServiceClient {
  *   An object stream which emits an object representing {@link protos.google.privacy.dlp.v2.DeidentifyTemplate|DeidentifyTemplate} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listDeidentifyTemplatesAsync()`
+ *   We recommend using `listDeidentifyTemplatesStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -3119,7 +3119,7 @@ export class DlpServiceClient {
  *   An object stream which emits an object representing {@link protos.google.privacy.dlp.v2.JobTrigger|JobTrigger} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listJobTriggersAsync()`
+ *   We recommend using `listJobTriggersStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -3436,7 +3436,7 @@ export class DlpServiceClient {
  *   An object stream which emits an object representing {@link protos.google.privacy.dlp.v2.DlpJob|DlpJob} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listDlpJobsAsync()`
+ *   We recommend using `listDlpJobsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -3701,7 +3701,7 @@ export class DlpServiceClient {
  *   An object stream which emits an object representing {@link protos.google.privacy.dlp.v2.StoredInfoType|StoredInfoType} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listStoredInfoTypesAsync()`
+ *   We recommend using `listStoredInfoTypesStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/dlp/src/v2/index.ts.baseline
+++ b/baselines/dlp/src/v2/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp/system-test/fixtures/sample/src/index.js.baseline
+++ b/baselines/dlp/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/dlp/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp/system-test/install.ts.baseline
+++ b/baselines/dlp/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/dlp/test/gapic_dlp_service_v2.ts.baseline
+++ b/baselines/dlp/test/gapic_dlp_service_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms-esm/.jsdoc.cjs.baseline
+++ b/baselines/kms-esm/.jsdoc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2024 Google LLC',
+    copyright: 'Copyright 2025 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'kms',

--- a/baselines/kms-esm/.mocharc.cjs.baseline
+++ b/baselines/kms-esm/.mocharc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms-esm/.prettierrc.cjs.baseline
+++ b/baselines/kms-esm/.prettierrc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms-esm/esm/src/index.ts.baseline
+++ b/baselines/kms-esm/esm/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms-esm/esm/src/v1/index.ts.baseline
+++ b/baselines/kms-esm/esm/src/v1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms-esm/esm/src/v1/key_management_service_client.ts.baseline
+++ b/baselines/kms-esm/esm/src/v1/key_management_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1959,7 +1959,7 @@ export class KeyManagementServiceClient {
  *   An object stream which emits an object representing {@link protos.google.cloud.kms.v1.KeyRing|KeyRing} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listKeyRingsAsync()`
+ *   We recommend using `listKeyRingsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -2163,7 +2163,7 @@ export class KeyManagementServiceClient {
  *   An object stream which emits an object representing {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKey} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listCryptoKeysAsync()`
+ *   We recommend using `listCryptoKeysStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -2371,7 +2371,7 @@ export class KeyManagementServiceClient {
  *   An object stream which emits an object representing {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listCryptoKeyVersionsAsync()`
+ *   We recommend using `listCryptoKeyVersionsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -2574,7 +2574,7 @@ export class KeyManagementServiceClient {
  *   An object stream which emits an object representing {@link protos.google.cloud.kms.v1.ImportJob|ImportJob} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listImportJobsAsync()`
+ *   We recommend using `listImportJobsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/kms-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
+++ b/baselines/kms-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms-esm/esm/system-test/fixtures/sample/src/index.js.baseline
+++ b/baselines/kms-esm/esm/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/kms-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,5 +1,5 @@
 /* eslint-disable node/no-missing-require, no-unused-vars, no-undef */
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms-esm/esm/system-test/install.ts.baseline
+++ b/baselines/kms-esm/esm/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms-esm/esm/test/gapic_key_management_service_v1.ts.baseline
+++ b/baselines/kms-esm/esm/test/gapic_key_management_service_v1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms-esm/samples/generated/v1/key_management_service.asymmetric_decrypt.js.baseline
+++ b/baselines/kms-esm/samples/generated/v1/key_management_service.asymmetric_decrypt.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms-esm/samples/generated/v1/key_management_service.asymmetric_sign.js.baseline
+++ b/baselines/kms-esm/samples/generated/v1/key_management_service.asymmetric_sign.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms-esm/samples/generated/v1/key_management_service.create_crypto_key.js.baseline
+++ b/baselines/kms-esm/samples/generated/v1/key_management_service.create_crypto_key.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms-esm/samples/generated/v1/key_management_service.create_crypto_key_version.js.baseline
+++ b/baselines/kms-esm/samples/generated/v1/key_management_service.create_crypto_key_version.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms-esm/samples/generated/v1/key_management_service.create_import_job.js.baseline
+++ b/baselines/kms-esm/samples/generated/v1/key_management_service.create_import_job.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms-esm/samples/generated/v1/key_management_service.create_key_ring.js.baseline
+++ b/baselines/kms-esm/samples/generated/v1/key_management_service.create_key_ring.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms-esm/samples/generated/v1/key_management_service.decrypt.js.baseline
+++ b/baselines/kms-esm/samples/generated/v1/key_management_service.decrypt.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms-esm/samples/generated/v1/key_management_service.destroy_crypto_key_version.js.baseline
+++ b/baselines/kms-esm/samples/generated/v1/key_management_service.destroy_crypto_key_version.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms-esm/samples/generated/v1/key_management_service.encrypt.js.baseline
+++ b/baselines/kms-esm/samples/generated/v1/key_management_service.encrypt.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms-esm/samples/generated/v1/key_management_service.get_crypto_key.js.baseline
+++ b/baselines/kms-esm/samples/generated/v1/key_management_service.get_crypto_key.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms-esm/samples/generated/v1/key_management_service.get_crypto_key_version.js.baseline
+++ b/baselines/kms-esm/samples/generated/v1/key_management_service.get_crypto_key_version.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms-esm/samples/generated/v1/key_management_service.get_import_job.js.baseline
+++ b/baselines/kms-esm/samples/generated/v1/key_management_service.get_import_job.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms-esm/samples/generated/v1/key_management_service.get_key_ring.js.baseline
+++ b/baselines/kms-esm/samples/generated/v1/key_management_service.get_key_ring.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms-esm/samples/generated/v1/key_management_service.get_public_key.js.baseline
+++ b/baselines/kms-esm/samples/generated/v1/key_management_service.get_public_key.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms-esm/samples/generated/v1/key_management_service.import_crypto_key_version.js.baseline
+++ b/baselines/kms-esm/samples/generated/v1/key_management_service.import_crypto_key_version.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms-esm/samples/generated/v1/key_management_service.list_crypto_key_versions.js.baseline
+++ b/baselines/kms-esm/samples/generated/v1/key_management_service.list_crypto_key_versions.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms-esm/samples/generated/v1/key_management_service.list_crypto_keys.js.baseline
+++ b/baselines/kms-esm/samples/generated/v1/key_management_service.list_crypto_keys.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms-esm/samples/generated/v1/key_management_service.list_import_jobs.js.baseline
+++ b/baselines/kms-esm/samples/generated/v1/key_management_service.list_import_jobs.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms-esm/samples/generated/v1/key_management_service.list_key_rings.js.baseline
+++ b/baselines/kms-esm/samples/generated/v1/key_management_service.list_key_rings.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms-esm/samples/generated/v1/key_management_service.restore_crypto_key_version.js.baseline
+++ b/baselines/kms-esm/samples/generated/v1/key_management_service.restore_crypto_key_version.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms-esm/samples/generated/v1/key_management_service.update_crypto_key.js.baseline
+++ b/baselines/kms-esm/samples/generated/v1/key_management_service.update_crypto_key.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms-esm/samples/generated/v1/key_management_service.update_crypto_key_primary_version.js.baseline
+++ b/baselines/kms-esm/samples/generated/v1/key_management_service.update_crypto_key_primary_version.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms-esm/samples/generated/v1/key_management_service.update_crypto_key_version.js.baseline
+++ b/baselines/kms-esm/samples/generated/v1/key_management_service.update_crypto_key_version.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms/.jsdoc.js.baseline
+++ b/baselines/kms/.jsdoc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2024 Google LLC',
+    copyright: 'Copyright 2025 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'kms',

--- a/baselines/kms/.mocharc.js.baseline
+++ b/baselines/kms/.mocharc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms/.prettierrc.js.baseline
+++ b/baselines/kms/.prettierrc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms/samples/generated/v1/key_management_service.asymmetric_decrypt.js.baseline
+++ b/baselines/kms/samples/generated/v1/key_management_service.asymmetric_decrypt.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms/samples/generated/v1/key_management_service.asymmetric_sign.js.baseline
+++ b/baselines/kms/samples/generated/v1/key_management_service.asymmetric_sign.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms/samples/generated/v1/key_management_service.create_crypto_key.js.baseline
+++ b/baselines/kms/samples/generated/v1/key_management_service.create_crypto_key.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms/samples/generated/v1/key_management_service.create_crypto_key_version.js.baseline
+++ b/baselines/kms/samples/generated/v1/key_management_service.create_crypto_key_version.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms/samples/generated/v1/key_management_service.create_import_job.js.baseline
+++ b/baselines/kms/samples/generated/v1/key_management_service.create_import_job.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms/samples/generated/v1/key_management_service.create_key_ring.js.baseline
+++ b/baselines/kms/samples/generated/v1/key_management_service.create_key_ring.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms/samples/generated/v1/key_management_service.decrypt.js.baseline
+++ b/baselines/kms/samples/generated/v1/key_management_service.decrypt.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms/samples/generated/v1/key_management_service.destroy_crypto_key_version.js.baseline
+++ b/baselines/kms/samples/generated/v1/key_management_service.destroy_crypto_key_version.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms/samples/generated/v1/key_management_service.encrypt.js.baseline
+++ b/baselines/kms/samples/generated/v1/key_management_service.encrypt.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms/samples/generated/v1/key_management_service.get_crypto_key.js.baseline
+++ b/baselines/kms/samples/generated/v1/key_management_service.get_crypto_key.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms/samples/generated/v1/key_management_service.get_crypto_key_version.js.baseline
+++ b/baselines/kms/samples/generated/v1/key_management_service.get_crypto_key_version.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms/samples/generated/v1/key_management_service.get_import_job.js.baseline
+++ b/baselines/kms/samples/generated/v1/key_management_service.get_import_job.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms/samples/generated/v1/key_management_service.get_key_ring.js.baseline
+++ b/baselines/kms/samples/generated/v1/key_management_service.get_key_ring.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms/samples/generated/v1/key_management_service.get_public_key.js.baseline
+++ b/baselines/kms/samples/generated/v1/key_management_service.get_public_key.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms/samples/generated/v1/key_management_service.import_crypto_key_version.js.baseline
+++ b/baselines/kms/samples/generated/v1/key_management_service.import_crypto_key_version.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms/samples/generated/v1/key_management_service.list_crypto_key_versions.js.baseline
+++ b/baselines/kms/samples/generated/v1/key_management_service.list_crypto_key_versions.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms/samples/generated/v1/key_management_service.list_crypto_keys.js.baseline
+++ b/baselines/kms/samples/generated/v1/key_management_service.list_crypto_keys.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms/samples/generated/v1/key_management_service.list_import_jobs.js.baseline
+++ b/baselines/kms/samples/generated/v1/key_management_service.list_import_jobs.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms/samples/generated/v1/key_management_service.list_key_rings.js.baseline
+++ b/baselines/kms/samples/generated/v1/key_management_service.list_key_rings.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms/samples/generated/v1/key_management_service.restore_crypto_key_version.js.baseline
+++ b/baselines/kms/samples/generated/v1/key_management_service.restore_crypto_key_version.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms/samples/generated/v1/key_management_service.update_crypto_key.js.baseline
+++ b/baselines/kms/samples/generated/v1/key_management_service.update_crypto_key.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms/samples/generated/v1/key_management_service.update_crypto_key_primary_version.js.baseline
+++ b/baselines/kms/samples/generated/v1/key_management_service.update_crypto_key_primary_version.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms/samples/generated/v1/key_management_service.update_crypto_key_version.js.baseline
+++ b/baselines/kms/samples/generated/v1/key_management_service.update_crypto_key_version.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms/src/index.ts.baseline
+++ b/baselines/kms/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms/src/v1/index.ts.baseline
+++ b/baselines/kms/src/v1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms/src/v1/key_management_service_client.ts.baseline
+++ b/baselines/kms/src/v1/key_management_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1937,7 +1937,7 @@ export class KeyManagementServiceClient {
  *   An object stream which emits an object representing {@link protos.google.cloud.kms.v1.KeyRing|KeyRing} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listKeyRingsAsync()`
+ *   We recommend using `listKeyRingsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -2141,7 +2141,7 @@ export class KeyManagementServiceClient {
  *   An object stream which emits an object representing {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKey} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listCryptoKeysAsync()`
+ *   We recommend using `listCryptoKeysStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -2349,7 +2349,7 @@ export class KeyManagementServiceClient {
  *   An object stream which emits an object representing {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listCryptoKeyVersionsAsync()`
+ *   We recommend using `listCryptoKeyVersionsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -2552,7 +2552,7 @@ export class KeyManagementServiceClient {
  *   An object stream which emits an object representing {@link protos.google.cloud.kms.v1.ImportJob|ImportJob} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listImportJobsAsync()`
+ *   We recommend using `listImportJobsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/kms/system-test/fixtures/sample/src/index.js.baseline
+++ b/baselines/kms/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/kms/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms/system-test/install.ts.baseline
+++ b/baselines/kms/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/kms/test/gapic_key_management_service_v1.ts.baseline
+++ b/baselines/kms/test/gapic_key_management_service_v1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/.jsdoc.cjs.baseline
+++ b/baselines/logging-esm/.jsdoc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2024 Google LLC',
+    copyright: 'Copyright 2025 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'logging',

--- a/baselines/logging-esm/.mocharc.cjs.baseline
+++ b/baselines/logging-esm/.mocharc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/.prettierrc.cjs.baseline
+++ b/baselines/logging-esm/.prettierrc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/esm/src/index.ts.baseline
+++ b/baselines/logging-esm/esm/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/esm/src/v2/config_service_v2_client.ts.baseline
+++ b/baselines/logging-esm/esm/src/v2/config_service_v2_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -2563,7 +2563,7 @@ export class ConfigServiceV2Client {
  *   An object stream which emits an object representing {@link protos.google.logging.v2.LogBucket|LogBucket} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listBucketsAsync()`
+ *   We recommend using `listBucketsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -2763,7 +2763,7 @@ export class ConfigServiceV2Client {
  *   An object stream which emits an object representing {@link protos.google.logging.v2.LogView|LogView} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listViewsAsync()`
+ *   We recommend using `listViewsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -2961,7 +2961,7 @@ export class ConfigServiceV2Client {
  *   An object stream which emits an object representing {@link protos.google.logging.v2.LogSink|LogSink} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listSinksAsync()`
+ *   We recommend using `listSinksStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -3161,7 +3161,7 @@ export class ConfigServiceV2Client {
  *   An object stream which emits an object representing {@link protos.google.logging.v2.LogExclusion|LogExclusion} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listExclusionsAsync()`
+ *   We recommend using `listExclusionsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/logging-esm/esm/src/v2/index.ts.baseline
+++ b/baselines/logging-esm/esm/src/v2/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/esm/src/v2/logging_service_v2_client.ts.baseline
+++ b/baselines/logging-esm/esm/src/v2/logging_service_v2_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -888,7 +888,7 @@ export class LoggingServiceV2Client {
  *   An object stream which emits an object representing {@link protos.google.logging.v2.LogEntry|LogEntry} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listLogEntriesAsync()`
+ *   We recommend using `listLogEntriesStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -1085,7 +1085,7 @@ export class LoggingServiceV2Client {
  *   An object stream which emits an object representing {@link protos.google.api.MonitoredResourceDescriptor|MonitoredResourceDescriptor} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listMonitoredResourceDescriptorsAsync()`
+ *   We recommend using `listMonitoredResourceDescriptorsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -1297,7 +1297,7 @@ export class LoggingServiceV2Client {
  *   An object stream which emits an object representing string on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listLogsAsync()`
+ *   We recommend using `listLogsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/logging-esm/esm/src/v2/metrics_service_v2_client.ts.baseline
+++ b/baselines/logging-esm/esm/src/v2/metrics_service_v2_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -853,7 +853,7 @@ export class MetricsServiceV2Client {
  *   An object stream which emits an object representing {@link protos.google.logging.v2.LogMetric|LogMetric} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listLogMetricsAsync()`
+ *   We recommend using `listLogMetricsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/logging-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
+++ b/baselines/logging-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/esm/system-test/fixtures/sample/src/index.js.baseline
+++ b/baselines/logging-esm/esm/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/logging-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,5 +1,5 @@
 /* eslint-disable node/no-missing-require, no-unused-vars, no-undef */
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/esm/system-test/install.ts.baseline
+++ b/baselines/logging-esm/esm/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/esm/test/gapic_config_service_v2_v2.ts.baseline
+++ b/baselines/logging-esm/esm/test/gapic_config_service_v2_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/esm/test/gapic_logging_service_v2_v2.ts.baseline
+++ b/baselines/logging-esm/esm/test/gapic_logging_service_v2_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/esm/test/gapic_metrics_service_v2_v2.ts.baseline
+++ b/baselines/logging-esm/esm/test/gapic_metrics_service_v2_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/samples/generated/v2/config_service_v2.copy_log_entries.js.baseline
+++ b/baselines/logging-esm/samples/generated/v2/config_service_v2.copy_log_entries.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/samples/generated/v2/config_service_v2.create_bucket.js.baseline
+++ b/baselines/logging-esm/samples/generated/v2/config_service_v2.create_bucket.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/samples/generated/v2/config_service_v2.create_exclusion.js.baseline
+++ b/baselines/logging-esm/samples/generated/v2/config_service_v2.create_exclusion.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/samples/generated/v2/config_service_v2.create_sink.js.baseline
+++ b/baselines/logging-esm/samples/generated/v2/config_service_v2.create_sink.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/samples/generated/v2/config_service_v2.create_view.js.baseline
+++ b/baselines/logging-esm/samples/generated/v2/config_service_v2.create_view.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/samples/generated/v2/config_service_v2.delete_bucket.js.baseline
+++ b/baselines/logging-esm/samples/generated/v2/config_service_v2.delete_bucket.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/samples/generated/v2/config_service_v2.delete_exclusion.js.baseline
+++ b/baselines/logging-esm/samples/generated/v2/config_service_v2.delete_exclusion.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/samples/generated/v2/config_service_v2.delete_sink.js.baseline
+++ b/baselines/logging-esm/samples/generated/v2/config_service_v2.delete_sink.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/samples/generated/v2/config_service_v2.delete_view.js.baseline
+++ b/baselines/logging-esm/samples/generated/v2/config_service_v2.delete_view.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/samples/generated/v2/config_service_v2.get_bucket.js.baseline
+++ b/baselines/logging-esm/samples/generated/v2/config_service_v2.get_bucket.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/samples/generated/v2/config_service_v2.get_cmek_settings.js.baseline
+++ b/baselines/logging-esm/samples/generated/v2/config_service_v2.get_cmek_settings.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/samples/generated/v2/config_service_v2.get_exclusion.js.baseline
+++ b/baselines/logging-esm/samples/generated/v2/config_service_v2.get_exclusion.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/samples/generated/v2/config_service_v2.get_settings.js.baseline
+++ b/baselines/logging-esm/samples/generated/v2/config_service_v2.get_settings.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/samples/generated/v2/config_service_v2.get_sink.js.baseline
+++ b/baselines/logging-esm/samples/generated/v2/config_service_v2.get_sink.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/samples/generated/v2/config_service_v2.get_view.js.baseline
+++ b/baselines/logging-esm/samples/generated/v2/config_service_v2.get_view.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/samples/generated/v2/config_service_v2.list_buckets.js.baseline
+++ b/baselines/logging-esm/samples/generated/v2/config_service_v2.list_buckets.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/samples/generated/v2/config_service_v2.list_exclusions.js.baseline
+++ b/baselines/logging-esm/samples/generated/v2/config_service_v2.list_exclusions.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/samples/generated/v2/config_service_v2.list_sinks.js.baseline
+++ b/baselines/logging-esm/samples/generated/v2/config_service_v2.list_sinks.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/samples/generated/v2/config_service_v2.list_views.js.baseline
+++ b/baselines/logging-esm/samples/generated/v2/config_service_v2.list_views.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/samples/generated/v2/config_service_v2.undelete_bucket.js.baseline
+++ b/baselines/logging-esm/samples/generated/v2/config_service_v2.undelete_bucket.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/samples/generated/v2/config_service_v2.update_bucket.js.baseline
+++ b/baselines/logging-esm/samples/generated/v2/config_service_v2.update_bucket.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/samples/generated/v2/config_service_v2.update_cmek_settings.js.baseline
+++ b/baselines/logging-esm/samples/generated/v2/config_service_v2.update_cmek_settings.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/samples/generated/v2/config_service_v2.update_exclusion.js.baseline
+++ b/baselines/logging-esm/samples/generated/v2/config_service_v2.update_exclusion.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/samples/generated/v2/config_service_v2.update_settings.js.baseline
+++ b/baselines/logging-esm/samples/generated/v2/config_service_v2.update_settings.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/samples/generated/v2/config_service_v2.update_sink.js.baseline
+++ b/baselines/logging-esm/samples/generated/v2/config_service_v2.update_sink.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/samples/generated/v2/config_service_v2.update_view.js.baseline
+++ b/baselines/logging-esm/samples/generated/v2/config_service_v2.update_view.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/samples/generated/v2/logging_service_v2.delete_log.js.baseline
+++ b/baselines/logging-esm/samples/generated/v2/logging_service_v2.delete_log.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/samples/generated/v2/logging_service_v2.list_log_entries.js.baseline
+++ b/baselines/logging-esm/samples/generated/v2/logging_service_v2.list_log_entries.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/samples/generated/v2/logging_service_v2.list_logs.js.baseline
+++ b/baselines/logging-esm/samples/generated/v2/logging_service_v2.list_logs.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/samples/generated/v2/logging_service_v2.list_monitored_resource_descriptors.js.baseline
+++ b/baselines/logging-esm/samples/generated/v2/logging_service_v2.list_monitored_resource_descriptors.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/samples/generated/v2/logging_service_v2.tail_log_entries.js.baseline
+++ b/baselines/logging-esm/samples/generated/v2/logging_service_v2.tail_log_entries.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/samples/generated/v2/logging_service_v2.write_log_entries.js.baseline
+++ b/baselines/logging-esm/samples/generated/v2/logging_service_v2.write_log_entries.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/samples/generated/v2/metrics_service_v2.create_log_metric.js.baseline
+++ b/baselines/logging-esm/samples/generated/v2/metrics_service_v2.create_log_metric.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/samples/generated/v2/metrics_service_v2.delete_log_metric.js.baseline
+++ b/baselines/logging-esm/samples/generated/v2/metrics_service_v2.delete_log_metric.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/samples/generated/v2/metrics_service_v2.get_log_metric.js.baseline
+++ b/baselines/logging-esm/samples/generated/v2/metrics_service_v2.get_log_metric.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/samples/generated/v2/metrics_service_v2.list_log_metrics.js.baseline
+++ b/baselines/logging-esm/samples/generated/v2/metrics_service_v2.list_log_metrics.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging-esm/samples/generated/v2/metrics_service_v2.update_log_metric.js.baseline
+++ b/baselines/logging-esm/samples/generated/v2/metrics_service_v2.update_log_metric.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/.jsdoc.js.baseline
+++ b/baselines/logging/.jsdoc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2024 Google LLC',
+    copyright: 'Copyright 2025 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'logging',

--- a/baselines/logging/.mocharc.js.baseline
+++ b/baselines/logging/.mocharc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/.prettierrc.js.baseline
+++ b/baselines/logging/.prettierrc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/samples/generated/v2/config_service_v2.copy_log_entries.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.copy_log_entries.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/samples/generated/v2/config_service_v2.create_bucket.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.create_bucket.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/samples/generated/v2/config_service_v2.create_exclusion.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.create_exclusion.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/samples/generated/v2/config_service_v2.create_sink.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.create_sink.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/samples/generated/v2/config_service_v2.create_view.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.create_view.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/samples/generated/v2/config_service_v2.delete_bucket.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.delete_bucket.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/samples/generated/v2/config_service_v2.delete_exclusion.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.delete_exclusion.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/samples/generated/v2/config_service_v2.delete_sink.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.delete_sink.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/samples/generated/v2/config_service_v2.delete_view.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.delete_view.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/samples/generated/v2/config_service_v2.get_bucket.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.get_bucket.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/samples/generated/v2/config_service_v2.get_cmek_settings.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.get_cmek_settings.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/samples/generated/v2/config_service_v2.get_exclusion.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.get_exclusion.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/samples/generated/v2/config_service_v2.get_settings.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.get_settings.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/samples/generated/v2/config_service_v2.get_sink.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.get_sink.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/samples/generated/v2/config_service_v2.get_view.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.get_view.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/samples/generated/v2/config_service_v2.list_buckets.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.list_buckets.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/samples/generated/v2/config_service_v2.list_exclusions.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.list_exclusions.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/samples/generated/v2/config_service_v2.list_sinks.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.list_sinks.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/samples/generated/v2/config_service_v2.list_views.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.list_views.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/samples/generated/v2/config_service_v2.undelete_bucket.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.undelete_bucket.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/samples/generated/v2/config_service_v2.update_bucket.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.update_bucket.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/samples/generated/v2/config_service_v2.update_cmek_settings.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.update_cmek_settings.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/samples/generated/v2/config_service_v2.update_exclusion.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.update_exclusion.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/samples/generated/v2/config_service_v2.update_settings.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.update_settings.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/samples/generated/v2/config_service_v2.update_sink.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.update_sink.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/samples/generated/v2/config_service_v2.update_view.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.update_view.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/samples/generated/v2/logging_service_v2.delete_log.js.baseline
+++ b/baselines/logging/samples/generated/v2/logging_service_v2.delete_log.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/samples/generated/v2/logging_service_v2.list_log_entries.js.baseline
+++ b/baselines/logging/samples/generated/v2/logging_service_v2.list_log_entries.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/samples/generated/v2/logging_service_v2.list_logs.js.baseline
+++ b/baselines/logging/samples/generated/v2/logging_service_v2.list_logs.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/samples/generated/v2/logging_service_v2.list_monitored_resource_descriptors.js.baseline
+++ b/baselines/logging/samples/generated/v2/logging_service_v2.list_monitored_resource_descriptors.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/samples/generated/v2/logging_service_v2.tail_log_entries.js.baseline
+++ b/baselines/logging/samples/generated/v2/logging_service_v2.tail_log_entries.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/samples/generated/v2/logging_service_v2.write_log_entries.js.baseline
+++ b/baselines/logging/samples/generated/v2/logging_service_v2.write_log_entries.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/samples/generated/v2/metrics_service_v2.create_log_metric.js.baseline
+++ b/baselines/logging/samples/generated/v2/metrics_service_v2.create_log_metric.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/samples/generated/v2/metrics_service_v2.delete_log_metric.js.baseline
+++ b/baselines/logging/samples/generated/v2/metrics_service_v2.delete_log_metric.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/samples/generated/v2/metrics_service_v2.get_log_metric.js.baseline
+++ b/baselines/logging/samples/generated/v2/metrics_service_v2.get_log_metric.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/samples/generated/v2/metrics_service_v2.list_log_metrics.js.baseline
+++ b/baselines/logging/samples/generated/v2/metrics_service_v2.list_log_metrics.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/samples/generated/v2/metrics_service_v2.update_log_metric.js.baseline
+++ b/baselines/logging/samples/generated/v2/metrics_service_v2.update_log_metric.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/src/index.ts.baseline
+++ b/baselines/logging/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/src/v2/config_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/config_service_v2_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -2541,7 +2541,7 @@ export class ConfigServiceV2Client {
  *   An object stream which emits an object representing {@link protos.google.logging.v2.LogBucket|LogBucket} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listBucketsAsync()`
+ *   We recommend using `listBucketsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -2741,7 +2741,7 @@ export class ConfigServiceV2Client {
  *   An object stream which emits an object representing {@link protos.google.logging.v2.LogView|LogView} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listViewsAsync()`
+ *   We recommend using `listViewsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -2939,7 +2939,7 @@ export class ConfigServiceV2Client {
  *   An object stream which emits an object representing {@link protos.google.logging.v2.LogSink|LogSink} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listSinksAsync()`
+ *   We recommend using `listSinksStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -3139,7 +3139,7 @@ export class ConfigServiceV2Client {
  *   An object stream which emits an object representing {@link protos.google.logging.v2.LogExclusion|LogExclusion} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listExclusionsAsync()`
+ *   We recommend using `listExclusionsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/logging/src/v2/index.ts.baseline
+++ b/baselines/logging/src/v2/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -866,7 +866,7 @@ export class LoggingServiceV2Client {
  *   An object stream which emits an object representing {@link protos.google.logging.v2.LogEntry|LogEntry} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listLogEntriesAsync()`
+ *   We recommend using `listLogEntriesStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -1063,7 +1063,7 @@ export class LoggingServiceV2Client {
  *   An object stream which emits an object representing {@link protos.google.api.MonitoredResourceDescriptor|MonitoredResourceDescriptor} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listMonitoredResourceDescriptorsAsync()`
+ *   We recommend using `listMonitoredResourceDescriptorsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -1275,7 +1275,7 @@ export class LoggingServiceV2Client {
  *   An object stream which emits an object representing string on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listLogsAsync()`
+ *   We recommend using `listLogsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/logging/src/v2/metrics_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/metrics_service_v2_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -831,7 +831,7 @@ export class MetricsServiceV2Client {
  *   An object stream which emits an object representing {@link protos.google.logging.v2.LogMetric|LogMetric} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listLogMetricsAsync()`
+ *   We recommend using `listLogMetricsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/logging/system-test/fixtures/sample/src/index.js.baseline
+++ b/baselines/logging/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/logging/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/system-test/install.ts.baseline
+++ b/baselines/logging/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/test/gapic_config_service_v2_v2.ts.baseline
+++ b/baselines/logging/test/gapic_config_service_v2_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/test/gapic_logging_service_v2_v2.ts.baseline
+++ b/baselines/logging/test/gapic_logging_service_v2_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/logging/test/gapic_metrics_service_v2_v2.ts.baseline
+++ b/baselines/logging/test/gapic_metrics_service_v2_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/.jsdoc.cjs.baseline
+++ b/baselines/monitoring-esm/.jsdoc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2024 Google LLC',
+    copyright: 'Copyright 2025 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'monitoring',

--- a/baselines/monitoring-esm/.mocharc.cjs.baseline
+++ b/baselines/monitoring-esm/.mocharc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/.prettierrc.cjs.baseline
+++ b/baselines/monitoring-esm/.prettierrc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/esm/src/index.ts.baseline
+++ b/baselines/monitoring-esm/esm/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/esm/src/v3/alert_policy_service_client.ts.baseline
+++ b/baselines/monitoring-esm/esm/src/v3/alert_policy_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -899,7 +899,7 @@ export class AlertPolicyServiceClient {
  *   An object stream which emits an object representing {@link protos.google.monitoring.v3.AlertPolicy|AlertPolicy} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listAlertPoliciesAsync()`
+ *   We recommend using `listAlertPoliciesStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/monitoring-esm/esm/src/v3/group_service_client.ts.baseline
+++ b/baselines/monitoring-esm/esm/src/v3/group_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -865,7 +865,7 @@ export class GroupServiceClient {
  *   An object stream which emits an object representing {@link protos.google.monitoring.v3.Group|Group} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listGroupsAsync()`
+ *   We recommend using `listGroupsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -1085,7 +1085,7 @@ export class GroupServiceClient {
  *   An object stream which emits an object representing {@link protos.google.api.MonitoredResource|MonitoredResource} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listGroupMembersAsync()`
+ *   We recommend using `listGroupMembersStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/monitoring-esm/esm/src/v3/index.ts.baseline
+++ b/baselines/monitoring-esm/esm/src/v3/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/esm/src/v3/metric_service_client.ts.baseline
+++ b/baselines/monitoring-esm/esm/src/v3/metric_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -944,7 +944,7 @@ export class MetricServiceClient {
  *   An object stream which emits an object representing {@link protos.google.api.MonitoredResourceDescriptor|MonitoredResourceDescriptor} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listMonitoredResourceDescriptorsAsync()`
+ *   We recommend using `listMonitoredResourceDescriptorsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -1149,7 +1149,7 @@ export class MetricServiceClient {
  *   An object stream which emits an object representing {@link protos.google.api.MetricDescriptor|MetricDescriptor} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listMetricDescriptorsAsync()`
+ *   We recommend using `listMetricDescriptorsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -1391,7 +1391,7 @@ export class MetricServiceClient {
  *   An object stream which emits an object representing {@link protos.google.monitoring.v3.TimeSeries|TimeSeries} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listTimeSeriesAsync()`
+ *   We recommend using `listTimeSeriesStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/monitoring-esm/esm/src/v3/notification_channel_service_client.ts.baseline
+++ b/baselines/monitoring-esm/esm/src/v3/notification_channel_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1180,7 +1180,7 @@ export class NotificationChannelServiceClient {
  *   An object stream which emits an object representing {@link protos.google.monitoring.v3.NotificationChannelDescriptor|NotificationChannelDescriptor} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listNotificationChannelDescriptorsAsync()`
+ *   We recommend using `listNotificationChannelDescriptorsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -1408,7 +1408,7 @@ export class NotificationChannelServiceClient {
  *   An object stream which emits an object representing {@link protos.google.monitoring.v3.NotificationChannel|NotificationChannel} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listNotificationChannelsAsync()`
+ *   We recommend using `listNotificationChannelsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/monitoring-esm/esm/src/v3/service_monitoring_service_client.ts.baseline
+++ b/baselines/monitoring-esm/esm/src/v3/service_monitoring_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1157,7 +1157,7 @@ export class ServiceMonitoringServiceClient {
  *   An object stream which emits an object representing {@link protos.google.monitoring.v3.Service|Service} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listServicesAsync()`
+ *   We recommend using `listServicesStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -1369,7 +1369,7 @@ export class ServiceMonitoringServiceClient {
  *   An object stream which emits an object representing {@link protos.google.monitoring.v3.ServiceLevelObjective|ServiceLevelObjective} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listServiceLevelObjectivesAsync()`
+ *   We recommend using `listServiceLevelObjectivesStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/monitoring-esm/esm/src/v3/uptime_check_service_client.ts.baseline
+++ b/baselines/monitoring-esm/esm/src/v3/uptime_check_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -847,7 +847,7 @@ export class UptimeCheckServiceClient {
  *   An object stream which emits an object representing {@link protos.google.monitoring.v3.UptimeCheckConfig|UptimeCheckConfig} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listUptimeCheckConfigsAsync()`
+ *   We recommend using `listUptimeCheckConfigsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -1028,7 +1028,7 @@ export class UptimeCheckServiceClient {
  *   An object stream which emits an object representing {@link protos.google.monitoring.v3.UptimeCheckIp|UptimeCheckIp} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listUptimeCheckIpsAsync()`
+ *   We recommend using `listUptimeCheckIpsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/monitoring-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
+++ b/baselines/monitoring-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/esm/system-test/fixtures/sample/src/index.js.baseline
+++ b/baselines/monitoring-esm/esm/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/monitoring-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,5 +1,5 @@
 /* eslint-disable node/no-missing-require, no-unused-vars, no-undef */
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/esm/system-test/install.ts.baseline
+++ b/baselines/monitoring-esm/esm/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/esm/test/gapic_alert_policy_service_v3.ts.baseline
+++ b/baselines/monitoring-esm/esm/test/gapic_alert_policy_service_v3.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/esm/test/gapic_group_service_v3.ts.baseline
+++ b/baselines/monitoring-esm/esm/test/gapic_group_service_v3.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/esm/test/gapic_metric_service_v3.ts.baseline
+++ b/baselines/monitoring-esm/esm/test/gapic_metric_service_v3.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/esm/test/gapic_notification_channel_service_v3.ts.baseline
+++ b/baselines/monitoring-esm/esm/test/gapic_notification_channel_service_v3.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/esm/test/gapic_service_monitoring_service_v3.ts.baseline
+++ b/baselines/monitoring-esm/esm/test/gapic_service_monitoring_service_v3.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/esm/test/gapic_uptime_check_service_v3.ts.baseline
+++ b/baselines/monitoring-esm/esm/test/gapic_uptime_check_service_v3.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/alert_policy_service.create_alert_policy.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/alert_policy_service.create_alert_policy.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/alert_policy_service.delete_alert_policy.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/alert_policy_service.delete_alert_policy.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/alert_policy_service.get_alert_policy.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/alert_policy_service.get_alert_policy.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/alert_policy_service.list_alert_policies.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/alert_policy_service.list_alert_policies.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/alert_policy_service.update_alert_policy.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/alert_policy_service.update_alert_policy.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/group_service.create_group.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/group_service.create_group.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/group_service.delete_group.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/group_service.delete_group.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/group_service.get_group.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/group_service.get_group.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/group_service.list_group_members.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/group_service.list_group_members.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/group_service.list_groups.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/group_service.list_groups.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/group_service.update_group.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/group_service.update_group.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/metric_service.create_metric_descriptor.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/metric_service.create_metric_descriptor.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/metric_service.create_time_series.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/metric_service.create_time_series.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/metric_service.delete_metric_descriptor.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/metric_service.delete_metric_descriptor.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/metric_service.get_metric_descriptor.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/metric_service.get_metric_descriptor.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/metric_service.get_monitored_resource_descriptor.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/metric_service.get_monitored_resource_descriptor.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/metric_service.list_metric_descriptors.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/metric_service.list_metric_descriptors.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/metric_service.list_monitored_resource_descriptors.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/metric_service.list_monitored_resource_descriptors.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/metric_service.list_time_series.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/metric_service.list_time_series.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/notification_channel_service.create_notification_channel.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/notification_channel_service.create_notification_channel.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/notification_channel_service.delete_notification_channel.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/notification_channel_service.delete_notification_channel.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/notification_channel_service.get_notification_channel.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/notification_channel_service.get_notification_channel.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/notification_channel_service.get_notification_channel_descriptor.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/notification_channel_service.get_notification_channel_descriptor.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/notification_channel_service.get_notification_channel_verification_code.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/notification_channel_service.get_notification_channel_verification_code.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/notification_channel_service.list_notification_channel_descriptors.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/notification_channel_service.list_notification_channel_descriptors.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/notification_channel_service.list_notification_channels.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/notification_channel_service.list_notification_channels.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/notification_channel_service.send_notification_channel_verification_code.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/notification_channel_service.send_notification_channel_verification_code.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/notification_channel_service.update_notification_channel.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/notification_channel_service.update_notification_channel.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/notification_channel_service.verify_notification_channel.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/notification_channel_service.verify_notification_channel.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/service_monitoring_service.create_service.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/service_monitoring_service.create_service.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/service_monitoring_service.create_service_level_objective.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/service_monitoring_service.create_service_level_objective.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/service_monitoring_service.delete_service.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/service_monitoring_service.delete_service.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/service_monitoring_service.delete_service_level_objective.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/service_monitoring_service.delete_service_level_objective.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/service_monitoring_service.get_service.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/service_monitoring_service.get_service.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/service_monitoring_service.get_service_level_objective.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/service_monitoring_service.get_service_level_objective.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/service_monitoring_service.list_service_level_objectives.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/service_monitoring_service.list_service_level_objectives.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/service_monitoring_service.list_services.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/service_monitoring_service.list_services.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/service_monitoring_service.update_service.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/service_monitoring_service.update_service.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/service_monitoring_service.update_service_level_objective.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/service_monitoring_service.update_service_level_objective.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/uptime_check_service.create_uptime_check_config.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/uptime_check_service.create_uptime_check_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/uptime_check_service.delete_uptime_check_config.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/uptime_check_service.delete_uptime_check_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/uptime_check_service.get_uptime_check_config.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/uptime_check_service.get_uptime_check_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/uptime_check_service.list_uptime_check_configs.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/uptime_check_service.list_uptime_check_configs.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/uptime_check_service.list_uptime_check_ips.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/uptime_check_service.list_uptime_check_ips.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring-esm/samples/generated/v3/uptime_check_service.update_uptime_check_config.js.baseline
+++ b/baselines/monitoring-esm/samples/generated/v3/uptime_check_service.update_uptime_check_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/.jsdoc.js.baseline
+++ b/baselines/monitoring/.jsdoc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2024 Google LLC',
+    copyright: 'Copyright 2025 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'monitoring',

--- a/baselines/monitoring/.mocharc.js.baseline
+++ b/baselines/monitoring/.mocharc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/.prettierrc.js.baseline
+++ b/baselines/monitoring/.prettierrc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/alert_policy_service.create_alert_policy.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/alert_policy_service.create_alert_policy.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/alert_policy_service.delete_alert_policy.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/alert_policy_service.delete_alert_policy.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/alert_policy_service.get_alert_policy.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/alert_policy_service.get_alert_policy.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/alert_policy_service.list_alert_policies.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/alert_policy_service.list_alert_policies.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/alert_policy_service.update_alert_policy.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/alert_policy_service.update_alert_policy.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/group_service.create_group.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/group_service.create_group.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/group_service.delete_group.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/group_service.delete_group.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/group_service.get_group.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/group_service.get_group.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/group_service.list_group_members.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/group_service.list_group_members.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/group_service.list_groups.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/group_service.list_groups.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/group_service.update_group.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/group_service.update_group.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/metric_service.create_metric_descriptor.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/metric_service.create_metric_descriptor.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/metric_service.create_time_series.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/metric_service.create_time_series.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/metric_service.delete_metric_descriptor.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/metric_service.delete_metric_descriptor.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/metric_service.get_metric_descriptor.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/metric_service.get_metric_descriptor.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/metric_service.get_monitored_resource_descriptor.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/metric_service.get_monitored_resource_descriptor.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/metric_service.list_metric_descriptors.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/metric_service.list_metric_descriptors.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/metric_service.list_monitored_resource_descriptors.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/metric_service.list_monitored_resource_descriptors.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/metric_service.list_time_series.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/metric_service.list_time_series.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/notification_channel_service.create_notification_channel.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/notification_channel_service.create_notification_channel.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/notification_channel_service.delete_notification_channel.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/notification_channel_service.delete_notification_channel.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/notification_channel_service.get_notification_channel.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/notification_channel_service.get_notification_channel.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/notification_channel_service.get_notification_channel_descriptor.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/notification_channel_service.get_notification_channel_descriptor.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/notification_channel_service.get_notification_channel_verification_code.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/notification_channel_service.get_notification_channel_verification_code.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/notification_channel_service.list_notification_channel_descriptors.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/notification_channel_service.list_notification_channel_descriptors.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/notification_channel_service.list_notification_channels.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/notification_channel_service.list_notification_channels.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/notification_channel_service.send_notification_channel_verification_code.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/notification_channel_service.send_notification_channel_verification_code.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/notification_channel_service.update_notification_channel.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/notification_channel_service.update_notification_channel.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/notification_channel_service.verify_notification_channel.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/notification_channel_service.verify_notification_channel.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/service_monitoring_service.create_service.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/service_monitoring_service.create_service.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/service_monitoring_service.create_service_level_objective.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/service_monitoring_service.create_service_level_objective.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/service_monitoring_service.delete_service.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/service_monitoring_service.delete_service.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/service_monitoring_service.delete_service_level_objective.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/service_monitoring_service.delete_service_level_objective.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/service_monitoring_service.get_service.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/service_monitoring_service.get_service.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/service_monitoring_service.get_service_level_objective.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/service_monitoring_service.get_service_level_objective.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/service_monitoring_service.list_service_level_objectives.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/service_monitoring_service.list_service_level_objectives.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/service_monitoring_service.list_services.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/service_monitoring_service.list_services.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/service_monitoring_service.update_service.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/service_monitoring_service.update_service.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/service_monitoring_service.update_service_level_objective.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/service_monitoring_service.update_service_level_objective.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/uptime_check_service.create_uptime_check_config.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/uptime_check_service.create_uptime_check_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/uptime_check_service.delete_uptime_check_config.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/uptime_check_service.delete_uptime_check_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/uptime_check_service.get_uptime_check_config.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/uptime_check_service.get_uptime_check_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/uptime_check_service.list_uptime_check_configs.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/uptime_check_service.list_uptime_check_configs.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/uptime_check_service.list_uptime_check_ips.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/uptime_check_service.list_uptime_check_ips.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/samples/generated/v3/uptime_check_service.update_uptime_check_config.js.baseline
+++ b/baselines/monitoring/samples/generated/v3/uptime_check_service.update_uptime_check_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/src/index.ts.baseline
+++ b/baselines/monitoring/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/src/v3/alert_policy_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/alert_policy_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -877,7 +877,7 @@ export class AlertPolicyServiceClient {
  *   An object stream which emits an object representing {@link protos.google.monitoring.v3.AlertPolicy|AlertPolicy} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listAlertPoliciesAsync()`
+ *   We recommend using `listAlertPoliciesStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/monitoring/src/v3/group_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/group_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -843,7 +843,7 @@ export class GroupServiceClient {
  *   An object stream which emits an object representing {@link protos.google.monitoring.v3.Group|Group} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listGroupsAsync()`
+ *   We recommend using `listGroupsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -1063,7 +1063,7 @@ export class GroupServiceClient {
  *   An object stream which emits an object representing {@link protos.google.api.MonitoredResource|MonitoredResource} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listGroupMembersAsync()`
+ *   We recommend using `listGroupMembersStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/monitoring/src/v3/index.ts.baseline
+++ b/baselines/monitoring/src/v3/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/src/v3/metric_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/metric_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -922,7 +922,7 @@ export class MetricServiceClient {
  *   An object stream which emits an object representing {@link protos.google.api.MonitoredResourceDescriptor|MonitoredResourceDescriptor} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listMonitoredResourceDescriptorsAsync()`
+ *   We recommend using `listMonitoredResourceDescriptorsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -1127,7 +1127,7 @@ export class MetricServiceClient {
  *   An object stream which emits an object representing {@link protos.google.api.MetricDescriptor|MetricDescriptor} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listMetricDescriptorsAsync()`
+ *   We recommend using `listMetricDescriptorsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -1369,7 +1369,7 @@ export class MetricServiceClient {
  *   An object stream which emits an object representing {@link protos.google.monitoring.v3.TimeSeries|TimeSeries} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listTimeSeriesAsync()`
+ *   We recommend using `listTimeSeriesStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/monitoring/src/v3/notification_channel_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/notification_channel_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1158,7 +1158,7 @@ export class NotificationChannelServiceClient {
  *   An object stream which emits an object representing {@link protos.google.monitoring.v3.NotificationChannelDescriptor|NotificationChannelDescriptor} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listNotificationChannelDescriptorsAsync()`
+ *   We recommend using `listNotificationChannelDescriptorsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -1386,7 +1386,7 @@ export class NotificationChannelServiceClient {
  *   An object stream which emits an object representing {@link protos.google.monitoring.v3.NotificationChannel|NotificationChannel} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listNotificationChannelsAsync()`
+ *   We recommend using `listNotificationChannelsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/monitoring/src/v3/service_monitoring_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/service_monitoring_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1135,7 +1135,7 @@ export class ServiceMonitoringServiceClient {
  *   An object stream which emits an object representing {@link protos.google.monitoring.v3.Service|Service} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listServicesAsync()`
+ *   We recommend using `listServicesStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -1347,7 +1347,7 @@ export class ServiceMonitoringServiceClient {
  *   An object stream which emits an object representing {@link protos.google.monitoring.v3.ServiceLevelObjective|ServiceLevelObjective} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listServiceLevelObjectivesAsync()`
+ *   We recommend using `listServiceLevelObjectivesStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/monitoring/src/v3/uptime_check_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/uptime_check_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -825,7 +825,7 @@ export class UptimeCheckServiceClient {
  *   An object stream which emits an object representing {@link protos.google.monitoring.v3.UptimeCheckConfig|UptimeCheckConfig} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listUptimeCheckConfigsAsync()`
+ *   We recommend using `listUptimeCheckConfigsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -1006,7 +1006,7 @@ export class UptimeCheckServiceClient {
  *   An object stream which emits an object representing {@link protos.google.monitoring.v3.UptimeCheckIp|UptimeCheckIp} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listUptimeCheckIpsAsync()`
+ *   We recommend using `listUptimeCheckIpsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/monitoring/system-test/fixtures/sample/src/index.js.baseline
+++ b/baselines/monitoring/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/monitoring/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/system-test/install.ts.baseline
+++ b/baselines/monitoring/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/test/gapic_alert_policy_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_alert_policy_service_v3.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/test/gapic_group_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_group_service_v3.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/test/gapic_metric_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_metric_service_v3.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/test/gapic_notification_channel_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_notification_channel_service_v3.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/test/gapic_service_monitoring_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_service_monitoring_service_v3.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/monitoring/test/gapic_uptime_check_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_uptime_check_service_v3.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming-esm/.jsdoc.cjs.baseline
+++ b/baselines/naming-esm/.jsdoc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2024 Google LLC',
+    copyright: 'Copyright 2025 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'naming',

--- a/baselines/naming-esm/.mocharc.cjs.baseline
+++ b/baselines/naming-esm/.mocharc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming-esm/.prettierrc.cjs.baseline
+++ b/baselines/naming-esm/.prettierrc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming-esm/esm/src/index.ts.baseline
+++ b/baselines/naming-esm/esm/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming-esm/esm/src/v1beta1/index.ts.baseline
+++ b/baselines/naming-esm/esm/src/v1beta1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming-esm/esm/src/v1beta1/naming_client.ts.baseline
+++ b/baselines/naming-esm/esm/src/v1beta1/naming_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1233,7 +1233,7 @@ export class NamingClient {
  *   An object stream which emits an object representing {@link protos.google.protobuf.Empty|Empty} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `paginatedMethodAsync1()`
+ *   We recommend using `paginatedMethodStream1()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/naming-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
+++ b/baselines/naming-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming-esm/esm/system-test/fixtures/sample/src/index.js.baseline
+++ b/baselines/naming-esm/esm/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/naming-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,5 +1,5 @@
 /* eslint-disable node/no-missing-require, no-unused-vars, no-undef */
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming-esm/esm/system-test/install.ts.baseline
+++ b/baselines/naming-esm/esm/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming-esm/esm/test/gapic_naming_v1beta1.ts.baseline
+++ b/baselines/naming-esm/esm/test/gapic_naming_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming-esm/samples/generated/v1beta1/naming.api_endpoint.js.baseline
+++ b/baselines/naming-esm/samples/generated/v1beta1/naming.api_endpoint.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming-esm/samples/generated/v1beta1/naming.check_long_running_progress.js.baseline
+++ b/baselines/naming-esm/samples/generated/v1beta1/naming.check_long_running_progress.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming-esm/samples/generated/v1beta1/naming.create_a_b_c_d_e_something.js.baseline
+++ b/baselines/naming-esm/samples/generated/v1beta1/naming.create_a_b_c_d_e_something.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming-esm/samples/generated/v1beta1/naming.get_project_id.js.baseline
+++ b/baselines/naming-esm/samples/generated/v1beta1/naming.get_project_id.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming-esm/samples/generated/v1beta1/naming.get_reserved_word.js.baseline
+++ b/baselines/naming-esm/samples/generated/v1beta1/naming.get_reserved_word.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming-esm/samples/generated/v1beta1/naming.initialize.js.baseline
+++ b/baselines/naming-esm/samples/generated/v1beta1/naming.initialize.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming-esm/samples/generated/v1beta1/naming.long_running.js.baseline
+++ b/baselines/naming-esm/samples/generated/v1beta1/naming.long_running.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming-esm/samples/generated/v1beta1/naming.paginated_method.js.baseline
+++ b/baselines/naming-esm/samples/generated/v1beta1/naming.paginated_method.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming-esm/samples/generated/v1beta1/naming.paginated_method_async.js.baseline
+++ b/baselines/naming-esm/samples/generated/v1beta1/naming.paginated_method_async.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming-esm/samples/generated/v1beta1/naming.paginated_method_stream.js.baseline
+++ b/baselines/naming-esm/samples/generated/v1beta1/naming.paginated_method_stream.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming-esm/samples/generated/v1beta1/naming.port.js.baseline
+++ b/baselines/naming-esm/samples/generated/v1beta1/naming.port.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming-esm/samples/generated/v1beta1/naming.scopes.js.baseline
+++ b/baselines/naming-esm/samples/generated/v1beta1/naming.scopes.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming-esm/samples/generated/v1beta1/naming.service_path.js.baseline
+++ b/baselines/naming-esm/samples/generated/v1beta1/naming.service_path.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming/.jsdoc.js.baseline
+++ b/baselines/naming/.jsdoc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2024 Google LLC',
+    copyright: 'Copyright 2025 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'naming',

--- a/baselines/naming/.mocharc.js.baseline
+++ b/baselines/naming/.mocharc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming/.prettierrc.js.baseline
+++ b/baselines/naming/.prettierrc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming/samples/generated/v1beta1/naming.api_endpoint.js.baseline
+++ b/baselines/naming/samples/generated/v1beta1/naming.api_endpoint.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming/samples/generated/v1beta1/naming.check_long_running_progress.js.baseline
+++ b/baselines/naming/samples/generated/v1beta1/naming.check_long_running_progress.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming/samples/generated/v1beta1/naming.create_a_b_c_d_e_something.js.baseline
+++ b/baselines/naming/samples/generated/v1beta1/naming.create_a_b_c_d_e_something.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming/samples/generated/v1beta1/naming.get_project_id.js.baseline
+++ b/baselines/naming/samples/generated/v1beta1/naming.get_project_id.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming/samples/generated/v1beta1/naming.get_reserved_word.js.baseline
+++ b/baselines/naming/samples/generated/v1beta1/naming.get_reserved_word.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming/samples/generated/v1beta1/naming.initialize.js.baseline
+++ b/baselines/naming/samples/generated/v1beta1/naming.initialize.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming/samples/generated/v1beta1/naming.long_running.js.baseline
+++ b/baselines/naming/samples/generated/v1beta1/naming.long_running.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming/samples/generated/v1beta1/naming.paginated_method.js.baseline
+++ b/baselines/naming/samples/generated/v1beta1/naming.paginated_method.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming/samples/generated/v1beta1/naming.paginated_method_async.js.baseline
+++ b/baselines/naming/samples/generated/v1beta1/naming.paginated_method_async.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming/samples/generated/v1beta1/naming.paginated_method_stream.js.baseline
+++ b/baselines/naming/samples/generated/v1beta1/naming.paginated_method_stream.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming/samples/generated/v1beta1/naming.port.js.baseline
+++ b/baselines/naming/samples/generated/v1beta1/naming.port.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming/samples/generated/v1beta1/naming.scopes.js.baseline
+++ b/baselines/naming/samples/generated/v1beta1/naming.scopes.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming/samples/generated/v1beta1/naming.service_path.js.baseline
+++ b/baselines/naming/samples/generated/v1beta1/naming.service_path.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming/src/index.ts.baseline
+++ b/baselines/naming/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming/src/v1beta1/index.ts.baseline
+++ b/baselines/naming/src/v1beta1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming/src/v1beta1/naming_client.ts.baseline
+++ b/baselines/naming/src/v1beta1/naming_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1211,7 +1211,7 @@ export class NamingClient {
  *   An object stream which emits an object representing {@link protos.google.protobuf.Empty|Empty} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `paginatedMethodAsync1()`
+ *   We recommend using `paginatedMethodStream1()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/naming/system-test/fixtures/sample/src/index.js.baseline
+++ b/baselines/naming/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/naming/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming/system-test/install.ts.baseline
+++ b/baselines/naming/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/naming/test/gapic_naming_v1beta1.ts.baseline
+++ b/baselines/naming/test/gapic_naming_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/redis-esm/.jsdoc.cjs.baseline
+++ b/baselines/redis-esm/.jsdoc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2024 Google LLC',
+    copyright: 'Copyright 2025 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'redis',

--- a/baselines/redis-esm/.mocharc.cjs.baseline
+++ b/baselines/redis-esm/.mocharc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/redis-esm/.prettierrc.cjs.baseline
+++ b/baselines/redis-esm/.prettierrc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/redis-esm/esm/src/index.ts.baseline
+++ b/baselines/redis-esm/esm/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/redis-esm/esm/src/v1beta1/cloud_redis_client.ts.baseline
+++ b/baselines/redis-esm/esm/src/v1beta1/cloud_redis_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1231,7 +1231,7 @@ export class CloudRedisClient {
  *   An object stream which emits an object representing {@link protos.google.cloud.redis.v1beta1.Instance|Instance} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listInstancesAsync()`
+ *   We recommend using `listInstancesStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/redis-esm/esm/src/v1beta1/index.ts.baseline
+++ b/baselines/redis-esm/esm/src/v1beta1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/redis-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
+++ b/baselines/redis-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/redis-esm/esm/system-test/fixtures/sample/src/index.js.baseline
+++ b/baselines/redis-esm/esm/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/redis-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/redis-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,5 +1,5 @@
 /* eslint-disable node/no-missing-require, no-unused-vars, no-undef */
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/redis-esm/esm/system-test/install.ts.baseline
+++ b/baselines/redis-esm/esm/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/redis-esm/esm/test/gapic_cloud_redis_v1beta1.ts.baseline
+++ b/baselines/redis-esm/esm/test/gapic_cloud_redis_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/redis-esm/samples/generated/v1beta1/cloud_redis.create_instance.js.baseline
+++ b/baselines/redis-esm/samples/generated/v1beta1/cloud_redis.create_instance.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/redis-esm/samples/generated/v1beta1/cloud_redis.delete_instance.js.baseline
+++ b/baselines/redis-esm/samples/generated/v1beta1/cloud_redis.delete_instance.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/redis-esm/samples/generated/v1beta1/cloud_redis.export_instance.js.baseline
+++ b/baselines/redis-esm/samples/generated/v1beta1/cloud_redis.export_instance.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/redis-esm/samples/generated/v1beta1/cloud_redis.failover_instance.js.baseline
+++ b/baselines/redis-esm/samples/generated/v1beta1/cloud_redis.failover_instance.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/redis-esm/samples/generated/v1beta1/cloud_redis.get_instance.js.baseline
+++ b/baselines/redis-esm/samples/generated/v1beta1/cloud_redis.get_instance.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/redis-esm/samples/generated/v1beta1/cloud_redis.import_instance.js.baseline
+++ b/baselines/redis-esm/samples/generated/v1beta1/cloud_redis.import_instance.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/redis-esm/samples/generated/v1beta1/cloud_redis.list_instances.js.baseline
+++ b/baselines/redis-esm/samples/generated/v1beta1/cloud_redis.list_instances.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/redis-esm/samples/generated/v1beta1/cloud_redis.update_instance.js.baseline
+++ b/baselines/redis-esm/samples/generated/v1beta1/cloud_redis.update_instance.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/redis/.jsdoc.js.baseline
+++ b/baselines/redis/.jsdoc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2024 Google LLC',
+    copyright: 'Copyright 2025 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'redis',

--- a/baselines/redis/.mocharc.js.baseline
+++ b/baselines/redis/.mocharc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/redis/.prettierrc.js.baseline
+++ b/baselines/redis/.prettierrc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/redis/samples/generated/v1beta1/cloud_redis.create_instance.js.baseline
+++ b/baselines/redis/samples/generated/v1beta1/cloud_redis.create_instance.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/redis/samples/generated/v1beta1/cloud_redis.delete_instance.js.baseline
+++ b/baselines/redis/samples/generated/v1beta1/cloud_redis.delete_instance.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/redis/samples/generated/v1beta1/cloud_redis.export_instance.js.baseline
+++ b/baselines/redis/samples/generated/v1beta1/cloud_redis.export_instance.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/redis/samples/generated/v1beta1/cloud_redis.failover_instance.js.baseline
+++ b/baselines/redis/samples/generated/v1beta1/cloud_redis.failover_instance.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/redis/samples/generated/v1beta1/cloud_redis.get_instance.js.baseline
+++ b/baselines/redis/samples/generated/v1beta1/cloud_redis.get_instance.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/redis/samples/generated/v1beta1/cloud_redis.import_instance.js.baseline
+++ b/baselines/redis/samples/generated/v1beta1/cloud_redis.import_instance.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/redis/samples/generated/v1beta1/cloud_redis.list_instances.js.baseline
+++ b/baselines/redis/samples/generated/v1beta1/cloud_redis.list_instances.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/redis/samples/generated/v1beta1/cloud_redis.update_instance.js.baseline
+++ b/baselines/redis/samples/generated/v1beta1/cloud_redis.update_instance.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/redis/src/index.ts.baseline
+++ b/baselines/redis/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/redis/src/v1beta1/cloud_redis_client.ts.baseline
+++ b/baselines/redis/src/v1beta1/cloud_redis_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1209,7 +1209,7 @@ export class CloudRedisClient {
  *   An object stream which emits an object representing {@link protos.google.cloud.redis.v1beta1.Instance|Instance} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listInstancesAsync()`
+ *   We recommend using `listInstancesStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/redis/src/v1beta1/index.ts.baseline
+++ b/baselines/redis/src/v1beta1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/redis/system-test/fixtures/sample/src/index.js.baseline
+++ b/baselines/redis/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/redis/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/redis/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/redis/system-test/install.ts.baseline
+++ b/baselines/redis/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/redis/test/gapic_cloud_redis_v1beta1.ts.baseline
+++ b/baselines/redis/test/gapic_cloud_redis_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/routingtest-esm/.jsdoc.cjs.baseline
+++ b/baselines/routingtest-esm/.jsdoc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2024 Google LLC',
+    copyright: 'Copyright 2025 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'routingtest',

--- a/baselines/routingtest-esm/.mocharc.cjs.baseline
+++ b/baselines/routingtest-esm/.mocharc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/routingtest-esm/.prettierrc.cjs.baseline
+++ b/baselines/routingtest-esm/.prettierrc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/routingtest-esm/esm/src/index.ts.baseline
+++ b/baselines/routingtest-esm/esm/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/routingtest-esm/esm/src/v1/index.ts.baseline
+++ b/baselines/routingtest-esm/esm/src/v1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/routingtest-esm/esm/src/v1/test_service_client.ts.baseline
+++ b/baselines/routingtest-esm/esm/src/v1/test_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/routingtest-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
+++ b/baselines/routingtest-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/routingtest-esm/esm/system-test/fixtures/sample/src/index.js.baseline
+++ b/baselines/routingtest-esm/esm/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/routingtest-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/routingtest-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,5 +1,5 @@
 /* eslint-disable node/no-missing-require, no-unused-vars, no-undef */
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/routingtest-esm/esm/system-test/install.ts.baseline
+++ b/baselines/routingtest-esm/esm/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/routingtest-esm/esm/test/gapic_test_service_v1.ts.baseline
+++ b/baselines/routingtest-esm/esm/test/gapic_test_service_v1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/routingtest-esm/samples/generated/v1/test_service.fast_fibonacci.js.baseline
+++ b/baselines/routingtest-esm/samples/generated/v1/test_service.fast_fibonacci.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/routingtest-esm/samples/generated/v1/test_service.random_fibonacci.js.baseline
+++ b/baselines/routingtest-esm/samples/generated/v1/test_service.random_fibonacci.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/routingtest-esm/samples/generated/v1/test_service.slow_fibonacci.js.baseline
+++ b/baselines/routingtest-esm/samples/generated/v1/test_service.slow_fibonacci.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/routingtest/.jsdoc.js.baseline
+++ b/baselines/routingtest/.jsdoc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2024 Google LLC',
+    copyright: 'Copyright 2025 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'routingtest',

--- a/baselines/routingtest/.mocharc.js.baseline
+++ b/baselines/routingtest/.mocharc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/routingtest/.prettierrc.js.baseline
+++ b/baselines/routingtest/.prettierrc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/routingtest/samples/generated/v1/test_service.fast_fibonacci.js.baseline
+++ b/baselines/routingtest/samples/generated/v1/test_service.fast_fibonacci.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/routingtest/samples/generated/v1/test_service.random_fibonacci.js.baseline
+++ b/baselines/routingtest/samples/generated/v1/test_service.random_fibonacci.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/routingtest/samples/generated/v1/test_service.slow_fibonacci.js.baseline
+++ b/baselines/routingtest/samples/generated/v1/test_service.slow_fibonacci.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/routingtest/src/index.ts.baseline
+++ b/baselines/routingtest/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/routingtest/src/v1/index.ts.baseline
+++ b/baselines/routingtest/src/v1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/routingtest/src/v1/test_service_client.ts.baseline
+++ b/baselines/routingtest/src/v1/test_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/routingtest/system-test/fixtures/sample/src/index.js.baseline
+++ b/baselines/routingtest/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/routingtest/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/routingtest/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/routingtest/system-test/install.ts.baseline
+++ b/baselines/routingtest/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/routingtest/test/gapic_test_service_v1.ts.baseline
+++ b/baselines/routingtest/test/gapic_test_service_v1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-esm/.jsdoc.cjs.baseline
+++ b/baselines/showcase-esm/.jsdoc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2024 Google LLC',
+    copyright: 'Copyright 2025 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'showcase',

--- a/baselines/showcase-esm/.mocharc.cjs.baseline
+++ b/baselines/showcase-esm/.mocharc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-esm/.prettierrc.cjs.baseline
+++ b/baselines/showcase-esm/.prettierrc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-esm/esm/src/index.ts.baseline
+++ b/baselines/showcase-esm/esm/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-esm/esm/src/v1beta1/compliance_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/compliance_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-esm/esm/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/echo_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1105,7 +1105,7 @@ export class EchoClient {
  *   An object stream which emits an object representing {@link protos.google.showcase.v1beta1.EchoResponse|EchoResponse} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `pagedExpandAsync()`
+ *   We recommend using `pagedExpandStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/showcase-esm/esm/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/identity_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -755,7 +755,7 @@ export class IdentityClient {
  *   An object stream which emits an object representing {@link protos.google.showcase.v1beta1.User|User} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listUsersAsync()`
+ *   We recommend using `listUsersStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/showcase-esm/esm/src/v1beta1/index.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-esm/esm/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/messaging_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1303,7 +1303,7 @@ export class MessagingClient {
  *   An object stream which emits an object representing {@link protos.google.showcase.v1beta1.Room|Room} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listRoomsAsync()`
+ *   We recommend using `listRoomsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -1473,7 +1473,7 @@ export class MessagingClient {
  *   An object stream which emits an object representing {@link protos.google.showcase.v1beta1.Blurb|Blurb} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listBlurbsAsync()`
+ *   We recommend using `listBlurbsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/showcase-esm/esm/src/v1beta1/sequence_service_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/sequence_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-esm/esm/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/testing_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -905,7 +905,7 @@ export class TestingClient {
  *   An object stream which emits an object representing {@link protos.google.showcase.v1beta1.Session|Session} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listSessionsAsync()`
+ *   We recommend using `listSessionsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -1063,7 +1063,7 @@ export class TestingClient {
  *   An object stream which emits an object representing {@link protos.google.showcase.v1beta1.Test|Test} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listTestsAsync()`
+ *   We recommend using `listTestsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/showcase-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
+++ b/baselines/showcase-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-esm/esm/system-test/fixtures/sample/src/index.js.baseline
+++ b/baselines/showcase-esm/esm/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/showcase-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,5 +1,5 @@
 /* eslint-disable node/no-missing-require, no-unused-vars, no-undef */
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-esm/esm/system-test/install.ts.baseline
+++ b/baselines/showcase-esm/esm/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-esm/esm/test/gapic_compliance_v1beta1.ts.baseline
+++ b/baselines/showcase-esm/esm/test/gapic_compliance_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-esm/esm/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase-esm/esm/test/gapic_echo_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-esm/esm/test/gapic_identity_v1beta1.ts.baseline
+++ b/baselines/showcase-esm/esm/test/gapic_identity_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-esm/esm/test/gapic_messaging_v1beta1.ts.baseline
+++ b/baselines/showcase-esm/esm/test/gapic_messaging_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-esm/esm/test/gapic_sequence_service_v1beta1.ts.baseline
+++ b/baselines/showcase-esm/esm/test/gapic_sequence_service_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-esm/esm/test/gapic_testing_v1beta1.ts.baseline
+++ b/baselines/showcase-esm/esm/test/gapic_testing_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-legacy-esm/.jsdoc.cjs.baseline
+++ b/baselines/showcase-legacy-esm/.jsdoc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2024 Google LLC',
+    copyright: 'Copyright 2025 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'showcase',

--- a/baselines/showcase-legacy-esm/.mocharc.cjs.baseline
+++ b/baselines/showcase-legacy-esm/.mocharc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-legacy-esm/.prettierrc.cjs.baseline
+++ b/baselines/showcase-legacy-esm/.prettierrc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-legacy-esm/esm/src/index.ts.baseline
+++ b/baselines/showcase-legacy-esm/esm/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-legacy-esm/esm/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase-legacy-esm/esm/src/v1beta1/echo_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1030,7 +1030,7 @@ export class EchoClient {
  *   An object stream which emits an object representing {@link protos.google.showcase.v1beta1.EchoResponse|EchoResponse} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `pagedExpandAsync()`
+ *   We recommend using `pagedExpandStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/showcase-legacy-esm/esm/src/v1beta1/index.ts.baseline
+++ b/baselines/showcase-legacy-esm/esm/src/v1beta1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-legacy-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
+++ b/baselines/showcase-legacy-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-legacy-esm/esm/system-test/fixtures/sample/src/index.js.baseline
+++ b/baselines/showcase-legacy-esm/esm/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-legacy-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/showcase-legacy-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,5 +1,5 @@
 /* eslint-disable node/no-missing-require, no-unused-vars, no-undef */
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-legacy-esm/esm/system-test/install.ts.baseline
+++ b/baselines/showcase-legacy-esm/esm/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-legacy-esm/esm/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase-legacy-esm/esm/test/gapic_echo_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-legacy-esm/samples/generated/v1beta1/echo.block.js.baseline
+++ b/baselines/showcase-legacy-esm/samples/generated/v1beta1/echo.block.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-legacy-esm/samples/generated/v1beta1/echo.chat.js.baseline
+++ b/baselines/showcase-legacy-esm/samples/generated/v1beta1/echo.chat.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-legacy-esm/samples/generated/v1beta1/echo.collect.js.baseline
+++ b/baselines/showcase-legacy-esm/samples/generated/v1beta1/echo.collect.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-legacy-esm/samples/generated/v1beta1/echo.echo.js.baseline
+++ b/baselines/showcase-legacy-esm/samples/generated/v1beta1/echo.echo.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-legacy-esm/samples/generated/v1beta1/echo.echo_error_details.js.baseline
+++ b/baselines/showcase-legacy-esm/samples/generated/v1beta1/echo.echo_error_details.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-legacy-esm/samples/generated/v1beta1/echo.expand.js.baseline
+++ b/baselines/showcase-legacy-esm/samples/generated/v1beta1/echo.expand.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-legacy-esm/samples/generated/v1beta1/echo.paged_expand.js.baseline
+++ b/baselines/showcase-legacy-esm/samples/generated/v1beta1/echo.paged_expand.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-legacy-esm/samples/generated/v1beta1/echo.paged_expand_legacy.js.baseline
+++ b/baselines/showcase-legacy-esm/samples/generated/v1beta1/echo.paged_expand_legacy.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-legacy-esm/samples/generated/v1beta1/echo.paged_expand_legacy_mapped.js.baseline
+++ b/baselines/showcase-legacy-esm/samples/generated/v1beta1/echo.paged_expand_legacy_mapped.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-legacy-esm/samples/generated/v1beta1/echo.wait.js.baseline
+++ b/baselines/showcase-legacy-esm/samples/generated/v1beta1/echo.wait.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-legacy/.jsdoc.js.baseline
+++ b/baselines/showcase-legacy/.jsdoc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2024 Google LLC',
+    copyright: 'Copyright 2025 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'showcase',

--- a/baselines/showcase-legacy/.mocharc.js.baseline
+++ b/baselines/showcase-legacy/.mocharc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-legacy/.prettierrc.js.baseline
+++ b/baselines/showcase-legacy/.prettierrc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-legacy/samples/generated/v1beta1/echo.block.js.baseline
+++ b/baselines/showcase-legacy/samples/generated/v1beta1/echo.block.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-legacy/samples/generated/v1beta1/echo.chat.js.baseline
+++ b/baselines/showcase-legacy/samples/generated/v1beta1/echo.chat.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-legacy/samples/generated/v1beta1/echo.collect.js.baseline
+++ b/baselines/showcase-legacy/samples/generated/v1beta1/echo.collect.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-legacy/samples/generated/v1beta1/echo.echo.js.baseline
+++ b/baselines/showcase-legacy/samples/generated/v1beta1/echo.echo.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-legacy/samples/generated/v1beta1/echo.echo_error_details.js.baseline
+++ b/baselines/showcase-legacy/samples/generated/v1beta1/echo.echo_error_details.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-legacy/samples/generated/v1beta1/echo.expand.js.baseline
+++ b/baselines/showcase-legacy/samples/generated/v1beta1/echo.expand.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-legacy/samples/generated/v1beta1/echo.paged_expand.js.baseline
+++ b/baselines/showcase-legacy/samples/generated/v1beta1/echo.paged_expand.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-legacy/samples/generated/v1beta1/echo.paged_expand_legacy.js.baseline
+++ b/baselines/showcase-legacy/samples/generated/v1beta1/echo.paged_expand_legacy.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-legacy/samples/generated/v1beta1/echo.paged_expand_legacy_mapped.js.baseline
+++ b/baselines/showcase-legacy/samples/generated/v1beta1/echo.paged_expand_legacy_mapped.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-legacy/samples/generated/v1beta1/echo.wait.js.baseline
+++ b/baselines/showcase-legacy/samples/generated/v1beta1/echo.wait.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-legacy/src/index.ts.baseline
+++ b/baselines/showcase-legacy/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1013,7 +1013,7 @@ export class EchoClient {
  *   An object stream which emits an object representing {@link protos.google.showcase.v1beta1.EchoResponse|EchoResponse} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `pagedExpandAsync()`
+ *   We recommend using `pagedExpandStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/showcase-legacy/src/v1beta1/index.ts.baseline
+++ b/baselines/showcase-legacy/src/v1beta1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-legacy/system-test/fixtures/sample/src/index.js.baseline
+++ b/baselines/showcase-legacy/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-legacy/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/showcase-legacy/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-legacy/system-test/install.ts.baseline
+++ b/baselines/showcase-legacy/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase-legacy/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase-legacy/test/gapic_echo_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase/.jsdoc.js.baseline
+++ b/baselines/showcase/.jsdoc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2024 Google LLC',
+    copyright: 'Copyright 2025 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'showcase',

--- a/baselines/showcase/.mocharc.js.baseline
+++ b/baselines/showcase/.mocharc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase/.prettierrc.js.baseline
+++ b/baselines/showcase/.prettierrc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase/src/index.ts.baseline
+++ b/baselines/showcase/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase/src/v1beta1/compliance_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/compliance_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/echo_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1083,7 +1083,7 @@ export class EchoClient {
  *   An object stream which emits an object representing {@link protos.google.showcase.v1beta1.EchoResponse|EchoResponse} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `pagedExpandAsync()`
+ *   We recommend using `pagedExpandStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/showcase/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/identity_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -733,7 +733,7 @@ export class IdentityClient {
  *   An object stream which emits an object representing {@link protos.google.showcase.v1beta1.User|User} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listUsersAsync()`
+ *   We recommend using `listUsersStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/showcase/src/v1beta1/index.ts.baseline
+++ b/baselines/showcase/src/v1beta1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1281,7 +1281,7 @@ export class MessagingClient {
  *   An object stream which emits an object representing {@link protos.google.showcase.v1beta1.Room|Room} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listRoomsAsync()`
+ *   We recommend using `listRoomsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -1451,7 +1451,7 @@ export class MessagingClient {
  *   An object stream which emits an object representing {@link protos.google.showcase.v1beta1.Blurb|Blurb} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listBlurbsAsync()`
+ *   We recommend using `listBlurbsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/showcase/src/v1beta1/sequence_service_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/sequence_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/testing_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -883,7 +883,7 @@ export class TestingClient {
  *   An object stream which emits an object representing {@link protos.google.showcase.v1beta1.Session|Session} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listSessionsAsync()`
+ *   We recommend using `listSessionsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -1041,7 +1041,7 @@ export class TestingClient {
  *   An object stream which emits an object representing {@link protos.google.showcase.v1beta1.Test|Test} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listTestsAsync()`
+ *   We recommend using `listTestsStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/showcase/system-test/fixtures/sample/src/index.js.baseline
+++ b/baselines/showcase/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/showcase/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase/system-test/install.ts.baseline
+++ b/baselines/showcase/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase/test/gapic_compliance_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_compliance_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_echo_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase/test/gapic_identity_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_identity_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase/test/gapic_messaging_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_messaging_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase/test/gapic_sequence_service_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_sequence_service_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/showcase/test/gapic_testing_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_testing_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks-esm/.jsdoc.cjs.baseline
+++ b/baselines/tasks-esm/.jsdoc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2024 Google LLC',
+    copyright: 'Copyright 2025 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'tasks',

--- a/baselines/tasks-esm/.mocharc.cjs.baseline
+++ b/baselines/tasks-esm/.mocharc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks-esm/.prettierrc.cjs.baseline
+++ b/baselines/tasks-esm/.prettierrc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks-esm/esm/src/index.ts.baseline
+++ b/baselines/tasks-esm/esm/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks-esm/esm/src/v2/cloud_tasks_client.ts.baseline
+++ b/baselines/tasks-esm/esm/src/v2/cloud_tasks_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1723,7 +1723,7 @@ export class CloudTasksClient {
  *   An object stream which emits an object representing {@link protos.google.cloud.tasks.v2.Queue|Queue} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listQueuesAsync()`
+ *   We recommend using `listQueuesStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -1985,7 +1985,7 @@ export class CloudTasksClient {
  *   An object stream which emits an object representing {@link protos.google.cloud.tasks.v2.Task|Task} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listTasksAsync()`
+ *   We recommend using `listTasksStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/tasks-esm/esm/src/v2/index.ts.baseline
+++ b/baselines/tasks-esm/esm/src/v2/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
+++ b/baselines/tasks-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks-esm/esm/system-test/fixtures/sample/src/index.js.baseline
+++ b/baselines/tasks-esm/esm/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/tasks-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,5 +1,5 @@
 /* eslint-disable node/no-missing-require, no-unused-vars, no-undef */
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks-esm/esm/system-test/install.ts.baseline
+++ b/baselines/tasks-esm/esm/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks-esm/esm/test/gapic_cloud_tasks_v2.ts.baseline
+++ b/baselines/tasks-esm/esm/test/gapic_cloud_tasks_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks-esm/samples/generated/v2/cloud_tasks.create_queue.js.baseline
+++ b/baselines/tasks-esm/samples/generated/v2/cloud_tasks.create_queue.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks-esm/samples/generated/v2/cloud_tasks.create_task.js.baseline
+++ b/baselines/tasks-esm/samples/generated/v2/cloud_tasks.create_task.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks-esm/samples/generated/v2/cloud_tasks.delete_queue.js.baseline
+++ b/baselines/tasks-esm/samples/generated/v2/cloud_tasks.delete_queue.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks-esm/samples/generated/v2/cloud_tasks.delete_task.js.baseline
+++ b/baselines/tasks-esm/samples/generated/v2/cloud_tasks.delete_task.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks-esm/samples/generated/v2/cloud_tasks.get_iam_policy.js.baseline
+++ b/baselines/tasks-esm/samples/generated/v2/cloud_tasks.get_iam_policy.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks-esm/samples/generated/v2/cloud_tasks.get_queue.js.baseline
+++ b/baselines/tasks-esm/samples/generated/v2/cloud_tasks.get_queue.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks-esm/samples/generated/v2/cloud_tasks.get_task.js.baseline
+++ b/baselines/tasks-esm/samples/generated/v2/cloud_tasks.get_task.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks-esm/samples/generated/v2/cloud_tasks.list_queues.js.baseline
+++ b/baselines/tasks-esm/samples/generated/v2/cloud_tasks.list_queues.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks-esm/samples/generated/v2/cloud_tasks.list_tasks.js.baseline
+++ b/baselines/tasks-esm/samples/generated/v2/cloud_tasks.list_tasks.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks-esm/samples/generated/v2/cloud_tasks.pause_queue.js.baseline
+++ b/baselines/tasks-esm/samples/generated/v2/cloud_tasks.pause_queue.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks-esm/samples/generated/v2/cloud_tasks.purge_queue.js.baseline
+++ b/baselines/tasks-esm/samples/generated/v2/cloud_tasks.purge_queue.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks-esm/samples/generated/v2/cloud_tasks.resume_queue.js.baseline
+++ b/baselines/tasks-esm/samples/generated/v2/cloud_tasks.resume_queue.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks-esm/samples/generated/v2/cloud_tasks.run_task.js.baseline
+++ b/baselines/tasks-esm/samples/generated/v2/cloud_tasks.run_task.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks-esm/samples/generated/v2/cloud_tasks.set_iam_policy.js.baseline
+++ b/baselines/tasks-esm/samples/generated/v2/cloud_tasks.set_iam_policy.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks-esm/samples/generated/v2/cloud_tasks.test_iam_permissions.js.baseline
+++ b/baselines/tasks-esm/samples/generated/v2/cloud_tasks.test_iam_permissions.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks-esm/samples/generated/v2/cloud_tasks.update_queue.js.baseline
+++ b/baselines/tasks-esm/samples/generated/v2/cloud_tasks.update_queue.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks/.jsdoc.js.baseline
+++ b/baselines/tasks/.jsdoc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2024 Google LLC',
+    copyright: 'Copyright 2025 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'tasks',

--- a/baselines/tasks/.mocharc.js.baseline
+++ b/baselines/tasks/.mocharc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks/.prettierrc.js.baseline
+++ b/baselines/tasks/.prettierrc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks/samples/generated/v2/cloud_tasks.create_queue.js.baseline
+++ b/baselines/tasks/samples/generated/v2/cloud_tasks.create_queue.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks/samples/generated/v2/cloud_tasks.create_task.js.baseline
+++ b/baselines/tasks/samples/generated/v2/cloud_tasks.create_task.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks/samples/generated/v2/cloud_tasks.delete_queue.js.baseline
+++ b/baselines/tasks/samples/generated/v2/cloud_tasks.delete_queue.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks/samples/generated/v2/cloud_tasks.delete_task.js.baseline
+++ b/baselines/tasks/samples/generated/v2/cloud_tasks.delete_task.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks/samples/generated/v2/cloud_tasks.get_iam_policy.js.baseline
+++ b/baselines/tasks/samples/generated/v2/cloud_tasks.get_iam_policy.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks/samples/generated/v2/cloud_tasks.get_queue.js.baseline
+++ b/baselines/tasks/samples/generated/v2/cloud_tasks.get_queue.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks/samples/generated/v2/cloud_tasks.get_task.js.baseline
+++ b/baselines/tasks/samples/generated/v2/cloud_tasks.get_task.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks/samples/generated/v2/cloud_tasks.list_queues.js.baseline
+++ b/baselines/tasks/samples/generated/v2/cloud_tasks.list_queues.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks/samples/generated/v2/cloud_tasks.list_tasks.js.baseline
+++ b/baselines/tasks/samples/generated/v2/cloud_tasks.list_tasks.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks/samples/generated/v2/cloud_tasks.pause_queue.js.baseline
+++ b/baselines/tasks/samples/generated/v2/cloud_tasks.pause_queue.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks/samples/generated/v2/cloud_tasks.purge_queue.js.baseline
+++ b/baselines/tasks/samples/generated/v2/cloud_tasks.purge_queue.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks/samples/generated/v2/cloud_tasks.resume_queue.js.baseline
+++ b/baselines/tasks/samples/generated/v2/cloud_tasks.resume_queue.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks/samples/generated/v2/cloud_tasks.run_task.js.baseline
+++ b/baselines/tasks/samples/generated/v2/cloud_tasks.run_task.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks/samples/generated/v2/cloud_tasks.set_iam_policy.js.baseline
+++ b/baselines/tasks/samples/generated/v2/cloud_tasks.set_iam_policy.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks/samples/generated/v2/cloud_tasks.test_iam_permissions.js.baseline
+++ b/baselines/tasks/samples/generated/v2/cloud_tasks.test_iam_permissions.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks/samples/generated/v2/cloud_tasks.update_queue.js.baseline
+++ b/baselines/tasks/samples/generated/v2/cloud_tasks.update_queue.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks/src/index.ts.baseline
+++ b/baselines/tasks/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks/src/v2/cloud_tasks_client.ts.baseline
+++ b/baselines/tasks/src/v2/cloud_tasks_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1701,7 +1701,7 @@ export class CloudTasksClient {
  *   An object stream which emits an object representing {@link protos.google.cloud.tasks.v2.Queue|Queue} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listQueuesAsync()`
+ *   We recommend using `listQueuesStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
@@ -1963,7 +1963,7 @@ export class CloudTasksClient {
  *   An object stream which emits an object representing {@link protos.google.cloud.tasks.v2.Task|Task} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listTasksAsync()`
+ *   We recommend using `listTasksStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/tasks/src/v2/index.ts.baseline
+++ b/baselines/tasks/src/v2/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks/system-test/fixtures/sample/src/index.js.baseline
+++ b/baselines/tasks/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/tasks/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks/system-test/install.ts.baseline
+++ b/baselines/tasks/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/tasks/test/gapic_cloud_tasks_v2.ts.baseline
+++ b/baselines/tasks/test/gapic_cloud_tasks_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/texttospeech-esm/.jsdoc.cjs.baseline
+++ b/baselines/texttospeech-esm/.jsdoc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2024 Google LLC',
+    copyright: 'Copyright 2025 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: '@google-cloud/text-to-speech',

--- a/baselines/texttospeech-esm/.mocharc.cjs.baseline
+++ b/baselines/texttospeech-esm/.mocharc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/texttospeech-esm/.prettierrc.cjs.baseline
+++ b/baselines/texttospeech-esm/.prettierrc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/texttospeech-esm/esm/src/index.ts.baseline
+++ b/baselines/texttospeech-esm/esm/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/texttospeech-esm/esm/src/v1/index.ts.baseline
+++ b/baselines/texttospeech-esm/esm/src/v1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/texttospeech-esm/esm/src/v1/text_to_speech_client.ts.baseline
+++ b/baselines/texttospeech-esm/esm/src/v1/text_to_speech_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/texttospeech-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
+++ b/baselines/texttospeech-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/texttospeech-esm/esm/system-test/fixtures/sample/src/index.js.baseline
+++ b/baselines/texttospeech-esm/esm/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/texttospeech-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/texttospeech-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,5 +1,5 @@
 /* eslint-disable node/no-missing-require, no-unused-vars, no-undef */
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/texttospeech-esm/esm/system-test/install.ts.baseline
+++ b/baselines/texttospeech-esm/esm/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/texttospeech-esm/esm/test/gapic_text_to_speech_v1.ts.baseline
+++ b/baselines/texttospeech-esm/esm/test/gapic_text_to_speech_v1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/texttospeech-esm/samples/generated/v1/text_to_speech.list_voices.js.baseline
+++ b/baselines/texttospeech-esm/samples/generated/v1/text_to_speech.list_voices.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/texttospeech-esm/samples/generated/v1/text_to_speech.synthesize_speech.js.baseline
+++ b/baselines/texttospeech-esm/samples/generated/v1/text_to_speech.synthesize_speech.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/texttospeech/.jsdoc.js.baseline
+++ b/baselines/texttospeech/.jsdoc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2024 Google LLC',
+    copyright: 'Copyright 2025 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: '@google-cloud/text-to-speech',

--- a/baselines/texttospeech/.mocharc.js.baseline
+++ b/baselines/texttospeech/.mocharc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/texttospeech/.prettierrc.js.baseline
+++ b/baselines/texttospeech/.prettierrc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/texttospeech/samples/generated/v1/text_to_speech.list_voices.js.baseline
+++ b/baselines/texttospeech/samples/generated/v1/text_to_speech.list_voices.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/texttospeech/samples/generated/v1/text_to_speech.synthesize_speech.js.baseline
+++ b/baselines/texttospeech/samples/generated/v1/text_to_speech.synthesize_speech.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/texttospeech/src/index.ts.baseline
+++ b/baselines/texttospeech/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/texttospeech/src/v1/index.ts.baseline
+++ b/baselines/texttospeech/src/v1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/texttospeech/src/v1/text_to_speech_client.ts.baseline
+++ b/baselines/texttospeech/src/v1/text_to_speech_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/texttospeech/system-test/fixtures/sample/src/index.js.baseline
+++ b/baselines/texttospeech/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/texttospeech/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/texttospeech/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/texttospeech/system-test/install.ts.baseline
+++ b/baselines/texttospeech/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/texttospeech/test/gapic_text_to_speech_v1.ts.baseline
+++ b/baselines/texttospeech/test/gapic_text_to_speech_v1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/translate-esm/.jsdoc.cjs.baseline
+++ b/baselines/translate-esm/.jsdoc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2024 Google LLC',
+    copyright: 'Copyright 2025 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'translation',

--- a/baselines/translate-esm/.mocharc.cjs.baseline
+++ b/baselines/translate-esm/.mocharc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/translate-esm/.prettierrc.cjs.baseline
+++ b/baselines/translate-esm/.prettierrc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/translate-esm/esm/src/index.ts.baseline
+++ b/baselines/translate-esm/esm/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/translate-esm/esm/src/v3beta1/index.ts.baseline
+++ b/baselines/translate-esm/esm/src/v3beta1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/translate-esm/esm/src/v3beta1/translation_service_client.ts.baseline
+++ b/baselines/translate-esm/esm/src/v3beta1/translation_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1247,7 +1247,7 @@ export class TranslationServiceClient {
  *   An object stream which emits an object representing {@link protos.google.cloud.translation.v3beta1.Glossary|Glossary} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listGlossariesAsync()`
+ *   We recommend using `listGlossariesStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/translate-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
+++ b/baselines/translate-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/translate-esm/esm/system-test/fixtures/sample/src/index.js.baseline
+++ b/baselines/translate-esm/esm/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/translate-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/translate-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,5 +1,5 @@
 /* eslint-disable node/no-missing-require, no-unused-vars, no-undef */
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/translate-esm/esm/system-test/install.ts.baseline
+++ b/baselines/translate-esm/esm/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/translate-esm/esm/test/gapic_translation_service_v3beta1.ts.baseline
+++ b/baselines/translate-esm/esm/test/gapic_translation_service_v3beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/translate-esm/samples/generated/v3beta1/translation_service.batch_translate_text.js.baseline
+++ b/baselines/translate-esm/samples/generated/v3beta1/translation_service.batch_translate_text.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/translate-esm/samples/generated/v3beta1/translation_service.create_glossary.js.baseline
+++ b/baselines/translate-esm/samples/generated/v3beta1/translation_service.create_glossary.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/translate-esm/samples/generated/v3beta1/translation_service.delete_glossary.js.baseline
+++ b/baselines/translate-esm/samples/generated/v3beta1/translation_service.delete_glossary.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/translate-esm/samples/generated/v3beta1/translation_service.detect_language.js.baseline
+++ b/baselines/translate-esm/samples/generated/v3beta1/translation_service.detect_language.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/translate-esm/samples/generated/v3beta1/translation_service.get_glossary.js.baseline
+++ b/baselines/translate-esm/samples/generated/v3beta1/translation_service.get_glossary.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/translate-esm/samples/generated/v3beta1/translation_service.get_supported_languages.js.baseline
+++ b/baselines/translate-esm/samples/generated/v3beta1/translation_service.get_supported_languages.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/translate-esm/samples/generated/v3beta1/translation_service.list_glossaries.js.baseline
+++ b/baselines/translate-esm/samples/generated/v3beta1/translation_service.list_glossaries.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/translate-esm/samples/generated/v3beta1/translation_service.translate_text.js.baseline
+++ b/baselines/translate-esm/samples/generated/v3beta1/translation_service.translate_text.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/translate/.jsdoc.js.baseline
+++ b/baselines/translate/.jsdoc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2024 Google LLC',
+    copyright: 'Copyright 2025 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'translation',

--- a/baselines/translate/.mocharc.js.baseline
+++ b/baselines/translate/.mocharc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/translate/.prettierrc.js.baseline
+++ b/baselines/translate/.prettierrc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/translate/samples/generated/v3beta1/translation_service.batch_translate_text.js.baseline
+++ b/baselines/translate/samples/generated/v3beta1/translation_service.batch_translate_text.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/translate/samples/generated/v3beta1/translation_service.create_glossary.js.baseline
+++ b/baselines/translate/samples/generated/v3beta1/translation_service.create_glossary.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/translate/samples/generated/v3beta1/translation_service.delete_glossary.js.baseline
+++ b/baselines/translate/samples/generated/v3beta1/translation_service.delete_glossary.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/translate/samples/generated/v3beta1/translation_service.detect_language.js.baseline
+++ b/baselines/translate/samples/generated/v3beta1/translation_service.detect_language.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/translate/samples/generated/v3beta1/translation_service.get_glossary.js.baseline
+++ b/baselines/translate/samples/generated/v3beta1/translation_service.get_glossary.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/translate/samples/generated/v3beta1/translation_service.get_supported_languages.js.baseline
+++ b/baselines/translate/samples/generated/v3beta1/translation_service.get_supported_languages.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/translate/samples/generated/v3beta1/translation_service.list_glossaries.js.baseline
+++ b/baselines/translate/samples/generated/v3beta1/translation_service.list_glossaries.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/translate/samples/generated/v3beta1/translation_service.translate_text.js.baseline
+++ b/baselines/translate/samples/generated/v3beta1/translation_service.translate_text.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/translate/src/index.ts.baseline
+++ b/baselines/translate/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/translate/src/v3beta1/index.ts.baseline
+++ b/baselines/translate/src/v3beta1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/translate/src/v3beta1/translation_service_client.ts.baseline
+++ b/baselines/translate/src/v3beta1/translation_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1225,7 +1225,7 @@ export class TranslationServiceClient {
  *   An object stream which emits an object representing {@link protos.google.cloud.translation.v3beta1.Glossary|Glossary} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
- *   We recommend using `listGlossariesAsync()`
+ *   We recommend using `listGlossariesStream()`
  *   method described below for async iteration which you can stop as needed.
  *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.

--- a/baselines/translate/system-test/fixtures/sample/src/index.js.baseline
+++ b/baselines/translate/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/translate/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/translate/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/translate/system-test/install.ts.baseline
+++ b/baselines/translate/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/translate/test/gapic_translation_service_v3beta1.ts.baseline
+++ b/baselines/translate/test/gapic_translation_service_v3beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/videointelligence-esm/.jsdoc.cjs.baseline
+++ b/baselines/videointelligence-esm/.jsdoc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2024 Google LLC',
+    copyright: 'Copyright 2025 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'videointelligence',

--- a/baselines/videointelligence-esm/.mocharc.cjs.baseline
+++ b/baselines/videointelligence-esm/.mocharc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/videointelligence-esm/.prettierrc.cjs.baseline
+++ b/baselines/videointelligence-esm/.prettierrc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/videointelligence-esm/esm/src/index.ts.baseline
+++ b/baselines/videointelligence-esm/esm/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/videointelligence-esm/esm/src/v1/index.ts.baseline
+++ b/baselines/videointelligence-esm/esm/src/v1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/videointelligence-esm/esm/src/v1/video_intelligence_service_client.ts.baseline
+++ b/baselines/videointelligence-esm/esm/src/v1/video_intelligence_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/videointelligence-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
+++ b/baselines/videointelligence-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/videointelligence-esm/esm/system-test/fixtures/sample/src/index.js.baseline
+++ b/baselines/videointelligence-esm/esm/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/videointelligence-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/videointelligence-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,5 +1,5 @@
 /* eslint-disable node/no-missing-require, no-unused-vars, no-undef */
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/videointelligence-esm/esm/system-test/install.ts.baseline
+++ b/baselines/videointelligence-esm/esm/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/videointelligence-esm/esm/test/gapic_video_intelligence_service_v1.ts.baseline
+++ b/baselines/videointelligence-esm/esm/test/gapic_video_intelligence_service_v1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/videointelligence-esm/samples/generated/v1/video_intelligence_service.annotate_video.js.baseline
+++ b/baselines/videointelligence-esm/samples/generated/v1/video_intelligence_service.annotate_video.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/videointelligence/.jsdoc.js.baseline
+++ b/baselines/videointelligence/.jsdoc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2024 Google LLC',
+    copyright: 'Copyright 2025 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'videointelligence',

--- a/baselines/videointelligence/.mocharc.js.baseline
+++ b/baselines/videointelligence/.mocharc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/videointelligence/.prettierrc.js.baseline
+++ b/baselines/videointelligence/.prettierrc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/videointelligence/samples/generated/v1/video_intelligence_service.annotate_video.js.baseline
+++ b/baselines/videointelligence/samples/generated/v1/video_intelligence_service.annotate_video.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/videointelligence/src/index.ts.baseline
+++ b/baselines/videointelligence/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/videointelligence/src/v1/index.ts.baseline
+++ b/baselines/videointelligence/src/v1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/videointelligence/src/v1/video_intelligence_service_client.ts.baseline
+++ b/baselines/videointelligence/src/v1/video_intelligence_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/videointelligence/system-test/fixtures/sample/src/index.js.baseline
+++ b/baselines/videointelligence/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/videointelligence/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/videointelligence/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/videointelligence/system-test/install.ts.baseline
+++ b/baselines/videointelligence/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/baselines/videointelligence/test/gapic_video_intelligence_service_v1.ts.baseline
+++ b/baselines/videointelligence/test/gapic_video_intelligence_service_v1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/templates/cjs/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/cjs/typescript_gapic/src/$version/$service_client.ts.njk
@@ -926,7 +926,7 @@ export class {{ service.name }}Client {
   }
 
 /**
-{{- util.printCommentsPageStream(method, id.get(method.name.toCamelCase() + "Async")) }}
+{{- util.printCommentsPageStream(method, id.get(method.name.toCamelCase() + "Stream")) }}
  {%- if method.options and method.options.deprecated %}
  * @deprecated {{method.name}} is deprecated and may be removed in a future version.
  {%- endif %}

--- a/templates/esm/typescript_gapic/esm/src/$version/$service_client.ts.njk
+++ b/templates/esm/typescript_gapic/esm/src/$version/$service_client.ts.njk
@@ -933,7 +933,7 @@ export class {{ service.name }}Client {
   }
 
 /**
-{{- util.printCommentsPageStream(method, id.get(method.name.toCamelCase() + "Async")) }}
+{{- util.printCommentsPageStream(method, id.get(method.name.toCamelCase() + "Stream")) }}
  {%- if method.options and method.options.deprecated %}
  * @deprecated {{method.name}} is deprecated and may be removed in a future version.
  {%- endif %}


### PR DESCRIPTION
I think this was just a copy paste error that has persisted in the templates for awhile! 
In case it has trouble loading because of the baselines, this is it
![image](https://github.com/user-attachments/assets/53055ccf-a5a9-4b1c-8a36-c0b73f89823f)
