### PR TITLE
fix: small issues with end-to-end generation test

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -107,7 +107,7 @@ gapic_node_processing_bin.gapic_node_processing_binary(
     name = "combine_libraries_binary",
     data = [
         "//:node_modules/nunjucks",
-        "//:node_modules/gapic-node-processing/templates/post-processing-templates/index.ts.njk"    ],
+    ],
     env = {
         "BAZEL_BINDIR": ".",
     },

--- a/baselines/asset-esm/README.md.baseline
+++ b/baselines/asset-esm/README.md.baseline
@@ -2,20 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# [: Nodejs Client][homepage]
+# [Asset: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/@google-cloud/asset.svg)](https://www.npmjs.org/package/@google-cloud/asset)
 
- client for Node.js
+Asset client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
 [the CHANGELOG][homepage_changelog].
 
-* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/asset/latest)
+* [Asset Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/asset/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -38,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the  API][enable_api].
+1.  [Enable the Asset API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library

--- a/baselines/asset-esm/README.md.baseline
+++ b/baselines/asset-esm/README.md.baseline
@@ -2,22 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-asset
-
-# [Asset: Nodejs Client][homepage]
+# [: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/@google-cloud/asset.svg)](https://www.npmjs.org/package/@google-cloud/asset)
 
-Asset client for Node.js
+ client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [Asset Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/asset/latest)
+* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/asset/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the Asset API][enable_api].
+1.  [Enable the  API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install @google-cloud/asset
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=cloudasset.googleapis.com
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-asset/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-asset/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-asset

--- a/baselines/asset/README.md.baseline
+++ b/baselines/asset/README.md.baseline
@@ -2,20 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# [: Nodejs Client][homepage]
+# [Asset: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/@google-cloud/asset.svg)](https://www.npmjs.org/package/@google-cloud/asset)
 
- client for Node.js
+Asset client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
 [the CHANGELOG][homepage_changelog].
 
-* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/asset/latest)
+* [Asset Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/asset/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -38,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the  API][enable_api].
+1.  [Enable the Asset API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library

--- a/baselines/asset/README.md.baseline
+++ b/baselines/asset/README.md.baseline
@@ -2,22 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-asset
-
-# [Asset: Nodejs Client][homepage]
+# [: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/@google-cloud/asset.svg)](https://www.npmjs.org/package/@google-cloud/asset)
 
-Asset client for Node.js
+ client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [Asset Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/asset/latest)
+* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/asset/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the Asset API][enable_api].
+1.  [Enable the  API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install @google-cloud/asset
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=cloudasset.googleapis.com
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-asset/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-asset/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-asset

--- a/baselines/bigquery-storage-esm/README.md.baseline
+++ b/baselines/bigquery-storage-esm/README.md.baseline
@@ -2,22 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-bigquery-storage
-
-# [Storage: Nodejs Client][homepage]
+# [: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/storage.svg)](https://www.npmjs.org/package/storage)
 
-Storage client for Node.js
+ client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [Storage Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/storage/latest)
+* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/storage/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the Storage API][enable_api].
+1.  [Enable the  API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install storage
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=bigquerystorage.googleapis.com
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-bigquery-storage/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-bigquery-storage/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-bigquery-storage

--- a/baselines/bigquery-storage-esm/README.md.baseline
+++ b/baselines/bigquery-storage-esm/README.md.baseline
@@ -2,20 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# [: Nodejs Client][homepage]
+# [Storage: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/storage.svg)](https://www.npmjs.org/package/storage)
 
- client for Node.js
+Storage client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
 [the CHANGELOG][homepage_changelog].
 
-* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/storage/latest)
+* [Storage Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/storage/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -38,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the  API][enable_api].
+1.  [Enable the Storage API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library

--- a/baselines/bigquery-storage/README.md.baseline
+++ b/baselines/bigquery-storage/README.md.baseline
@@ -2,22 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-bigquery-storage
-
-# [Storage: Nodejs Client][homepage]
+# [: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/storage.svg)](https://www.npmjs.org/package/storage)
 
-Storage client for Node.js
+ client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [Storage Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/storage/latest)
+* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/storage/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the Storage API][enable_api].
+1.  [Enable the  API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install storage
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=bigquerystorage.googleapis.com
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-bigquery-storage/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-bigquery-storage/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-bigquery-storage

--- a/baselines/bigquery-storage/README.md.baseline
+++ b/baselines/bigquery-storage/README.md.baseline
@@ -2,20 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# [: Nodejs Client][homepage]
+# [Storage: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/storage.svg)](https://www.npmjs.org/package/storage)
 
- client for Node.js
+Storage client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
 [the CHANGELOG][homepage_changelog].
 
-* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/storage/latest)
+* [Storage Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/storage/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -38,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the  API][enable_api].
+1.  [Enable the Storage API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library

--- a/baselines/bigquery-v2-esm/README.md.baseline
+++ b/baselines/bigquery-v2-esm/README.md.baseline
@@ -2,20 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# [: Nodejs Client][homepage]
+# [Bigquery: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/bigquery.svg)](https://www.npmjs.org/package/bigquery)
 
- client for Node.js
+Bigquery client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
 [the CHANGELOG][homepage_changelog].
 
-* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/bigquery/latest)
+* [Bigquery Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/bigquery/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -38,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the  API][enable_api].
+1.  [Enable the Bigquery API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library

--- a/baselines/bigquery-v2-esm/README.md.baseline
+++ b/baselines/bigquery-v2-esm/README.md.baseline
@@ -2,22 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-bigquery
-
-# [Bigquery: Nodejs Client][homepage]
+# [: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/bigquery.svg)](https://www.npmjs.org/package/bigquery)
 
-Bigquery client for Node.js
+ client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [Bigquery Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/bigquery/latest)
+* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/bigquery/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the Bigquery API][enable_api].
+1.  [Enable the  API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install bigquery
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=bigquery.googleapis.com
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-bigquery/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-bigquery/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-bigquery

--- a/baselines/bigquery-v2/README.md.baseline
+++ b/baselines/bigquery-v2/README.md.baseline
@@ -2,20 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# [: Nodejs Client][homepage]
+# [Bigquery: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/bigquery.svg)](https://www.npmjs.org/package/bigquery)
 
- client for Node.js
+Bigquery client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
 [the CHANGELOG][homepage_changelog].
 
-* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/bigquery/latest)
+* [Bigquery Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/bigquery/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -38,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the  API][enable_api].
+1.  [Enable the Bigquery API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library

--- a/baselines/bigquery-v2/README.md.baseline
+++ b/baselines/bigquery-v2/README.md.baseline
@@ -2,22 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-bigquery
-
-# [Bigquery: Nodejs Client][homepage]
+# [: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/bigquery.svg)](https://www.npmjs.org/package/bigquery)
 
-Bigquery client for Node.js
+ client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [Bigquery Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/bigquery/latest)
+* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/bigquery/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the Bigquery API][enable_api].
+1.  [Enable the  API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install bigquery
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=bigquery.googleapis.com
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-bigquery/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-bigquery/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-bigquery

--- a/baselines/compute-esm/README.md.baseline
+++ b/baselines/compute-esm/README.md.baseline
@@ -2,22 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-compute
-
-# [Compute: Nodejs Client][homepage]
+# [: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/@google-cloud/compute.svg)](https://www.npmjs.org/package/@google-cloud/compute)
 
-Compute client for Node.js
+ client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [Compute Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/compute/latest)
+* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/compute/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the Compute API][enable_api].
+1.  [Enable the  API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install @google-cloud/compute
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=compute.googleapis.com
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-compute/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-compute/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-compute

--- a/baselines/compute-esm/README.md.baseline
+++ b/baselines/compute-esm/README.md.baseline
@@ -2,20 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# [: Nodejs Client][homepage]
+# [Compute: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/@google-cloud/compute.svg)](https://www.npmjs.org/package/@google-cloud/compute)
 
- client for Node.js
+Compute client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
 [the CHANGELOG][homepage_changelog].
 
-* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/compute/latest)
+* [Compute Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/compute/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -38,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the  API][enable_api].
+1.  [Enable the Compute API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library

--- a/baselines/compute/README.md.baseline
+++ b/baselines/compute/README.md.baseline
@@ -2,22 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-compute
-
-# [Compute: Nodejs Client][homepage]
+# [: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/@google-cloud/compute.svg)](https://www.npmjs.org/package/@google-cloud/compute)
 
-Compute client for Node.js
+ client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [Compute Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/compute/latest)
+* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/compute/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the Compute API][enable_api].
+1.  [Enable the  API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install @google-cloud/compute
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=compute.googleapis.com
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-compute/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-compute/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-compute

--- a/baselines/compute/README.md.baseline
+++ b/baselines/compute/README.md.baseline
@@ -2,20 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# [: Nodejs Client][homepage]
+# [Compute: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/@google-cloud/compute.svg)](https://www.npmjs.org/package/@google-cloud/compute)
 
- client for Node.js
+Compute client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
 [the CHANGELOG][homepage_changelog].
 
-* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/compute/latest)
+* [Compute Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/compute/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -38,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the  API][enable_api].
+1.  [Enable the Compute API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library

--- a/baselines/deprecatedtest-esm/README.md.baseline
+++ b/baselines/deprecatedtest-esm/README.md.baseline
@@ -2,22 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-deprecatedtest
-
-# [Deprecatedtest: Nodejs Client][homepage]
+# [: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/deprecatedtest.svg)](https://www.npmjs.org/package/deprecatedtest)
 
-Deprecatedtest client for Node.js
+ client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [Deprecatedtest Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/deprecatedtest/latest)
+* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/deprecatedtest/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the Deprecatedtest API][enable_api].
+1.  [Enable the  API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install deprecatedtest
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=localhost
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-deprecatedtest/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-deprecatedtest/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-deprecatedtest

--- a/baselines/deprecatedtest-esm/README.md.baseline
+++ b/baselines/deprecatedtest-esm/README.md.baseline
@@ -2,20 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# [: Nodejs Client][homepage]
+# [Deprecatedtest: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/deprecatedtest.svg)](https://www.npmjs.org/package/deprecatedtest)
 
- client for Node.js
+Deprecatedtest client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
 [the CHANGELOG][homepage_changelog].
 
-* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/deprecatedtest/latest)
+* [Deprecatedtest Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/deprecatedtest/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -38,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the  API][enable_api].
+1.  [Enable the Deprecatedtest API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library

--- a/baselines/deprecatedtest/README.md.baseline
+++ b/baselines/deprecatedtest/README.md.baseline
@@ -2,22 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-deprecatedtest
-
-# [Deprecatedtest: Nodejs Client][homepage]
+# [: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/deprecatedtest.svg)](https://www.npmjs.org/package/deprecatedtest)
 
-Deprecatedtest client for Node.js
+ client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [Deprecatedtest Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/deprecatedtest/latest)
+* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/deprecatedtest/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the Deprecatedtest API][enable_api].
+1.  [Enable the  API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install deprecatedtest
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=localhost
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-deprecatedtest/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-deprecatedtest/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-deprecatedtest

--- a/baselines/deprecatedtest/README.md.baseline
+++ b/baselines/deprecatedtest/README.md.baseline
@@ -2,20 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# [: Nodejs Client][homepage]
+# [Deprecatedtest: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/deprecatedtest.svg)](https://www.npmjs.org/package/deprecatedtest)
 
- client for Node.js
+Deprecatedtest client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
 [the CHANGELOG][homepage_changelog].
 
-* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/deprecatedtest/latest)
+* [Deprecatedtest Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/deprecatedtest/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -38,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the  API][enable_api].
+1.  [Enable the Deprecatedtest API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library

--- a/baselines/disable-packing-test-esm/README.md.baseline
+++ b/baselines/disable-packing-test-esm/README.md.baseline
@@ -2,22 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-showcase
-
-# [Showcase: Nodejs Client][homepage]
+# [: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/showcase.svg)](https://www.npmjs.org/package/showcase)
 
-Showcase client for Node.js
+ client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [Showcase Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/showcase/latest)
+* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/showcase/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the Showcase API][enable_api].
+1.  [Enable the  API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install showcase
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=localhost
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-showcase/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-showcase/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-showcase

--- a/baselines/disable-packing-test-esm/README.md.baseline
+++ b/baselines/disable-packing-test-esm/README.md.baseline
@@ -2,20 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# [: Nodejs Client][homepage]
+# [Showcase: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/showcase.svg)](https://www.npmjs.org/package/showcase)
 
- client for Node.js
+Showcase client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
 [the CHANGELOG][homepage_changelog].
 
-* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/showcase/latest)
+* [Showcase Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/showcase/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -38,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the  API][enable_api].
+1.  [Enable the Showcase API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library

--- a/baselines/disable-packing-test/README.md.baseline
+++ b/baselines/disable-packing-test/README.md.baseline
@@ -2,22 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-showcase
-
-# [Showcase: Nodejs Client][homepage]
+# [: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/showcase.svg)](https://www.npmjs.org/package/showcase)
 
-Showcase client for Node.js
+ client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [Showcase Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/showcase/latest)
+* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/showcase/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the Showcase API][enable_api].
+1.  [Enable the  API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install showcase
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=localhost
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-showcase/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-showcase/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-showcase

--- a/baselines/disable-packing-test/README.md.baseline
+++ b/baselines/disable-packing-test/README.md.baseline
@@ -2,20 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# [: Nodejs Client][homepage]
+# [Showcase: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/showcase.svg)](https://www.npmjs.org/package/showcase)
 
- client for Node.js
+Showcase client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
 [the CHANGELOG][homepage_changelog].
 
-* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/showcase/latest)
+* [Showcase Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/showcase/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -38,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the  API][enable_api].
+1.  [Enable the Showcase API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library

--- a/baselines/dlp-esm/README.md.baseline
+++ b/baselines/dlp-esm/README.md.baseline
@@ -2,22 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-privacy-dlp
-
-# [Dlp: Nodejs Client][homepage]
+# [: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/dlp.svg)](https://www.npmjs.org/package/dlp)
 
-Dlp client for Node.js
+ client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [Dlp Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/dlp/latest)
+* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/dlp/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the Dlp API][enable_api].
+1.  [Enable the  API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install dlp
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=dlp.googleapis.com
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-privacy-dlp/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-privacy-dlp/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-privacy-dlp

--- a/baselines/dlp-esm/README.md.baseline
+++ b/baselines/dlp-esm/README.md.baseline
@@ -2,20 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# [: Nodejs Client][homepage]
+# [Dlp: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/dlp.svg)](https://www.npmjs.org/package/dlp)
 
- client for Node.js
+Dlp client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
 [the CHANGELOG][homepage_changelog].
 
-* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/dlp/latest)
+* [Dlp Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/dlp/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -38,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the  API][enable_api].
+1.  [Enable the Dlp API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library

--- a/baselines/dlp/README.md.baseline
+++ b/baselines/dlp/README.md.baseline
@@ -2,22 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-privacy-dlp
-
-# [Dlp: Nodejs Client][homepage]
+# [: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/dlp.svg)](https://www.npmjs.org/package/dlp)
 
-Dlp client for Node.js
+ client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [Dlp Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/dlp/latest)
+* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/dlp/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the Dlp API][enable_api].
+1.  [Enable the  API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install dlp
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=dlp.googleapis.com
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-privacy-dlp/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-privacy-dlp/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-privacy-dlp

--- a/baselines/dlp/README.md.baseline
+++ b/baselines/dlp/README.md.baseline
@@ -2,20 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# [: Nodejs Client][homepage]
+# [Dlp: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/dlp.svg)](https://www.npmjs.org/package/dlp)
 
- client for Node.js
+Dlp client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
 [the CHANGELOG][homepage_changelog].
 
-* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/dlp/latest)
+* [Dlp Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/dlp/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -38,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the  API][enable_api].
+1.  [Enable the Dlp API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library

--- a/baselines/kms-esm/README.md.baseline
+++ b/baselines/kms-esm/README.md.baseline
@@ -2,22 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-kms
-
-# [Kms: Nodejs Client][homepage]
+# [Cloud Key Management Service (KMS) API: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/kms.svg)](https://www.npmjs.org/package/kms)
 
-Kms client for Node.js
+Cloud Key Management Service (KMS) API client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [Kms Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/kms/latest)
+* [Cloud Key Management Service (KMS) API Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/kms/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the Kms API][enable_api].
+1.  [Enable the Cloud Key Management Service (KMS) API API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install kms
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=cloudkms.googleapis.com
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-kms/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-kms/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-kms

--- a/baselines/kms/README.md.baseline
+++ b/baselines/kms/README.md.baseline
@@ -2,22 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-kms
-
-# [Kms: Nodejs Client][homepage]
+# [Cloud Key Management Service (KMS) API: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/kms.svg)](https://www.npmjs.org/package/kms)
 
-Kms client for Node.js
+Cloud Key Management Service (KMS) API client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [Kms Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/kms/latest)
+* [Cloud Key Management Service (KMS) API Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/kms/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the Kms API][enable_api].
+1.  [Enable the Cloud Key Management Service (KMS) API API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install kms
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=cloudkms.googleapis.com
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-kms/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-kms/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-kms

--- a/baselines/logging-esm/README.md.baseline
+++ b/baselines/logging-esm/README.md.baseline
@@ -2,22 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-logging
-
-# [Logging: Nodejs Client][homepage]
+# [: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/logging.svg)](https://www.npmjs.org/package/logging)
 
-Logging client for Node.js
+ client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [Logging Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/logging/latest)
+* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/logging/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the Logging API][enable_api].
+1.  [Enable the  API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install logging
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=logging.googleapis.com
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-logging/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-logging/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-logging

--- a/baselines/logging-esm/README.md.baseline
+++ b/baselines/logging-esm/README.md.baseline
@@ -2,20 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# [: Nodejs Client][homepage]
+# [Logging: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/logging.svg)](https://www.npmjs.org/package/logging)
 
- client for Node.js
+Logging client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
 [the CHANGELOG][homepage_changelog].
 
-* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/logging/latest)
+* [Logging Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/logging/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -38,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the  API][enable_api].
+1.  [Enable the Logging API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library

--- a/baselines/logging/README.md.baseline
+++ b/baselines/logging/README.md.baseline
@@ -2,22 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-logging
-
-# [Logging: Nodejs Client][homepage]
+# [: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/logging.svg)](https://www.npmjs.org/package/logging)
 
-Logging client for Node.js
+ client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [Logging Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/logging/latest)
+* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/logging/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the Logging API][enable_api].
+1.  [Enable the  API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install logging
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=logging.googleapis.com
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-logging/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-logging/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-logging

--- a/baselines/logging/README.md.baseline
+++ b/baselines/logging/README.md.baseline
@@ -2,20 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# [: Nodejs Client][homepage]
+# [Logging: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/logging.svg)](https://www.npmjs.org/package/logging)
 
- client for Node.js
+Logging client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
 [the CHANGELOG][homepage_changelog].
 
-* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/logging/latest)
+* [Logging Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/logging/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -38,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the  API][enable_api].
+1.  [Enable the Logging API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library

--- a/baselines/monitoring-esm/README.md.baseline
+++ b/baselines/monitoring-esm/README.md.baseline
@@ -2,20 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# [: Nodejs Client][homepage]
+# [Monitoring: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/monitoring.svg)](https://www.npmjs.org/package/monitoring)
 
- client for Node.js
+Monitoring client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
 [the CHANGELOG][homepage_changelog].
 
-* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/monitoring/latest)
+* [Monitoring Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/monitoring/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -38,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the  API][enable_api].
+1.  [Enable the Monitoring API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library

--- a/baselines/monitoring-esm/README.md.baseline
+++ b/baselines/monitoring-esm/README.md.baseline
@@ -2,22 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-monitoring
-
-# [Monitoring: Nodejs Client][homepage]
+# [: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/monitoring.svg)](https://www.npmjs.org/package/monitoring)
 
-Monitoring client for Node.js
+ client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [Monitoring Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/monitoring/latest)
+* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/monitoring/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the Monitoring API][enable_api].
+1.  [Enable the  API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install monitoring
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=monitoring.googleapis.com
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-monitoring/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-monitoring/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-monitoring

--- a/baselines/monitoring/README.md.baseline
+++ b/baselines/monitoring/README.md.baseline
@@ -2,20 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# [: Nodejs Client][homepage]
+# [Monitoring: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/monitoring.svg)](https://www.npmjs.org/package/monitoring)
 
- client for Node.js
+Monitoring client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
 [the CHANGELOG][homepage_changelog].
 
-* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/monitoring/latest)
+* [Monitoring Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/monitoring/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -38,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the  API][enable_api].
+1.  [Enable the Monitoring API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library

--- a/baselines/monitoring/README.md.baseline
+++ b/baselines/monitoring/README.md.baseline
@@ -2,22 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-monitoring
-
-# [Monitoring: Nodejs Client][homepage]
+# [: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/monitoring.svg)](https://www.npmjs.org/package/monitoring)
 
-Monitoring client for Node.js
+ client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [Monitoring Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/monitoring/latest)
+* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/monitoring/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the Monitoring API][enable_api].
+1.  [Enable the  API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install monitoring
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=monitoring.googleapis.com
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-monitoring/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-monitoring/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-monitoring

--- a/baselines/naming-esm/README.md.baseline
+++ b/baselines/naming-esm/README.md.baseline
@@ -2,20 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# [: Nodejs Client][homepage]
+# [Naming: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/naming.svg)](https://www.npmjs.org/package/naming)
 
- client for Node.js
+Naming client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
 [the CHANGELOG][homepage_changelog].
 
-* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/naming/latest)
+* [Naming Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/naming/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -38,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the  API][enable_api].
+1.  [Enable the Naming API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library

--- a/baselines/naming-esm/README.md.baseline
+++ b/baselines/naming-esm/README.md.baseline
@@ -2,22 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-naming
-
-# [Naming: Nodejs Client][homepage]
+# [: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/naming.svg)](https://www.npmjs.org/package/naming)
 
-Naming client for Node.js
+ client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [Naming Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/naming/latest)
+* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/naming/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the Naming API][enable_api].
+1.  [Enable the  API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install naming
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=localhost
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-naming/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-naming/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-naming

--- a/baselines/naming/README.md.baseline
+++ b/baselines/naming/README.md.baseline
@@ -2,20 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# [: Nodejs Client][homepage]
+# [Naming: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/naming.svg)](https://www.npmjs.org/package/naming)
 
- client for Node.js
+Naming client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
 [the CHANGELOG][homepage_changelog].
 
-* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/naming/latest)
+* [Naming Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/naming/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -38,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the  API][enable_api].
+1.  [Enable the Naming API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library

--- a/baselines/naming/README.md.baseline
+++ b/baselines/naming/README.md.baseline
@@ -2,22 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-naming
-
-# [Naming: Nodejs Client][homepage]
+# [: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/naming.svg)](https://www.npmjs.org/package/naming)
 
-Naming client for Node.js
+ client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [Naming Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/naming/latest)
+* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/naming/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the Naming API][enable_api].
+1.  [Enable the  API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install naming
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=localhost
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-naming/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-naming/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-naming

--- a/baselines/redis-esm/README.md.baseline
+++ b/baselines/redis-esm/README.md.baseline
@@ -2,22 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-redis
-
-# [Redis: Nodejs Client][homepage]
+# [: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/redis.svg)](https://www.npmjs.org/package/redis)
 
-Redis client for Node.js
+ client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [Redis Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/redis/latest)
+* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/redis/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the Redis API][enable_api].
+1.  [Enable the  API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install redis
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=redis.googleapis.com
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-redis/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-redis/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-redis

--- a/baselines/redis-esm/README.md.baseline
+++ b/baselines/redis-esm/README.md.baseline
@@ -2,20 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# [: Nodejs Client][homepage]
+# [Redis: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/redis.svg)](https://www.npmjs.org/package/redis)
 
- client for Node.js
+Redis client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
 [the CHANGELOG][homepage_changelog].
 
-* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/redis/latest)
+* [Redis Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/redis/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -38,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the  API][enable_api].
+1.  [Enable the Redis API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library

--- a/baselines/redis/README.md.baseline
+++ b/baselines/redis/README.md.baseline
@@ -2,22 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-redis
-
-# [Redis: Nodejs Client][homepage]
+# [: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/redis.svg)](https://www.npmjs.org/package/redis)
 
-Redis client for Node.js
+ client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [Redis Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/redis/latest)
+* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/redis/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the Redis API][enable_api].
+1.  [Enable the  API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install redis
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=redis.googleapis.com
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-redis/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-redis/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-redis

--- a/baselines/redis/README.md.baseline
+++ b/baselines/redis/README.md.baseline
@@ -2,20 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# [: Nodejs Client][homepage]
+# [Redis: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/redis.svg)](https://www.npmjs.org/package/redis)
 
- client for Node.js
+Redis client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
 [the CHANGELOG][homepage_changelog].
 
-* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/redis/latest)
+* [Redis Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/redis/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -38,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the  API][enable_api].
+1.  [Enable the Redis API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library

--- a/baselines/retail-esm/README.md.baseline
+++ b/baselines/retail-esm/README.md.baseline
@@ -2,22 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-retail
-
-# [Retail: Nodejs Client][homepage]
+# [Vertex AI Search for commerce API: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/retail.svg)](https://www.npmjs.org/package/retail)
 
-Retail client for Node.js
+Vertex AI Search for commerce API client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [Retail Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/retail/latest)
+* [Vertex AI Search for commerce API Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/retail/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the Retail API][enable_api].
+1.  [Enable the Vertex AI Search for commerce API API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install retail
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=retail.googleapis.com
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-retail/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-retail/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-retail

--- a/baselines/retail/README.md.baseline
+++ b/baselines/retail/README.md.baseline
@@ -2,22 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-retail
-
-# [Retail: Nodejs Client][homepage]
+# [Vertex AI Search for commerce API: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/retail.svg)](https://www.npmjs.org/package/retail)
 
-Retail client for Node.js
+Vertex AI Search for commerce API client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [Retail Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/retail/latest)
+* [Vertex AI Search for commerce API Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/retail/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the Retail API][enable_api].
+1.  [Enable the Vertex AI Search for commerce API API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install retail
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=retail.googleapis.com
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-retail/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-retail/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-retail

--- a/baselines/routingtest-esm/README.md.baseline
+++ b/baselines/routingtest-esm/README.md.baseline
@@ -2,20 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# [: Nodejs Client][homepage]
+# [Routingtest: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/routingtest.svg)](https://www.npmjs.org/package/routingtest)
 
- client for Node.js
+Routingtest client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
 [the CHANGELOG][homepage_changelog].
 
-* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/routingtest/latest)
+* [Routingtest Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/routingtest/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -38,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the  API][enable_api].
+1.  [Enable the Routingtest API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library

--- a/baselines/routingtest-esm/README.md.baseline
+++ b/baselines/routingtest-esm/README.md.baseline
@@ -2,22 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-routingtest
-
-# [Routingtest: Nodejs Client][homepage]
+# [: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/routingtest.svg)](https://www.npmjs.org/package/routingtest)
 
-Routingtest client for Node.js
+ client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [Routingtest Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/routingtest/latest)
+* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/routingtest/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the Routingtest API][enable_api].
+1.  [Enable the  API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install routingtest
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=localhost
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-routingtest/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-routingtest/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-routingtest

--- a/baselines/routingtest/README.md.baseline
+++ b/baselines/routingtest/README.md.baseline
@@ -2,20 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# [: Nodejs Client][homepage]
+# [Routingtest: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/routingtest.svg)](https://www.npmjs.org/package/routingtest)
 
- client for Node.js
+Routingtest client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
 [the CHANGELOG][homepage_changelog].
 
-* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/routingtest/latest)
+* [Routingtest Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/routingtest/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -38,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the  API][enable_api].
+1.  [Enable the Routingtest API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library

--- a/baselines/routingtest/README.md.baseline
+++ b/baselines/routingtest/README.md.baseline
@@ -2,22 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-routingtest
-
-# [Routingtest: Nodejs Client][homepage]
+# [: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/routingtest.svg)](https://www.npmjs.org/package/routingtest)
 
-Routingtest client for Node.js
+ client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [Routingtest Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/routingtest/latest)
+* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/routingtest/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the Routingtest API][enable_api].
+1.  [Enable the  API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install routingtest
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=localhost
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-routingtest/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-routingtest/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-routingtest

--- a/baselines/showcase-esm/README.md.baseline
+++ b/baselines/showcase-esm/README.md.baseline
@@ -2,22 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-showcase
-
-# [Showcase: Nodejs Client][homepage]
+# [Client Libraries Showcase API: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/showcase.svg)](https://www.npmjs.org/package/showcase)
 
-Showcase client for Node.js
+Client Libraries Showcase API client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [Showcase Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/showcase/latest)
+* [Client Libraries Showcase API Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/showcase/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the Showcase API][enable_api].
+1.  [Enable the Client Libraries Showcase API API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install showcase
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=localhost
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-showcase/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-showcase/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-showcase

--- a/baselines/showcase-legacy-esm/README.md.baseline
+++ b/baselines/showcase-legacy-esm/README.md.baseline
@@ -2,22 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-showcase
-
-# [Showcase: Nodejs Client][homepage]
+# [: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/showcase.svg)](https://www.npmjs.org/package/showcase)
 
-Showcase client for Node.js
+ client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [Showcase Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/showcase/latest)
+* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/showcase/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the Showcase API][enable_api].
+1.  [Enable the  API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install showcase
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=localhost
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-showcase/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-showcase/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-showcase

--- a/baselines/showcase-legacy-esm/README.md.baseline
+++ b/baselines/showcase-legacy-esm/README.md.baseline
@@ -2,20 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# [: Nodejs Client][homepage]
+# [Showcase: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/showcase.svg)](https://www.npmjs.org/package/showcase)
 
- client for Node.js
+Showcase client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
 [the CHANGELOG][homepage_changelog].
 
-* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/showcase/latest)
+* [Showcase Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/showcase/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -38,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the  API][enable_api].
+1.  [Enable the Showcase API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library

--- a/baselines/showcase-legacy/README.md.baseline
+++ b/baselines/showcase-legacy/README.md.baseline
@@ -2,22 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-showcase
-
-# [Showcase: Nodejs Client][homepage]
+# [: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/showcase.svg)](https://www.npmjs.org/package/showcase)
 
-Showcase client for Node.js
+ client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [Showcase Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/showcase/latest)
+* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/showcase/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the Showcase API][enable_api].
+1.  [Enable the  API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install showcase
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=localhost
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-showcase/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-showcase/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-showcase

--- a/baselines/showcase-legacy/README.md.baseline
+++ b/baselines/showcase-legacy/README.md.baseline
@@ -2,20 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# [: Nodejs Client][homepage]
+# [Showcase: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/showcase.svg)](https://www.npmjs.org/package/showcase)
 
- client for Node.js
+Showcase client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
 [the CHANGELOG][homepage_changelog].
 
-* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/showcase/latest)
+* [Showcase Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/showcase/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -38,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the  API][enable_api].
+1.  [Enable the Showcase API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library

--- a/baselines/showcase/README.md.baseline
+++ b/baselines/showcase/README.md.baseline
@@ -2,22 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-showcase
-
-# [Showcase: Nodejs Client][homepage]
+# [Client Libraries Showcase API: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/showcase.svg)](https://www.npmjs.org/package/showcase)
 
-Showcase client for Node.js
+Client Libraries Showcase API client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [Showcase Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/showcase/latest)
+* [Client Libraries Showcase API Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/showcase/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the Showcase API][enable_api].
+1.  [Enable the Client Libraries Showcase API API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install showcase
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=localhost
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-showcase/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-showcase/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-showcase

--- a/baselines/tasks-esm/README.md.baseline
+++ b/baselines/tasks-esm/README.md.baseline
@@ -2,20 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# [: Nodejs Client][homepage]
+# [Tasks: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/tasks.svg)](https://www.npmjs.org/package/tasks)
 
- client for Node.js
+Tasks client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
 [the CHANGELOG][homepage_changelog].
 
-* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/tasks/latest)
+* [Tasks Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/tasks/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -38,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the  API][enable_api].
+1.  [Enable the Tasks API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library

--- a/baselines/tasks-esm/README.md.baseline
+++ b/baselines/tasks-esm/README.md.baseline
@@ -2,22 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-tasks
-
-# [Tasks: Nodejs Client][homepage]
+# [: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/tasks.svg)](https://www.npmjs.org/package/tasks)
 
-Tasks client for Node.js
+ client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [Tasks Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/tasks/latest)
+* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/tasks/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the Tasks API][enable_api].
+1.  [Enable the  API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install tasks
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=cloudtasks.googleapis.com
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-tasks/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-tasks/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-tasks

--- a/baselines/tasks/README.md.baseline
+++ b/baselines/tasks/README.md.baseline
@@ -2,20 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# [: Nodejs Client][homepage]
+# [Tasks: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/tasks.svg)](https://www.npmjs.org/package/tasks)
 
- client for Node.js
+Tasks client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
 [the CHANGELOG][homepage_changelog].
 
-* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/tasks/latest)
+* [Tasks Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/tasks/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -38,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the  API][enable_api].
+1.  [Enable the Tasks API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library

--- a/baselines/tasks/README.md.baseline
+++ b/baselines/tasks/README.md.baseline
@@ -2,22 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-tasks
-
-# [Tasks: Nodejs Client][homepage]
+# [: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/tasks.svg)](https://www.npmjs.org/package/tasks)
 
-Tasks client for Node.js
+ client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [Tasks Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/tasks/latest)
+* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/tasks/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the Tasks API][enable_api].
+1.  [Enable the  API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install tasks
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=cloudtasks.googleapis.com
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-tasks/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-tasks/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-tasks

--- a/baselines/texttospeech-esm/README.md.baseline
+++ b/baselines/texttospeech-esm/README.md.baseline
@@ -2,20 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# [: Nodejs Client][homepage]
+# [Texttospeech: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/@google-cloud/text-to-speech.svg)](https://www.npmjs.org/package/@google-cloud/text-to-speech)
 
- client for Node.js
+Texttospeech client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
 [the CHANGELOG][homepage_changelog].
 
-* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/texttospeech/latest)
+* [Texttospeech Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/texttospeech/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -38,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the  API][enable_api].
+1.  [Enable the Texttospeech API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library

--- a/baselines/texttospeech-esm/README.md.baseline
+++ b/baselines/texttospeech-esm/README.md.baseline
@@ -2,22 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-texttospeech
-
-# [Texttospeech: Nodejs Client][homepage]
+# [: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/@google-cloud/text-to-speech.svg)](https://www.npmjs.org/package/@google-cloud/text-to-speech)
 
-Texttospeech client for Node.js
+ client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [Texttospeech Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/texttospeech/latest)
+* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/texttospeech/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the Texttospeech API][enable_api].
+1.  [Enable the  API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install @google-cloud/text-to-speech
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=texttospeech.googleapis.com
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-texttospeech/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-texttospeech/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-texttospeech

--- a/baselines/texttospeech/README.md.baseline
+++ b/baselines/texttospeech/README.md.baseline
@@ -2,20 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# [: Nodejs Client][homepage]
+# [Texttospeech: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/@google-cloud/text-to-speech.svg)](https://www.npmjs.org/package/@google-cloud/text-to-speech)
 
- client for Node.js
+Texttospeech client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
 [the CHANGELOG][homepage_changelog].
 
-* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/texttospeech/latest)
+* [Texttospeech Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/texttospeech/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -38,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the  API][enable_api].
+1.  [Enable the Texttospeech API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library

--- a/baselines/texttospeech/README.md.baseline
+++ b/baselines/texttospeech/README.md.baseline
@@ -2,22 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-texttospeech
-
-# [Texttospeech: Nodejs Client][homepage]
+# [: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/@google-cloud/text-to-speech.svg)](https://www.npmjs.org/package/@google-cloud/text-to-speech)
 
-Texttospeech client for Node.js
+ client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [Texttospeech Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/texttospeech/latest)
+* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/texttospeech/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the Texttospeech API][enable_api].
+1.  [Enable the  API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install @google-cloud/text-to-speech
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=texttospeech.googleapis.com
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-texttospeech/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-texttospeech/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-texttospeech

--- a/baselines/translate-esm/README.md.baseline
+++ b/baselines/translate-esm/README.md.baseline
@@ -2,20 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# [: Nodejs Client][homepage]
+# [Translation: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/translation.svg)](https://www.npmjs.org/package/translation)
 
- client for Node.js
+Translation client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
 [the CHANGELOG][homepage_changelog].
 
-* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/translation/latest)
+* [Translation Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/translation/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -38,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the  API][enable_api].
+1.  [Enable the Translation API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library

--- a/baselines/translate-esm/README.md.baseline
+++ b/baselines/translate-esm/README.md.baseline
@@ -2,22 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-translation
-
-# [Translation: Nodejs Client][homepage]
+# [: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/translation.svg)](https://www.npmjs.org/package/translation)
 
-Translation client for Node.js
+ client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [Translation Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/translation/latest)
+* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/translation/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the Translation API][enable_api].
+1.  [Enable the  API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install translation
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=translate.googleapis.com
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-translation/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-translation/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-translation

--- a/baselines/translate/README.md.baseline
+++ b/baselines/translate/README.md.baseline
@@ -2,20 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# [: Nodejs Client][homepage]
+# [Translation: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/translation.svg)](https://www.npmjs.org/package/translation)
 
- client for Node.js
+Translation client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
 [the CHANGELOG][homepage_changelog].
 
-* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/translation/latest)
+* [Translation Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/translation/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -38,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the  API][enable_api].
+1.  [Enable the Translation API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library

--- a/baselines/translate/README.md.baseline
+++ b/baselines/translate/README.md.baseline
@@ -2,22 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-translation
-
-# [Translation: Nodejs Client][homepage]
+# [: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/translation.svg)](https://www.npmjs.org/package/translation)
 
-Translation client for Node.js
+ client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [Translation Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/translation/latest)
+* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/translation/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the Translation API][enable_api].
+1.  [Enable the  API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install translation
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=translate.googleapis.com
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-translation/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-translation/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-translation

--- a/baselines/videointelligence-esm/README.md.baseline
+++ b/baselines/videointelligence-esm/README.md.baseline
@@ -2,22 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-videointelligence
-
-# [Videointelligence: Nodejs Client][homepage]
+# [: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/videointelligence.svg)](https://www.npmjs.org/package/videointelligence)
 
-Videointelligence client for Node.js
+ client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [Videointelligence Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/videointelligence/latest)
+* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/videointelligence/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the Videointelligence API][enable_api].
+1.  [Enable the  API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install videointelligence
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=videointelligence.googleapis.com
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-videointelligence/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-videointelligence/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-videointelligence

--- a/baselines/videointelligence-esm/README.md.baseline
+++ b/baselines/videointelligence-esm/README.md.baseline
@@ -2,20 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# [: Nodejs Client][homepage]
+# [Videointelligence: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/videointelligence.svg)](https://www.npmjs.org/package/videointelligence)
 
- client for Node.js
+Videointelligence client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
 [the CHANGELOG][homepage_changelog].
 
-* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/videointelligence/latest)
+* [Videointelligence Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/videointelligence/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -38,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the  API][enable_api].
+1.  [Enable the Videointelligence API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library

--- a/baselines/videointelligence/README.md.baseline
+++ b/baselines/videointelligence/README.md.baseline
@@ -2,22 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-videointelligence
-
-# [Videointelligence: Nodejs Client][homepage]
+# [: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/videointelligence.svg)](https://www.npmjs.org/package/videointelligence)
 
-Videointelligence client for Node.js
+ client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [Videointelligence Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/videointelligence/latest)
+* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/videointelligence/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the Videointelligence API][enable_api].
+1.  [Enable the  API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install videointelligence
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=videointelligence.googleapis.com
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-videointelligence/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-videointelligence/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-videointelligence

--- a/baselines/videointelligence/README.md.baseline
+++ b/baselines/videointelligence/README.md.baseline
@@ -2,20 +2,20 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# [: Nodejs Client][homepage]
+# [Videointelligence: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/videointelligence.svg)](https://www.npmjs.org/package/videointelligence)
 
- client for Node.js
+Videointelligence client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
 [the CHANGELOG][homepage_changelog].
 
-* [ Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/videointelligence/latest)
+* [Videointelligence Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/videointelligence/latest)
 
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -38,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the  API][enable_api].
+1.  [Enable the Videointelligence API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library

--- a/rules_typescript_gapic/typescript_gapic_combined_pkg.bzl
+++ b/rules_typescript_gapic/typescript_gapic_combined_pkg.bzl
@@ -40,8 +40,8 @@ def _typescript_gapic_combined_pkg_impl(ctx):
     echo "EXCLUDING THE FOLLOWING TEMPLATES: "
     echo "{templates_excludes}"
     echo -e "{templates_excludes}" | while read template; do
-        echo "rm -rf $template";
-        rm -rf "$template";
+        echo "rm -rf $LIBRARY_DIR/$template";
+        rm -rf "$LIBRARY_DIR"/"$template";
     done
     # Rezip package
     tar cfz "{pkg}" -C "$LIBRARY_DIR/.." "{package_dir}"

--- a/templates/cjs/typescript_gapic/README.md.njk
+++ b/templates/cjs/typescript_gapic/README.md.njk
@@ -2,21 +2,21 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# [{{ api.title }}: Nodejs Client][homepage]
+# [{{ api.title or api.naming.productName }}: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/{{ api.publishName }}.svg)](https://www.npmjs.org/package/{{ api.publishName }})
 
-{{ api.title }} client for Node.js
+{{ api.title or api.naming.productName }} client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
 [the CHANGELOG][homepage_changelog].
 
-* [{{ api.title }} Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/{{ api.naming.nameNotCapitalized }}/latest)
-{% if api.documentationUri %}* [{{ api.title }} Documentation]({{ api.documentationUri }}){% endif %}
+* [{{ api.title or api.naming.productName }} Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/{{ api.naming.nameNotCapitalized }}/latest)
+{% if api.documentationUri %}* [{{ api.title or api.naming.productName }} Documentation]({{ api.documentationUri }}){% endif %}
 
 Read more about the client libraries for Cloud APIs, including the older
 Google APIs Client Libraries, in [Client Libraries Explained][explained].
@@ -38,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the {{ api.title }} API][enable_api].
+1.  [Enable the {{ api.title or api.naming.productName }} API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library

--- a/templates/cjs/typescript_gapic/README.md.njk
+++ b/templates/cjs/typescript_gapic/README.md.njk
@@ -2,23 +2,21 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/{{ api.naming.namePath }}
-
-# [{{ api.naming.productName }}: Nodejs Client][homepage]
+# [{{ api.title }}: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/{{ api.publishName }}.svg)](https://www.npmjs.org/package/{{ api.publishName }})
 
-{{ api.naming.productName }} client for Node.js
+{{ api.title }} client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [{{ api.naming.productName }} Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/{{ api.naming.nameNotCapitalized }}/latest)
-{% if api.documentationUri %}* [{{ api.naming.productName }} Documentation]({{ api.documentationUri }}){% endif %}
+* [{{ api.title }} Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/{{ api.naming.nameNotCapitalized }}/latest)
+{% if api.documentationUri %}* [{{ api.title }} Documentation]({{ api.documentationUri }}){% endif %}
 
 Read more about the client libraries for Cloud APIs, including the older
 Google APIs Client Libraries, in [Client Libraries Explained][explained].
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the {{ api.naming.productName }} API][enable_api].
+1.  [Enable the {{ api.title }} API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install {{api.publishName}}
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid={{ api.hostName }}
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/{{ api.naming.namePath }}/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/{{ api.naming.namePath }}/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/{{ api.naming.namePath }}

--- a/templates/esm/typescript_gapic/README.md.njk
+++ b/templates/esm/typescript_gapic/README.md.njk
@@ -2,21 +2,21 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# [{{ api.title }}: Nodejs Client][homepage]
+# [{{ api.title or api.naming.productName }}: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/{{ api.publishName }}.svg)](https://www.npmjs.org/package/{{ api.publishName }})
 
-{{ api.title }} client for Node.js
+{{ api.title or api.naming.productName }} client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
 [the CHANGELOG][homepage_changelog].
 
-* [{{ api.title }} Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/{{ api.naming.nameNotCapitalized }}/latest)
-{% if api.documentationUri %}* [{{ api.title }} Documentation]({{ api.documentationUri }}){% endif %}
+* [{{ api.title or api.naming.productName }} Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/{{ api.naming.nameNotCapitalized }}/latest)
+{% if api.documentationUri %}* [{{ api.title or api.naming.productName }} Documentation]({{ api.documentationUri }}){% endif %}
 
 Read more about the client libraries for Cloud APIs, including the older
 Google APIs Client Libraries, in [Client Libraries Explained][explained].
@@ -38,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the {{ api.title }} API][enable_api].
+1.  [Enable the {{ api.title or api.naming.productName }} API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library

--- a/templates/esm/typescript_gapic/README.md.njk
+++ b/templates/esm/typescript_gapic/README.md.njk
@@ -2,23 +2,21 @@
 [//]: # "The comments you see below are used to generate those parts of the template in later states."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/{{ api.naming.namePath }}
-
-# [{{ api.naming.productName }}: Nodejs Client][homepage]
+# [{{ api.title }}: Nodejs Client][homepage]
 
 [//]: # "releaseLevel"
 
 [![npm version](https://img.shields.io/npm/v/{{ api.publishName }}.svg)](https://www.npmjs.org/package/{{ api.publishName }})
 
-{{ api.naming.productName }} client for Node.js
+{{ api.title }} client for Node.js
 
 [//]: # "partials.introduction"
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG]([homepage]/CHANGELOG.md).
+[the CHANGELOG][homepage_changelog].
 
-* [{{ api.naming.productName }} Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/{{ api.naming.nameNotCapitalized }}/latest)
-{% if api.documentationUri %}* [{{ api.naming.productName }} Documentation]({{ api.documentationUri }}){% endif %}
+* [{{ api.title }} Nodejs Client API Reference](https://cloud.google.com/nodejs/docs/reference/{{ api.naming.nameNotCapitalized }}/latest)
+{% if api.documentationUri %}* [{{ api.title }} Documentation]({{ api.documentationUri }}){% endif %}
 
 Read more about the client libraries for Cloud APIs, including the older
 Google APIs Client Libraries, in [Client Libraries Explained][explained].
@@ -40,7 +38,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 1.  [Select or create a Cloud Platform project][projects].
 1.  [Enable billing for your project][billing].
-1.  [Enable the {{ api.naming.productName }} API][enable_api].
+1.  [Enable the {{ api.title }} API][enable_api].
 1.  [Set up authentication][auth] so you can access the
     API from your local workstation.
 ### Installing the client library
@@ -53,7 +51,7 @@ npm install {{api.publishName}}
 
 ## Samples
 
-Samples are in the [`samples/`]([homepage]/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`][homepage_samples] directory. Each sample's `README.md` has instructions for running its sample.
 
 [//]: # "samples"
 
@@ -105,3 +103,6 @@ See [LICENSE](https://github.com/googleapis/google-cloud-node/blob/main/packages
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid={{ api.hostName }}
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local
+[homepage_samples]: https://github.com/googleapis/google-cloud-node/blob/main/packages/{{ api.naming.namePath }}/samples
+[homepage_changelog]: https://github.com/googleapis/google-cloud-node/blob/main/packages/{{ api.naming.namePath }}/CHANGELOG.md
+[homepage]: https://github.com/googleapis/google-cloud-node/blob/main/packages/{{ api.naming.namePath }}

--- a/typescript/src/schema/api.ts
+++ b/typescript/src/schema/api.ts
@@ -45,7 +45,7 @@ export class API {
   restNumericEnums: boolean;
   documentationUri: any;
   newIssueUri: string;
-  title: string;
+  title?: string;
 
   static isIgnoredService(
     fd: protos.google.protobuf.IFileDescriptorProto,
@@ -112,7 +112,7 @@ export class API {
     this.documentationUri =
       options.serviceYaml?.publishing?.documentation_uri ?? '';
     this.newIssueUri = options.serviceYaml?.publishing?.new_issue_uri ?? '';
-    this.title = options.serviceYaml?.title ?? '';
+    this.title = options.serviceYaml?.title;
 
     const [allResourceDatabase, resourceDatabase] =
       getResourceDatabase(fileDescriptors);

--- a/typescript/src/schema/api.ts
+++ b/typescript/src/schema/api.ts
@@ -45,6 +45,7 @@ export class API {
   restNumericEnums: boolean;
   documentationUri: any;
   newIssueUri: string;
+  title: string;
 
   static isIgnoredService(
     fd: protos.google.protobuf.IFileDescriptorProto,
@@ -111,6 +112,7 @@ export class API {
     this.documentationUri =
       options.serviceYaml?.publishing?.documentation_uri ?? '';
     this.newIssueUri = options.serviceYaml?.publishing?.new_issue_uri ?? '';
+    this.title = options.serviceYaml?.title ?? '';
 
     const [allResourceDatabase, resourceDatabase] =
       getResourceDatabase(fileDescriptors);


### PR DESCRIPTION
Fixing some small issues I found with generation in this test: https://github.com/googleapis/google-cloud-node/pull/6676

1. README links don't render properly. I fixed the way the links are included, as well as the md links.
2. API Name isn't the title in the README. I updated to add the actual Service yaml title for the README if it exists.
3. Excluded templates weren't actually being excluded because the full path wasn't provided. I fixed that.