### PR TITLE
chore: update tsconfig templates, companion to #1692

### DIFF
--- a/baselines/asset-esm/tsconfig.json.baseline
+++ b/baselines/asset-esm/tsconfig.json.baseline
@@ -14,7 +14,7 @@
     "isolatedModules": false,
     "emitDeclarationOnly": true,
     "lib": [
-      "es2018",
+      "es2023",
       "dom"
     ]
   },
@@ -25,6 +25,8 @@
     "esm/test/**/*.ts",
     "esm/src/**/*.json",
     "esm/system-test/*.ts",
-    "esm/src/*.cjs"
+    "esm/src/*.cjs",
+    "samples/**/*.json",
+    "protos/protos.json"
   ]
 }

--- a/baselines/asset/tsconfig.json.baseline
+++ b/baselines/asset/tsconfig.json.baseline
@@ -5,7 +5,7 @@
     "outDir": "build",
     "resolveJsonModule": true,
     "lib": [
-      "es2018",
+      "es2023",
       "dom"
     ]
   },
@@ -16,6 +16,7 @@
     "test/**/*.ts",
     "system-test/*.ts",
     "src/**/*.json",
+    "samples/**/*.json",
     "protos/protos.json"
   ]
 }

--- a/baselines/bigquery-storage-esm/tsconfig.json.baseline
+++ b/baselines/bigquery-storage-esm/tsconfig.json.baseline
@@ -14,7 +14,7 @@
     "isolatedModules": false,
     "emitDeclarationOnly": true,
     "lib": [
-      "es2018",
+      "es2023",
       "dom"
     ]
   },
@@ -25,6 +25,8 @@
     "esm/test/**/*.ts",
     "esm/src/**/*.json",
     "esm/system-test/*.ts",
-    "esm/src/*.cjs"
+    "esm/src/*.cjs",
+    "samples/**/*.json",
+    "protos/protos.json"
   ]
 }

--- a/baselines/bigquery-storage/tsconfig.json.baseline
+++ b/baselines/bigquery-storage/tsconfig.json.baseline
@@ -5,7 +5,7 @@
     "outDir": "build",
     "resolveJsonModule": true,
     "lib": [
-      "es2018",
+      "es2023",
       "dom"
     ]
   },
@@ -16,6 +16,7 @@
     "test/**/*.ts",
     "system-test/*.ts",
     "src/**/*.json",
+    "samples/**/*.json",
     "protos/protos.json"
   ]
 }

--- a/baselines/bigquery-v2-esm/tsconfig.json.baseline
+++ b/baselines/bigquery-v2-esm/tsconfig.json.baseline
@@ -14,7 +14,7 @@
     "isolatedModules": false,
     "emitDeclarationOnly": true,
     "lib": [
-      "es2018",
+      "es2023",
       "dom"
     ]
   },
@@ -25,6 +25,8 @@
     "esm/test/**/*.ts",
     "esm/src/**/*.json",
     "esm/system-test/*.ts",
-    "esm/src/*.cjs"
+    "esm/src/*.cjs",
+    "samples/**/*.json",
+    "protos/protos.json"
   ]
 }

--- a/baselines/bigquery-v2/tsconfig.json.baseline
+++ b/baselines/bigquery-v2/tsconfig.json.baseline
@@ -5,7 +5,7 @@
     "outDir": "build",
     "resolveJsonModule": true,
     "lib": [
-      "es2018",
+      "es2023",
       "dom"
     ]
   },
@@ -16,6 +16,7 @@
     "test/**/*.ts",
     "system-test/*.ts",
     "src/**/*.json",
+    "samples/**/*.json",
     "protos/protos.json"
   ]
 }

--- a/baselines/compute-esm/tsconfig.json.baseline
+++ b/baselines/compute-esm/tsconfig.json.baseline
@@ -14,7 +14,7 @@
     "isolatedModules": false,
     "emitDeclarationOnly": true,
     "lib": [
-      "es2018",
+      "es2023",
       "dom"
     ]
   },
@@ -25,6 +25,8 @@
     "esm/test/**/*.ts",
     "esm/src/**/*.json",
     "esm/system-test/*.ts",
-    "esm/src/*.cjs"
+    "esm/src/*.cjs",
+    "samples/**/*.json",
+    "protos/protos.json"
   ]
 }

--- a/baselines/compute/tsconfig.json.baseline
+++ b/baselines/compute/tsconfig.json.baseline
@@ -5,7 +5,7 @@
     "outDir": "build",
     "resolveJsonModule": true,
     "lib": [
-      "es2018",
+      "es2023",
       "dom"
     ]
   },
@@ -16,6 +16,7 @@
     "test/**/*.ts",
     "system-test/*.ts",
     "src/**/*.json",
+    "samples/**/*.json",
     "protos/protos.json"
   ]
 }

--- a/baselines/deprecatedtest-esm/tsconfig.json.baseline
+++ b/baselines/deprecatedtest-esm/tsconfig.json.baseline
@@ -14,7 +14,7 @@
     "isolatedModules": false,
     "emitDeclarationOnly": true,
     "lib": [
-      "es2018",
+      "es2023",
       "dom"
     ]
   },
@@ -25,6 +25,8 @@
     "esm/test/**/*.ts",
     "esm/src/**/*.json",
     "esm/system-test/*.ts",
-    "esm/src/*.cjs"
+    "esm/src/*.cjs",
+    "samples/**/*.json",
+    "protos/protos.json"
   ]
 }

--- a/baselines/deprecatedtest/tsconfig.json.baseline
+++ b/baselines/deprecatedtest/tsconfig.json.baseline
@@ -5,7 +5,7 @@
     "outDir": "build",
     "resolveJsonModule": true,
     "lib": [
-      "es2018",
+      "es2023",
       "dom"
     ]
   },
@@ -16,6 +16,7 @@
     "test/**/*.ts",
     "system-test/*.ts",
     "src/**/*.json",
+    "samples/**/*.json",
     "protos/protos.json"
   ]
 }

--- a/baselines/disable-packing-test-esm/tsconfig.json.baseline
+++ b/baselines/disable-packing-test-esm/tsconfig.json.baseline
@@ -14,7 +14,7 @@
     "isolatedModules": false,
     "emitDeclarationOnly": true,
     "lib": [
-      "es2018",
+      "es2023",
       "dom"
     ]
   },
@@ -25,6 +25,8 @@
     "esm/test/**/*.ts",
     "esm/src/**/*.json",
     "esm/system-test/*.ts",
-    "esm/src/*.cjs"
+    "esm/src/*.cjs",
+    "samples/**/*.json",
+    "protos/protos.json"
   ]
 }

--- a/baselines/disable-packing-test/tsconfig.json.baseline
+++ b/baselines/disable-packing-test/tsconfig.json.baseline
@@ -5,7 +5,7 @@
     "outDir": "build",
     "resolveJsonModule": true,
     "lib": [
-      "es2018",
+      "es2023",
       "dom"
     ]
   },
@@ -16,6 +16,7 @@
     "test/**/*.ts",
     "system-test/*.ts",
     "src/**/*.json",
+    "samples/**/*.json",
     "protos/protos.json"
   ]
 }

--- a/baselines/dlp-esm/tsconfig.json.baseline
+++ b/baselines/dlp-esm/tsconfig.json.baseline
@@ -14,7 +14,7 @@
     "isolatedModules": false,
     "emitDeclarationOnly": true,
     "lib": [
-      "es2018",
+      "es2023",
       "dom"
     ]
   },
@@ -25,6 +25,8 @@
     "esm/test/**/*.ts",
     "esm/src/**/*.json",
     "esm/system-test/*.ts",
-    "esm/src/*.cjs"
+    "esm/src/*.cjs",
+    "samples/**/*.json",
+    "protos/protos.json"
   ]
 }

--- a/baselines/dlp/tsconfig.json.baseline
+++ b/baselines/dlp/tsconfig.json.baseline
@@ -5,7 +5,7 @@
     "outDir": "build",
     "resolveJsonModule": true,
     "lib": [
-      "es2018",
+      "es2023",
       "dom"
     ]
   },
@@ -16,6 +16,7 @@
     "test/**/*.ts",
     "system-test/*.ts",
     "src/**/*.json",
+    "samples/**/*.json",
     "protos/protos.json"
   ]
 }

--- a/baselines/kms-esm/tsconfig.json.baseline
+++ b/baselines/kms-esm/tsconfig.json.baseline
@@ -14,7 +14,7 @@
     "isolatedModules": false,
     "emitDeclarationOnly": true,
     "lib": [
-      "es2018",
+      "es2023",
       "dom"
     ]
   },
@@ -25,6 +25,8 @@
     "esm/test/**/*.ts",
     "esm/src/**/*.json",
     "esm/system-test/*.ts",
-    "esm/src/*.cjs"
+    "esm/src/*.cjs",
+    "samples/**/*.json",
+    "protos/protos.json"
   ]
 }

--- a/baselines/kms/tsconfig.json.baseline
+++ b/baselines/kms/tsconfig.json.baseline
@@ -5,7 +5,7 @@
     "outDir": "build",
     "resolveJsonModule": true,
     "lib": [
-      "es2018",
+      "es2023",
       "dom"
     ]
   },
@@ -16,6 +16,7 @@
     "test/**/*.ts",
     "system-test/*.ts",
     "src/**/*.json",
+    "samples/**/*.json",
     "protos/protos.json"
   ]
 }

--- a/baselines/logging-esm/tsconfig.json.baseline
+++ b/baselines/logging-esm/tsconfig.json.baseline
@@ -14,7 +14,7 @@
     "isolatedModules": false,
     "emitDeclarationOnly": true,
     "lib": [
-      "es2018",
+      "es2023",
       "dom"
     ]
   },
@@ -25,6 +25,8 @@
     "esm/test/**/*.ts",
     "esm/src/**/*.json",
     "esm/system-test/*.ts",
-    "esm/src/*.cjs"
+    "esm/src/*.cjs",
+    "samples/**/*.json",
+    "protos/protos.json"
   ]
 }

--- a/baselines/logging/tsconfig.json.baseline
+++ b/baselines/logging/tsconfig.json.baseline
@@ -5,7 +5,7 @@
     "outDir": "build",
     "resolveJsonModule": true,
     "lib": [
-      "es2018",
+      "es2023",
       "dom"
     ]
   },
@@ -16,6 +16,7 @@
     "test/**/*.ts",
     "system-test/*.ts",
     "src/**/*.json",
+    "samples/**/*.json",
     "protos/protos.json"
   ]
 }

--- a/baselines/monitoring-esm/tsconfig.json.baseline
+++ b/baselines/monitoring-esm/tsconfig.json.baseline
@@ -14,7 +14,7 @@
     "isolatedModules": false,
     "emitDeclarationOnly": true,
     "lib": [
-      "es2018",
+      "es2023",
       "dom"
     ]
   },
@@ -25,6 +25,8 @@
     "esm/test/**/*.ts",
     "esm/src/**/*.json",
     "esm/system-test/*.ts",
-    "esm/src/*.cjs"
+    "esm/src/*.cjs",
+    "samples/**/*.json",
+    "protos/protos.json"
   ]
 }

--- a/baselines/monitoring/tsconfig.json.baseline
+++ b/baselines/monitoring/tsconfig.json.baseline
@@ -5,7 +5,7 @@
     "outDir": "build",
     "resolveJsonModule": true,
     "lib": [
-      "es2018",
+      "es2023",
       "dom"
     ]
   },
@@ -16,6 +16,7 @@
     "test/**/*.ts",
     "system-test/*.ts",
     "src/**/*.json",
+    "samples/**/*.json",
     "protos/protos.json"
   ]
 }

--- a/baselines/naming-esm/tsconfig.json.baseline
+++ b/baselines/naming-esm/tsconfig.json.baseline
@@ -14,7 +14,7 @@
     "isolatedModules": false,
     "emitDeclarationOnly": true,
     "lib": [
-      "es2018",
+      "es2023",
       "dom"
     ]
   },
@@ -25,6 +25,8 @@
     "esm/test/**/*.ts",
     "esm/src/**/*.json",
     "esm/system-test/*.ts",
-    "esm/src/*.cjs"
+    "esm/src/*.cjs",
+    "samples/**/*.json",
+    "protos/protos.json"
   ]
 }

--- a/baselines/naming/tsconfig.json.baseline
+++ b/baselines/naming/tsconfig.json.baseline
@@ -5,7 +5,7 @@
     "outDir": "build",
     "resolveJsonModule": true,
     "lib": [
-      "es2018",
+      "es2023",
       "dom"
     ]
   },
@@ -16,6 +16,7 @@
     "test/**/*.ts",
     "system-test/*.ts",
     "src/**/*.json",
+    "samples/**/*.json",
     "protos/protos.json"
   ]
 }

--- a/baselines/redis-esm/tsconfig.json.baseline
+++ b/baselines/redis-esm/tsconfig.json.baseline
@@ -14,7 +14,7 @@
     "isolatedModules": false,
     "emitDeclarationOnly": true,
     "lib": [
-      "es2018",
+      "es2023",
       "dom"
     ]
   },
@@ -25,6 +25,8 @@
     "esm/test/**/*.ts",
     "esm/src/**/*.json",
     "esm/system-test/*.ts",
-    "esm/src/*.cjs"
+    "esm/src/*.cjs",
+    "samples/**/*.json",
+    "protos/protos.json"
   ]
 }

--- a/baselines/redis/tsconfig.json.baseline
+++ b/baselines/redis/tsconfig.json.baseline
@@ -5,7 +5,7 @@
     "outDir": "build",
     "resolveJsonModule": true,
     "lib": [
-      "es2018",
+      "es2023",
       "dom"
     ]
   },
@@ -16,6 +16,7 @@
     "test/**/*.ts",
     "system-test/*.ts",
     "src/**/*.json",
+    "samples/**/*.json",
     "protos/protos.json"
   ]
 }

--- a/baselines/routingtest-esm/tsconfig.json.baseline
+++ b/baselines/routingtest-esm/tsconfig.json.baseline
@@ -14,7 +14,7 @@
     "isolatedModules": false,
     "emitDeclarationOnly": true,
     "lib": [
-      "es2018",
+      "es2023",
       "dom"
     ]
   },
@@ -25,6 +25,8 @@
     "esm/test/**/*.ts",
     "esm/src/**/*.json",
     "esm/system-test/*.ts",
-    "esm/src/*.cjs"
+    "esm/src/*.cjs",
+    "samples/**/*.json",
+    "protos/protos.json"
   ]
 }

--- a/baselines/routingtest/tsconfig.json.baseline
+++ b/baselines/routingtest/tsconfig.json.baseline
@@ -5,7 +5,7 @@
     "outDir": "build",
     "resolveJsonModule": true,
     "lib": [
-      "es2018",
+      "es2023",
       "dom"
     ]
   },
@@ -16,6 +16,7 @@
     "test/**/*.ts",
     "system-test/*.ts",
     "src/**/*.json",
+    "samples/**/*.json",
     "protos/protos.json"
   ]
 }

--- a/baselines/showcase-esm/tsconfig.json.baseline
+++ b/baselines/showcase-esm/tsconfig.json.baseline
@@ -14,7 +14,7 @@
     "isolatedModules": false,
     "emitDeclarationOnly": true,
     "lib": [
-      "es2018",
+      "es2023",
       "dom"
     ]
   },
@@ -25,6 +25,8 @@
     "esm/test/**/*.ts",
     "esm/src/**/*.json",
     "esm/system-test/*.ts",
-    "esm/src/*.cjs"
+    "esm/src/*.cjs",
+    "samples/**/*.json",
+    "protos/protos.json"
   ]
 }

--- a/baselines/showcase-legacy-esm/tsconfig.json.baseline
+++ b/baselines/showcase-legacy-esm/tsconfig.json.baseline
@@ -14,7 +14,7 @@
     "isolatedModules": false,
     "emitDeclarationOnly": true,
     "lib": [
-      "es2018",
+      "es2023",
       "dom"
     ]
   },
@@ -25,6 +25,8 @@
     "esm/test/**/*.ts",
     "esm/src/**/*.json",
     "esm/system-test/*.ts",
-    "esm/src/*.cjs"
+    "esm/src/*.cjs",
+    "samples/**/*.json",
+    "protos/protos.json"
   ]
 }

--- a/baselines/showcase-legacy/tsconfig.json.baseline
+++ b/baselines/showcase-legacy/tsconfig.json.baseline
@@ -5,7 +5,7 @@
     "outDir": "build",
     "resolveJsonModule": true,
     "lib": [
-      "es2018",
+      "es2023",
       "dom"
     ]
   },
@@ -16,6 +16,7 @@
     "test/**/*.ts",
     "system-test/*.ts",
     "src/**/*.json",
+    "samples/**/*.json",
     "protos/protos.json"
   ]
 }

--- a/baselines/showcase/tsconfig.json.baseline
+++ b/baselines/showcase/tsconfig.json.baseline
@@ -5,7 +5,7 @@
     "outDir": "build",
     "resolveJsonModule": true,
     "lib": [
-      "es2018",
+      "es2023",
       "dom"
     ]
   },
@@ -16,6 +16,7 @@
     "test/**/*.ts",
     "system-test/*.ts",
     "src/**/*.json",
+    "samples/**/*.json",
     "protos/protos.json"
   ]
 }

--- a/baselines/tasks-esm/tsconfig.json.baseline
+++ b/baselines/tasks-esm/tsconfig.json.baseline
@@ -14,7 +14,7 @@
     "isolatedModules": false,
     "emitDeclarationOnly": true,
     "lib": [
-      "es2018",
+      "es2023",
       "dom"
     ]
   },
@@ -25,6 +25,8 @@
     "esm/test/**/*.ts",
     "esm/src/**/*.json",
     "esm/system-test/*.ts",
-    "esm/src/*.cjs"
+    "esm/src/*.cjs",
+    "samples/**/*.json",
+    "protos/protos.json"
   ]
 }

--- a/baselines/tasks/tsconfig.json.baseline
+++ b/baselines/tasks/tsconfig.json.baseline
@@ -5,7 +5,7 @@
     "outDir": "build",
     "resolveJsonModule": true,
     "lib": [
-      "es2018",
+      "es2023",
       "dom"
     ]
   },
@@ -16,6 +16,7 @@
     "test/**/*.ts",
     "system-test/*.ts",
     "src/**/*.json",
+    "samples/**/*.json",
     "protos/protos.json"
   ]
 }

--- a/baselines/texttospeech-esm/tsconfig.json.baseline
+++ b/baselines/texttospeech-esm/tsconfig.json.baseline
@@ -14,7 +14,7 @@
     "isolatedModules": false,
     "emitDeclarationOnly": true,
     "lib": [
-      "es2018",
+      "es2023",
       "dom"
     ]
   },
@@ -25,6 +25,8 @@
     "esm/test/**/*.ts",
     "esm/src/**/*.json",
     "esm/system-test/*.ts",
-    "esm/src/*.cjs"
+    "esm/src/*.cjs",
+    "samples/**/*.json",
+    "protos/protos.json"
   ]
 }

--- a/baselines/texttospeech/tsconfig.json.baseline
+++ b/baselines/texttospeech/tsconfig.json.baseline
@@ -5,7 +5,7 @@
     "outDir": "build",
     "resolveJsonModule": true,
     "lib": [
-      "es2018",
+      "es2023",
       "dom"
     ]
   },
@@ -16,6 +16,7 @@
     "test/**/*.ts",
     "system-test/*.ts",
     "src/**/*.json",
+    "samples/**/*.json",
     "protos/protos.json"
   ]
 }

--- a/baselines/translate-esm/tsconfig.json.baseline
+++ b/baselines/translate-esm/tsconfig.json.baseline
@@ -14,7 +14,7 @@
     "isolatedModules": false,
     "emitDeclarationOnly": true,
     "lib": [
-      "es2018",
+      "es2023",
       "dom"
     ]
   },
@@ -25,6 +25,8 @@
     "esm/test/**/*.ts",
     "esm/src/**/*.json",
     "esm/system-test/*.ts",
-    "esm/src/*.cjs"
+    "esm/src/*.cjs",
+    "samples/**/*.json",
+    "protos/protos.json"
   ]
 }

--- a/baselines/translate/tsconfig.json.baseline
+++ b/baselines/translate/tsconfig.json.baseline
@@ -5,7 +5,7 @@
     "outDir": "build",
     "resolveJsonModule": true,
     "lib": [
-      "es2018",
+      "es2023",
       "dom"
     ]
   },
@@ -16,6 +16,7 @@
     "test/**/*.ts",
     "system-test/*.ts",
     "src/**/*.json",
+    "samples/**/*.json",
     "protos/protos.json"
   ]
 }

--- a/baselines/videointelligence-esm/tsconfig.json.baseline
+++ b/baselines/videointelligence-esm/tsconfig.json.baseline
@@ -14,7 +14,7 @@
     "isolatedModules": false,
     "emitDeclarationOnly": true,
     "lib": [
-      "es2018",
+      "es2023",
       "dom"
     ]
   },
@@ -25,6 +25,8 @@
     "esm/test/**/*.ts",
     "esm/src/**/*.json",
     "esm/system-test/*.ts",
-    "esm/src/*.cjs"
+    "esm/src/*.cjs",
+    "samples/**/*.json",
+    "protos/protos.json"
   ]
 }

--- a/baselines/videointelligence/tsconfig.json.baseline
+++ b/baselines/videointelligence/tsconfig.json.baseline
@@ -5,7 +5,7 @@
     "outDir": "build",
     "resolveJsonModule": true,
     "lib": [
-      "es2018",
+      "es2023",
       "dom"
     ]
   },
@@ -16,6 +16,7 @@
     "test/**/*.ts",
     "system-test/*.ts",
     "src/**/*.json",
+    "samples/**/*.json",
     "protos/protos.json"
   ]
 }

--- a/templates/cjs/typescript_gapic/tsconfig.json.njk
+++ b/templates/cjs/typescript_gapic/tsconfig.json.njk
@@ -21,7 +21,7 @@ limitations under the License.
     "rootDir": ".",
     "outDir": "build",
     "resolveJsonModule": true,
-    "lib": ["es2018", "dom"]
+    "lib": ["es2023", "dom"]
   },
   "include": [
     "src/*.ts",
@@ -30,6 +30,7 @@ limitations under the License.
     "test/**/*.ts",
     "system-test/*.ts",
     "src/**/*.json",
+    "samples/**/*.json",
     "protos/protos.json"
   ]
 }

--- a/templates/esm/typescript_gapic/tsconfig.json.njk
+++ b/templates/esm/typescript_gapic/tsconfig.json.njk
@@ -31,7 +31,7 @@ limitations under the License.
     "isolatedModules": false,
     "emitDeclarationOnly": true,
     "lib": [
-      "es2018",
+      "es2023",
       "dom"
     ]
   },
@@ -42,6 +42,8 @@ limitations under the License.
     "esm/test/**/*.ts",
     "esm/src/**/*.json",
     "esm/system-test/*.ts",
-    "esm/src/*.cjs"
+    "esm/src/*.cjs",
+    "esm/samples/**/*.json",
+    "esm/protos/protos.json"
   ]
 }

--- a/templates/esm/typescript_gapic/tsconfig.json.njk
+++ b/templates/esm/typescript_gapic/tsconfig.json.njk
@@ -43,7 +43,7 @@ limitations under the License.
     "esm/src/**/*.json",
     "esm/system-test/*.ts",
     "esm/src/*.cjs",
-    "esm/samples/**/*.json",
-    "esm/protos/protos.json"
+    "samples/**/*.json",
+    "protos/protos.json"
   ]
 }


### PR DESCRIPTION
I think this is the companion to #1692 - In BQ storage, we have some samples files for JSON that need to be included. If it's preferred I leave that out of this, I can. But I'm pretty sure we need to be updating to es2023 anyways! 