### PR TITLE
fix: update ts_rules, js_rules, and typescript version

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -15,3 +15,10 @@ build:linux --sandbox_tmpfs_path=/tmp
 
 build --cxxopt=-std=c++17
 build --host_cxxopt=-std=c++17
+
+common --@aspect_rules_ts//ts:skipLibCheck=honor_tsconfig
+
+    # Between Bazel 6.0 and 6.3, you need all of this, to avoid discarding the analysis cache:
+    build --@aspect_rules_ts//ts:skipLibCheck=honor_tsconfig
+    fetch --@aspect_rules_ts//ts:skipLibCheck=honor_tsconfig
+    query --@aspect_rules_ts//ts:skipLibCheck=honor_tsconfig

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,7 +52,7 @@ jobs:
         curl -sSL https://github.com/googleapis/gapic-config-validator/releases/download/v0.6.0/gapic-config-validator-0.6.0-linux-amd64.tar.gz > config-validator.tar.gz
         tar xzf config-validator.tar.gz --no-same-owner
         chmod +x gapic-error-conformance
-        chmod +x bazel-bin/protoc_plugin_/ptotoc_plugin
+        chmod +x bazel-bin/protoc_plugin_/protoc_plugin
         ./gapic-error-conformance -plugin="bazel-bin/protoc_plugin_/protoc_plugin"
 
     - name: Prepare baseline artifacts

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ~/.cache/bazel
-        key: ${{ runner.os }}-googleapis-20250414-${{ secrets.CACHE_VERSION }}
+        key: ${{ runner.os }}-googleapis-20250422-${{ secrets.CACHE_VERSION }}
 
     - name: Cache not found
       if: steps.cache-bazel.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,8 +52,8 @@ jobs:
         curl -sSL https://github.com/googleapis/gapic-config-validator/releases/download/v0.6.0/gapic-config-validator-0.6.0-linux-amd64.tar.gz > config-validator.tar.gz
         tar xzf config-validator.tar.gz --no-same-owner
         chmod +x gapic-error-conformance
-        chmod +x bazel-bin/protoc_plugin_
-        ./gapic-error-conformance -plugin="bazel-bin/protoc_plugin.sh"
+        chmod +x bazel-bin/protoc_plugin_/ptotoc_plugin
+        ./gapic-error-conformance -plugin="bazel-bin/protoc_plugin_/protoc_plugin"
 
     - name: Prepare baseline artifacts
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,7 +52,7 @@ jobs:
         curl -sSL https://github.com/googleapis/gapic-config-validator/releases/download/v0.6.0/gapic-config-validator-0.6.0-linux-amd64.tar.gz > config-validator.tar.gz
         tar xzf config-validator.tar.gz --no-same-owner
         chmod +x gapic-error-conformance
-        chmod +x bazel-bin/protoc_plugin.sh
+        chmod +x bazel-bin/protoc_plugin_
         ./gapic-error-conformance -plugin="bazel-bin/protoc_plugin.sh"
 
     - name: Prepare baseline artifacts

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -82,7 +82,8 @@ ts_project(
         "--target",
         "esnext",
     ],
-    supports_workers = False,
+    supports_workers = 0,
+    transpiler = "tsc"
 )
 
 js_library(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,31 +16,34 @@ load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_
 rules_proto_dependencies()
 rules_proto_toolchains()
 
-load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
-rules_js_dependencies()
-
 load("@aspect_rules_ts//ts:repositories.bzl", "rules_ts_dependencies")
 rules_ts_dependencies(
     ts_version_from = "//:package.json",
 )
 
-load("@rules_nodejs//nodejs:repositories.bzl", "nodejs_register_toolchains")
-nodejs_register_toolchains(
-    name = "nodejs",
-    node_version = NODE_VERSION,
-)
+load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
+rules_js_dependencies()
 
-load("@aspect_rules_js//npm:npm_import.bzl", "npm_translate_lock", "pnpm_repository")
+load("@aspect_rules_js//js:toolchains.bzl", "DEFAULT_NODE_VERSION", "rules_js_register_toolchains")
+
+rules_js_register_toolchains(node_version = DEFAULT_NODE_VERSION)
+
+load("@aspect_rules_js//npm:repositories.bzl", "npm_translate_lock", "pnpm_repository")
+
+
 npm_translate_lock(
     name = "npm",
     pnpm_lock = "//:pnpm-lock.yaml",
     update_pnpm_lock = True,
     data = ["//:package.json"],
 )
+pnpm_repository(name = "pnpm")
+load("@npm//:repositories.bzl", "npm_repositories")
+npm_repositories()
+
+
+
 # To regenerate the lock file, run:
 # bazel run -- @pnpm//:pnpm --dir $PWD install --lockfile-only
 # More information: https://github.com/aspect-build/rules_js/blob/main/docs/faq.md#can-i-use-bazel-managed-pnpm
 
-load("@npm//:repositories.bzl", "npm_repositories")
-npm_repositories()
-pnpm_repository(name = "pnpm")

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "google-gax": "^4.4.1",
     "gts": "^5.3.1",
     "mocha": "^10.7.3",
-    "typescript": "5.1.6"
+    "typescript": "5.6.2"
   },
   "engines": {
     "node": ">=18"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,7 +57,7 @@ devDependencies:
     version: 17.0.33
   espower-typescript:
     specifier: ^10.0.1
-    version: 10.0.1(@types/node@22.14.0)(typescript@5.1.6)
+    version: 10.0.1(@types/node@22.14.0)(typescript@5.6.2)
   gapic-tools:
     specifier: ^1.0.1
     version: 1.0.1(protobufjs@7.5.0)
@@ -66,13 +66,13 @@ devDependencies:
     version: 4.4.1
   gts:
     specifier: ^5.3.1
-    version: 5.3.1(typescript@5.1.6)
+    version: 5.3.1(typescript@5.6.2)
   mocha:
     specifier: ^10.7.3
     version: 10.8.2
   typescript:
-    specifier: 5.1.6
-    version: 5.1.6
+    specifier: 5.6.2
+    version: 5.6.2
 
 packages:
 
@@ -534,7 +534,7 @@ packages:
       '@types/yargs-parser': 21.0.3
     dev: true
 
-  /@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.57.0)(typescript@5.1.6):
+  /@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.57.0)(typescript@5.6.2):
     resolution: {integrity: sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -546,23 +546,23 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.6.2)
       '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.0)(typescript@5.1.6)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@5.1.6)
+      '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.0)(typescript@5.6.2)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@5.6.2)
       debug: 4.4.0(supports-color@8.1.1)
       eslint: 8.57.0
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare-lite: 1.4.0
       semver: 7.7.1
-      tsutils: 3.21.0(typescript@5.1.6)
-      typescript: 5.1.6
+      tsutils: 3.21.0(typescript@5.6.2)
+      typescript: 5.6.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.1.6):
+  /@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2):
     resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -574,10 +574,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.1.6)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.6.2)
       debug: 4.4.0(supports-color@8.1.1)
       eslint: 8.57.0
-      typescript: 5.1.6
+      typescript: 5.6.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -590,7 +590,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.62.0
     dev: true
 
-  /@typescript-eslint/type-utils@5.62.0(eslint@8.57.0)(typescript@5.1.6):
+  /@typescript-eslint/type-utils@5.62.0(eslint@8.57.0)(typescript@5.6.2):
     resolution: {integrity: sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -600,12 +600,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.1.6)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@5.1.6)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.6.2)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@5.6.2)
       debug: 4.4.0(supports-color@8.1.1)
       eslint: 8.57.0
-      tsutils: 3.21.0(typescript@5.1.6)
-      typescript: 5.1.6
+      tsutils: 3.21.0(typescript@5.6.2)
+      typescript: 5.6.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -615,7 +615,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree@5.62.0(typescript@5.1.6):
+  /@typescript-eslint/typescript-estree@5.62.0(typescript@5.6.2):
     resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -630,13 +630,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.7.1
-      tsutils: 3.21.0(typescript@5.1.6)
-      typescript: 5.1.6
+      tsutils: 3.21.0(typescript@5.6.2)
+      typescript: 5.6.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@5.62.0(eslint@8.57.0)(typescript@5.1.6):
+  /@typescript-eslint/utils@5.62.0(eslint@8.57.0)(typescript@5.6.2):
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -647,7 +647,7 @@ packages:
       '@types/semver': 7.5.8
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.1.6)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.6.2)
       eslint: 8.57.0
       eslint-scope: 5.1.1
       semver: 7.7.1
@@ -1518,7 +1518,7 @@ packages:
       xtend: 4.0.2
     dev: true
 
-  /espower-typescript@10.0.1(@types/node@22.14.0)(typescript@5.1.6):
+  /espower-typescript@10.0.1(@types/node@22.14.0)(typescript@5.6.2):
     resolution: {integrity: sha512-Otz3g+JKQCPG3CxyUQnmcmr9LeYXe+bEU2F/WtBeaByIj+kgR+8lyYSa1Rcqh27b/sp9EjrDLDUTW+d7dsfJQw==}
     engines: {node: '>=10.17'}
     peerDependencies:
@@ -1527,8 +1527,8 @@ packages:
       espower-source: 2.3.0
       minimatch: 5.1.6
       source-map-support: 0.5.21
-      ts-node: 10.9.2(@types/node@22.14.0)(typescript@5.1.6)
-      typescript: 5.1.6
+      ts-node: 10.9.2(@types/node@22.14.0)(typescript@5.6.2)
+      typescript: 5.6.2
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -2064,15 +2064,15 @@ packages:
       - supports-color
     dev: true
 
-  /gts@5.3.1(typescript@5.1.6):
+  /gts@5.3.1(typescript@5.6.2):
     resolution: {integrity: sha512-P9F+krJkGOkisUX+P9pfUas1Xy+U+CxBFZT62uInkJbgvZpnW1ug/pIcMJJmLOthMq1J88lpQUGhXDC9UTvVcw==}
     engines: {node: '>=14'}
     hasBin: true
     peerDependencies:
       typescript: '>=3'
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.57.0)(typescript@5.1.6)
-      '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.1.6)
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.57.0)(typescript@5.6.2)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.6.2)
       chalk: 4.1.2
       eslint: 8.57.0
       eslint-config-prettier: 9.1.0(eslint@8.57.0)
@@ -2085,7 +2085,7 @@ packages:
       ncp: 2.0.0
       prettier: 3.2.5
       rimraf: 3.0.2
-      typescript: 5.1.6
+      typescript: 5.6.2
       write-file-atomic: 4.0.2
     transitivePeerDependencies:
       - '@types/eslint'
@@ -3418,7 +3418,7 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /ts-node@10.9.2(@types/node@22.14.0)(typescript@5.1.6):
+  /ts-node@10.9.2(@types/node@22.14.0)(typescript@5.6.2):
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
     hasBin: true
     peerDependencies:
@@ -3444,7 +3444,7 @@ packages:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.1.6
+      typescript: 5.6.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     dev: true
@@ -3457,14 +3457,14 @@ packages:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
     dev: true
 
-  /tsutils@3.21.0(typescript@5.1.6):
+  /tsutils@3.21.0(typescript@5.6.2):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 5.1.6
+      typescript: 5.6.2
     dev: true
 
   /type-check@0.3.2:
@@ -3513,8 +3513,8 @@ packages:
     resolution: {integrity: sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==}
     dev: true
 
-  /typescript@5.1.6:
-    resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
+  /typescript@5.6.2:
+    resolution: {integrity: sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -5,17 +5,17 @@ def gapic_generator_typescript_repositories():
   maybe(
     http_archive,
     name = "aspect_rules_js",
-    sha256 = "fc6887091ee3243661fb532fd3244230b6e193c22566a038c9fd748ca68fb880",
-    strip_prefix = "rules_js-1.42.3",
-    url = "https://github.com/aspect-build/rules_js/archive/refs/tags/v1.42.3.tar.gz",
+    sha256 = "9db12fb5013bb2fb0c8ecf1abd4da10781864e1f5e4faa7ba7382cc96f45949c",
+    strip_prefix = "rules_js-2.1.3",
+    url = "https://github.com/aspect-build/rules_js/archive/refs/tags/v2.1.3.tar.gz",
   )
 
   maybe(
     http_archive,
     name = "aspect_rules_ts",
-    sha256 = "4c3f34fff9f96ffc9c26635d8235a32a23a6797324486c7d23c1dfa477e8b451",
-    strip_prefix = "rules_ts-1.4.5",
-    url = "https://github.com/aspect-build/rules_ts/archive/refs/tags/v1.4.5.tar.gz",
+    sha256 = "8bbac753f4b61adbfc1d9878b87b9cd0f64c9e8e6d8fafc8a1bbfa9625bab162",
+    strip_prefix = "rules_ts-3.2.1",
+    url = "https://github.com/aspect-build/rules_ts/archive/refs/tags/v3.2.1.tar.gz",
   )
 
   maybe(

--- a/typescript/src/generator.ts
+++ b/typescript/src/generator.ts
@@ -164,7 +164,7 @@ export class Generator {
       const info = yaml.load(content) as ServiceYaml;
       this.serviceYaml = info;
       const serviceMixins = [];
-      for (let i = 0; i < info.apis?.length ?? 0; i++) {
+      for (let i = 0; i < info.apis?.length || 0; i++) {
         const api = info.apis[i];
         for (const [, value] of Object.entries(api)) {
           serviceMixins.push(value);


### PR DESCRIPTION
In lieu of #1624, #1637, #1638, since they need to be done all together.

Very tricky to figure out - mix of the [release notes](https://github.com/aspect-build/rules_ts/releases/tag/v3.2.1), https://github.com/aspect-build/rules_js/releases/tag/v2.1.3, migration  [guide](https://docs.aspect.build/guides/rules_js_2_migration), gemini. In the future. look to a previous PR for debugging help.