### PR TITLE
fix: add per-service apiVersion to gapic_metadata

### DIFF
--- a/baselines/showcase-esm/esm/src/v1beta1/gapic_metadata.json.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/gapic_metadata.json.baseline
@@ -120,6 +120,7 @@
       }
     },
     "Echo": {
+      "apiVersion": "v1_20240408",
       "clients": {
         "grpc": {
           "libraryClient": "EchoClient",

--- a/baselines/showcase/src/v1beta1/gapic_metadata.json.baseline
+++ b/baselines/showcase/src/v1beta1/gapic_metadata.json.baseline
@@ -120,6 +120,7 @@
       }
     },
     "Echo": {
+      "apiVersion": "v1_20240408",
       "clients": {
         "grpc": {
           "libraryClient": "EchoClient",

--- a/templates/cjs/typescript_gapic_metadata/src/$version/gapic_metadata.json.njk
+++ b/templates/cjs/typescript_gapic_metadata/src/$version/gapic_metadata.json.njk
@@ -43,6 +43,9 @@ limitations under the License.
 {%- for service in api.services -%}
     {{- serviceJoiner() -}}
     "{{ service.name }}": {
+      {%- if service.apiVersion -%}
+      "apiVersion": "{{ service.apiVersion }}",
+      {%- endif -%}
 {#- TODO(@alexander-fenster): replace hardcoded transports ("grpc", etc.) with an iteration. -#}
       "clients": {
         "grpc": {

--- a/templates/esm/typescript_gapic_metadata/esm/src/$version/gapic_metadata.json.njk
+++ b/templates/esm/typescript_gapic_metadata/esm/src/$version/gapic_metadata.json.njk
@@ -43,6 +43,9 @@ limitations under the License.
 {%- for service in api.services -%}
     {{- serviceJoiner() -}}
     "{{ service.name }}": {
+      {%- if service.apiVersion -%}
+      "apiVersion": "{{ service.apiVersion }}",
+      {%- endif -%}
 {#- TODO(@alexander-fenster): replace hardcoded transports ("grpc", etc.) with an iteration. -#}
       "clients": {
         "grpc": {


### PR DESCRIPTION
Populates the `api_version` field on a per-`service` basis to the generated `gapic_metadata.json` using the value from the `service`-level annotation `google.api.api_version` already parsed for use in the `X-Goog-Api-Version`/`$apiVersion` system parameter (as of #1576).

Showcase-based tests already have `google.api.api_version` set on `service Echo`, so the baselines are appropriately updated to account for inclusion of `apiVersion` in the `gapic_metadata.json` output.

It's presence in `gapic_metadata.json` will allow parsers to correlate `service` client to API version. It is not in use by any API yet. Only the unit tests needed updating.

Internal bug http://b/452365074.